### PR TITLE
fix(dns): cache would never expire caused by #63 by accident

### DIFF
--- a/control/dns_control.go
+++ b/control/dns_control.go
@@ -134,7 +134,7 @@ func (c *DnsController) LookupDnsRespCache(qname string, qtype dnsmessage.Type) 
 	c.dnsCacheMu.Lock()
 	cache, ok := c.dnsCache[c.cacheKey(qname, qtype)]
 	c.dnsCacheMu.Unlock()
-	// We should make sure the remaining TTL is greater than 120s (minFirefoxCacheTimeout), or
+	// We should make sure the cache does not expire, or
 	// return nil and request a new lookup to refresh the cache.
 	if ok && cache.Deadline.After(time.Now()) {
 		return cache

--- a/control/dns_control.go
+++ b/control/dns_control.go
@@ -134,7 +134,7 @@ func (c *DnsController) LookupDnsRespCache(qname string, qtype dnsmessage.Type) 
 	c.dnsCacheMu.Lock()
 	cache, ok := c.dnsCache[c.cacheKey(qname, qtype)]
 	c.dnsCacheMu.Unlock()
-	// We should make sure the cache does not expire, or
+	// We should make sure the cache did not expire, or
 	// return nil and request a new lookup to refresh the cache.
 	if ok && cache.Deadline.After(time.Now()) {
 		return cache

--- a/control/dns_control.go
+++ b/control/dns_control.go
@@ -136,7 +136,7 @@ func (c *DnsController) LookupDnsRespCache(qname string, qtype dnsmessage.Type) 
 	c.dnsCacheMu.Unlock()
 	// We should make sure the remaining TTL is greater than 120s (minFirefoxCacheTimeout), or
 	// return nil and request a new lookup to refresh the cache.
-	if ok {
+	if ok && cache.Deadline.After(time.Now()) {
 		return cache
 	}
 	return nil


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Cache would never expire by accident.

### Checklist

- [x] The Pull Request has been fully tested

### Full changelog

- Add expiration check when looking up the DNS cache.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

Fix #83
Related PR: https://github.com/daeuniverse/dae/pull/63/files#diff-7092e5e0724411e117b147fe12471c61569d904d911ef0f049885f9c1b4ce37eL135
