### PR TITLE
fix: rand seed for network check

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"math/rand"
+	"github.com/mzz2017/softwind/pkg/fastrand"
 	"net"
 	"net/http"
 	"os"
@@ -45,7 +45,7 @@ func init() {
 	runCmd.PersistentFlags().BoolVarP(&disableTimestamp, "disable-timestamp", "", false, "disable timestamp")
 	runCmd.PersistentFlags().BoolVarP(&disableTimestamp, "disable-pidfile", "", false, "not generate /var/run/dae.pid")
 
-	rand.Shuffle(len(CheckNetworkLinks), func(i, j int) {
+	fastrand.Rand().Shuffle(len(CheckNetworkLinks), func(i, j int) {
 		CheckNetworkLinks[i], CheckNetworkLinks[j] = CheckNetworkLinks[j], CheckNetworkLinks[i]
 	})
 }


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Every time check network using following list, it always performs in solid order.

https://github.com/daeuniverse/dae/blob/2a8f8f90107069bdd501a402c4b3d77e5a80692b/cmd/run.go#L36-L40


### Checklist

- [x] The Pull Request has been fully tested

### Full changelog

- Replace rand with fastrand, which uses seed in its init func. 

