### PR TITLE
docs: remove local dns from must_direct in README

### DIFF
--- a/docs/getting-started/README_zh.md
+++ b/docs/getting-started/README_zh.md
@@ -161,7 +161,7 @@ group {
 
 # 更多的 Routing 样例见 https://github.com/daeuniverse/dae/blob/main/docs/routing.md
 routing {
-  pname(NetworkManager, systemd-resolved, dnsmasq) -> must_direct
+  pname(NetworkManager) -> must_direct
   dip(224.0.0.0/3, 'ff00::/8') -> direct
 
   ### 以下为自定义规则


### PR DESCRIPTION
## Motivation & Background

If we add `dnsmasq` and `systemd-resolved` to must_direct, in 'binding to WAN' scenario, DNS mapping will fail because all DNS queries will bypass `dae`.

The best way is to refer to [external-dns.md](https://github.com/daeuniverse/dae/blob/main/docs/getting-started/external-dns.md). But it is not OOTB (out-of-the-box) and is expensive to configure.

Removing them from must_direct is not the best way but just acceptable. Its **disadvantage** is that those local domain servers have cache and they will not always request to upstream each time, thus if some domains share the same IP, domain rules can be incorrectly matched due to incorrect mappings.