### PR TITLE
fix: sniffed domain with brackets

### DIFF
--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -18,6 +18,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/bits-and-blooms/bloom/v3"
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/rlimit"
 	"github.com/daeuniverse/dae/common"

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -18,7 +18,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/bits-and-blooms/bloom/v3"
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/rlimit"
 	"github.com/daeuniverse/dae/common"
@@ -557,6 +556,10 @@ func (c *ControlPlane) ChooseDialTarget(outbound consts.OutboundIndex, dst netip
 	case consts.DialMode_Ip:
 		dialTarget = dst.String()
 	case consts.DialMode_Domain:
+		if strings.HasPrefix(domain, "[") && strings.HasSuffix(domain, "]") {
+			// Sniffed domain may be like `[2606:4700:20::681a:d1f]`. We should remove the brackets.
+			domain = domain[1 : len(domain)-1]
+		}
 		if _, err := netip.ParseAddr(domain); err == nil {
 			// domain is IPv4 or IPv6 (has colon)
 			dialTarget = net.JoinHostPort(domain, strconv.Itoa(int(dst.Port())))


### PR DESCRIPTION
## Motivation

`curl http://[2606:4700:20::681a:d1f]:80` will fail in `domain++` mode.

```
level=warning msg="handleConn: failed to dial [2606:4700:20::681a:d1f]:80: SplitHostPort: address [[2606:4700:20::681a:d1f]]:80: missing port in address"
```

## Modification

Remove duplicated brackets from sniffed ipv6-like domain.

## Test

The problem disappeared after the fix.