### PR TITLE
ci: use dedicated self-hosted runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,6 +85,7 @@ jobs:
           fi
           echo "VERSION=$version" >> $GITHUB_OUTPUT
           echo "VERSION=$version" >> $GITHUB_ENV
+          echo "/usr/local/go/bin" >> $GITHUB_PATH
       - name: Show workflow information
         id: get_filename
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
           # END Linux AMD64 v1 v2 v3
       fail-fast: false
 
-    runs-on: ubuntu-22.04
+    runs-on: self-hosted
     env:
       GOOS: ${{ matrix.goos }}
       GOARCH: ${{ matrix.goarch }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   docker:
-    runs-on: ubuntu-22.04
+    runs-on: self-hosted
     steps:
       - name: Checkout codebase
         uses: actions/checkout@v3


### PR DESCRIPTION
## Summary

The `min_num` runner is set to `13` as shown in the screenshot below. Max capacity is set to `39` for now. Let's have a try.

<img width="1911" alt="image" src="https://user-images.githubusercontent.com/31861128/229278958-5d94f392-70d7-4dbb-9755-f897fdf840f6.png">
