### PR TITLE
fix(dns): mismatched qname matching rules

### DIFF
--- a/common/consts/dns.go
+++ b/common/consts/dns.go
@@ -19,7 +19,7 @@ const (
 	DnsRequestOutboundIndex_LogicalAnd  DnsRequestOutboundIndex = 0xFF
 	DnsRequestOutboundIndex_LogicalMask DnsRequestOutboundIndex = 0xFE
 
-	DnsRequestOutboundIndex_UserDefinedMax = DnsRequestOutboundIndex_AsIs - 1
+	DnsRequestOutboundIndex_UserDefinedMax = DnsRequestOutboundIndex_Reject - 1
 )
 
 func (i DnsRequestOutboundIndex) String() string {

--- a/component/dns/request_routing.go
+++ b/component/dns/request_routing.go
@@ -73,7 +73,7 @@ func (b *RequestMatcherBuilder) addQName(f *config_parser.Function, key string, 
 	}
 	b.simulatedDomainSet = append(b.simulatedDomainSet, routing.DomainSet{
 		Key:       consts.RoutingDomainKey(key),
-		RuleIndex: len(b.simulatedDomainSet),
+		RuleIndex: len(b.rules),
 		Domains:   values,
 	})
 	upstreamId, err := b.upstreamToId(upstream.Name)

--- a/component/dns/response_routing.go
+++ b/component/dns/response_routing.go
@@ -132,7 +132,7 @@ func (b *ResponseMatcherBuilder) addQName(f *config_parser.Function, key string,
 	}
 	b.simulatedDomainSet = append(b.simulatedDomainSet, routing.DomainSet{
 		Key:       consts.RoutingDomainKey(key),
-		RuleIndex: len(b.simulatedDomainSet),
+		RuleIndex: len(b.rules),
 		Domains:   values,
 	})
 	upstreamId, err := b.upstreamToId(upstream.Name)


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Some qname matching in DNS section does not work unstablely.

### Checklist

- [x] The Pull Request has been fully tested

### Full changelog

- MatcherBuilder implementation used incorrect rule index, which is fixed in this PR.
