### PR TITLE
chore: fix incorrect number of routing rule stringer

### DIFF
--- a/pkg/config_parser/section.go
+++ b/pkg/config_parser/section.go
@@ -202,7 +202,7 @@ func (r *RoutingRule) String(replaceParamWithN bool, compact bool, quoteVal bool
 			}
 		}
 		var paramBuilder strings.Builder
-		n += len(f.Params)
+		n = len(f.Params)
 		if replaceParamWithN {
 			paramBuilder.WriteString("[n = " + strconv.Itoa(n) + "]")
 		} else {


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Before the fix:
```
[Jun 10 14:26:46] DEBUG rule: ip([n = 219214]) && l4proto([n = 219215]) -> proxy
[Jun 10 14:26:46] DEBUG         ip() -> <AND>
[Jun 10 14:26:46] DEBUG         l4proto() -> proxy
```

After the fix:
```
[Jun 10 14:37:05] DEBUG rule: ip([n = 219214]) && l4proto([n = 1]) -> proxy
[Jun 10 14:37:05] DEBUG         ip() -> <AND>
[Jun 10 14:37:05] DEBUG         l4proto() -> proxy
```

This problem is caused by the incorrect accumulation of `n` within the same rule.

This problem only impacts showing.

### Checklist

- [x] The Pull Request has been fully tested

### Full changelog

- Remove accumulation of n.

