### PR TITLE
fix(test): domain_matcher/benchmark_test.go

### DIFF
--- a/component/routing/domain_matcher/benchmark_test.go
+++ b/component/routing/domain_matcher/benchmark_test.go
@@ -7,6 +7,7 @@ package domain_matcher
 
 import (
 	"fmt"
+	"github.com/daeuniverse/dae/common/assets"
 	"hash/fnv"
 	"math/rand"
 	"reflect"
@@ -145,7 +146,7 @@ routing {
 	}
 	if rules, err = routing.ApplyRulesOptimizers(r.Rules,
 		&routing.AliasOptimizer{},
-		&routing.DatReaderOptimizer{Logger: logrus.StandardLogger()},
+		&routing.DatReaderOptimizer{Logger: logrus.StandardLogger(), LocationFinder: assets.NewLocationFinder(nil)},
 		&routing.MergeAndSortRulesOptimizer{},
 		&routing.DeduplicateParamsOptimizer{},
 	); err != nil {


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

`component/routing/domain_matcher/benchmark_test.go` panic due to nil pointer.

### Checklist

- [x] The Pull Request has been fully tested
