### PR TITLE
patch(geodata): fix incorrect geodata search path /etc/dae/dae caused by #84

### DIFF
--- a/common/assets/assets.go
+++ b/common/assets/assets.go
@@ -91,11 +91,11 @@ func (c *LocationFinder) GetLocationAsset(log *logrus.Logger, filename string) (
 		searchDirs = append(searchDirs, c.externDirs...)
 		if runtime.GOOS != "windows" {
 			// Search XDG data directories on non windows platform
-			searchDirs = append(searchDirs, xdg.DataHome)
-			searchDirs = append(searchDirs, xdg.DataDirs...)
-			for i := range searchDirs {
-				searchDirs[i] = filepath.Join(searchDirs[i], folder)
+			xdgDirs := append([]string{xdg.DataHome}, xdg.DataDirs...)
+			for i := range xdgDirs {
+				xdgDirs[i] = filepath.Join(xdgDirs[i], folder)
 			}
+			searchDirs = append(searchDirs, xdgDirs...)
 		} else {
 			// fallback to the old behavior of using only current dir on Windows
 			pwd := "./"


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Fix that searching geodata in incorrect directory `/etc/dae/dae/` instead of `/etc/dae/`.

### Checklist

- [ ] The Pull Request has been fully tested

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

Related PR #84 
