### PR TITLE
optimize: cache NXDomain and reject with 0.0.0.0/::

### DIFF
--- a/control/control_plane_core.go
+++ b/control/control_plane_core.go
@@ -523,12 +523,17 @@ func (c *controlPlaneCore) BatchUpdateDomainRouting(cache *DnsCache) error {
 	// Parse ips from DNS resp answers.
 	var ips []netip.Addr
 	for _, ans := range cache.Answers {
+		var ip netip.Addr
 		switch ans.Header.Type {
 		case dnsmessage.TypeA:
-			ips = append(ips, netip.AddrFrom4(ans.Body.(*dnsmessage.AResource).A))
+			ip = netip.AddrFrom4(ans.Body.(*dnsmessage.AResource).A)
 		case dnsmessage.TypeAAAA:
-			ips = append(ips, netip.AddrFrom16(ans.Body.(*dnsmessage.AAAAResource).AAAA))
+			ip = netip.AddrFrom16(ans.Body.(*dnsmessage.AAAAResource).AAAA)
 		}
+		if ip.IsUnspecified() {
+			continue
+		}
+		ips = append(ips, ip)
 	}
 	if len(ips) == 0 {
 		return nil

--- a/control/dns_cache.go
+++ b/control/dns_cache.go
@@ -58,3 +58,13 @@ func (c *DnsCache) IncludeIp(ip netip.Addr) bool {
 	}
 	return false
 }
+
+func (c *DnsCache) IncludeAnyIp() bool {
+	for _, ans := range c.Answers {
+		switch ans.Body.(type) {
+		case *dnsmessage.AResource, *dnsmessage.AAAAResource:
+			return true
+		}
+	}
+	return false
+}

--- a/control/dns_control.go
+++ b/control/dns_control.go
@@ -436,7 +436,7 @@ func (c *DnsController) Handle_(dnsMessage *dnsmessage.Message, req *udpRequest)
 	}
 	// resp is valid.
 	cache2 := c.LookupDnsRespCache(qname, qtype2)
-	if c.qtypePrefer == qtype || cache2 == nil {
+	if c.qtypePrefer == qtype || cache2 == nil || !cache2.IncludeAnyIp() {
 		return sendPkt(resp, req.realDst, req.realSrc, req.src, req.lConn, req.lanWanFlag)
 	} else {
 		return c.sendReject_(dnsMessage, req)

--- a/control/dns_control.go
+++ b/control/dns_control.go
@@ -525,18 +525,20 @@ func (c *DnsController) sendReject_(dnsMessage *dnsmessage.Message, req *udpRequ
 		case dnsmessage.TypeA:
 			dnsMessage.Answers = []dnsmessage.Resource{{
 				Header: dnsmessage.ResourceHeader{
-					Name: q.Name,
-					Type: typ,
-					TTL:  0,
+					Name:  q.Name,
+					Type:  typ,
+					Class: dnsmessage.ClassINET,
+					TTL:   0,
 				},
 				Body: &dnsmessage.AResource{A: UnspecifiedAddressA.As4()},
 			}}
 		case dnsmessage.TypeAAAA:
 			dnsMessage.Answers = []dnsmessage.Resource{{
 				Header: dnsmessage.ResourceHeader{
-					Name: q.Name,
-					Type: typ,
-					TTL:  0,
+					Name:  q.Name,
+					Type:  typ,
+					Class: dnsmessage.ClassINET,
+					TTL:   0,
 				},
 				Body: &dnsmessage.AAAAResource{AAAA: UnspecifiedAddressAAAA.As16()},
 			}}


### PR DESCRIPTION
## Background

1. When "ipversion_prefer" is on and the domain being looked up does not have an AAAA record, NXDomain was not cached and a new lookup was required each time. It cost much time.
2. Empty answer is NXDomain, which will not be cached by downstream domain server implementation. And a new lookup would be sent to `dae` each time. It cost many connections/packets.

## Modification

1. Cache NXDomain result and non-A/AAAA result.
2. Reject with 0.0.0.0/:: instead of NXDomain.
