### PR TITLE
optimize(routing): fix slow domain++ ip routing

### DIFF
--- a/component/outbound/dialer/connectivity_check.go
+++ b/component/outbound/dialer/connectivity_check.go
@@ -6,10 +6,12 @@
 package dialer
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"github.com/daeuniverse/dae/common"
+	"io"
 	"net"
 	"net/http"
 	"net/netip"
@@ -580,6 +582,10 @@ func (d *Dialer) HttpCheck(ctx context.Context, u *netutils.URL, ip netip.Addr, 
 	// Judge the status code.
 	if page := path.Base(req.URL.Path); strings.HasPrefix(page, "generate_") {
 		if strconv.Itoa(resp.StatusCode) != strings.TrimPrefix(page, "generate_") {
+			b, _ := io.ReadAll(resp.Body)
+			buf := bytes.NewBuffer(nil)
+			_ = resp.Request.Write(buf)
+			d.Log.Debugln(buf.String(), "Resp: ", string(b))
 			return false, fmt.Errorf("unexpected status code: %v", resp.StatusCode)
 		}
 		return true, nil

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -330,7 +330,7 @@ func NewControlPlane(
 	if err = builder.BuildKernspace(log); err != nil {
 		return nil, fmt.Errorf("RoutingMatcherBuilder.BuildKernspace: %w", err)
 	}
-	routingMatcher, err := builder.BuildUserspace(core.bpf.LpmArrayMap)
+	routingMatcher, err := builder.BuildUserspace()
 	if err != nil {
 		return nil, fmt.Errorf("RoutingMatcherBuilder.BuildUserspace: %w", err)
 	}

--- a/control/kern/tproxy.c
+++ b/control/kern/tproxy.c
@@ -1016,8 +1016,8 @@ route(const __u32 flag[6], const void *l4hdr, const __be32 saddr[4],
 #ifdef __DEBUG_ROUTING
       key = match_set->type;
       bpf_printk("key(match_set->type): %llu", key);
-      bpf_printk("Skip to judge. bad_rule: %d, good_subrule: %d", bad_rule,
-                 good_subrule);
+      bpf_printk("Skip to judge. bad_rule: %d, good_subrule: %d", isdns_must_goodsubrule_badrule&0b10,
+                 isdns_must_goodsubrule_badrule&0b1);
 #endif
       goto before_next_loop;
     }
@@ -1103,7 +1103,7 @@ route(const __u32 flag[6], const void *l4hdr, const __be32 saddr[4],
 
   before_next_loop:
 #ifdef __DEBUG_ROUTING
-    bpf_printk("good_subrule: %d, bad_rule: %d", good_subrule, bad_rule);
+    bpf_printk("good_subrule: %d, bad_rule: %d", isdns_must_goodsubrule_badrule&0b10, isdns_must_goodsubrule_badrule&0b1);
 #endif
     if (match_set->outbound != OUTBOUND_LOGICAL_OR) {
       // This match_set reaches the end of subrule.
@@ -1119,7 +1119,7 @@ route(const __u32 flag[6], const void *l4hdr, const __be32 saddr[4],
       isdns_must_goodsubrule_badrule &= ~0b10;
     }
 #ifdef __DEBUG_ROUTING
-    bpf_printk("_bad_rule: %d", bad_rule);
+    bpf_printk("_bad_rule: %d", isdns_must_goodsubrule_badrule&0b1);
 #endif
     if ((match_set->outbound & OUTBOUND_LOGICAL_MASK) !=
         OUTBOUND_LOGICAL_MASK) {

--- a/control/routing_matcher_builder.go
+++ b/control/routing_matcher_builder.go
@@ -329,7 +329,7 @@ func (b *RoutingMatcherBuilder) BuildKernspace(log *logrus.Logger) (err error) {
 	return nil
 }
 
-func (b *RoutingMatcherBuilder) BuildUserspace(lpmArrayMap *ebpf.Map) (matcher *RoutingMatcher, err error) {
+func (b *RoutingMatcherBuilder) BuildUserspace() (matcher *RoutingMatcher, err error) {
 	// Build domainMatcher
 	domainMatcher := domain_matcher.NewAhocorasickSlimtrie(b.log, consts.MaxMatchSetLen)
 	for _, domains := range b.simulatedDomainSet {

--- a/control/routing_matcher_builder.go
+++ b/control/routing_matcher_builder.go
@@ -337,8 +337,8 @@ func (b *RoutingMatcherBuilder) BuildUserspace() (matcher *RoutingMatcher, err e
 	}
 	// Build Ip matcher.
 	var lpmMatcher []*trie.Trie
-	for _, v := range b.simulatedLpmTries {
-		t, err := trie.NewTrieFromPrefixes(v)
+	for _, prefixes := range b.simulatedLpmTries {
+		t, err := trie.NewTrieFromPrefixes(prefixes)
 		if err != nil {
 			return nil, err
 		}

--- a/control/routing_matcher_userspace.go
+++ b/control/routing_matcher_userspace.go
@@ -8,16 +8,16 @@ package control
 import (
 	"encoding/binary"
 	"fmt"
+	"github.com/daeuniverse/dae/pkg/trie"
 	"net"
+	"net/netip"
 
-	"github.com/cilium/ebpf"
-	"github.com/daeuniverse/dae/common"
 	"github.com/daeuniverse/dae/common/consts"
 	"github.com/daeuniverse/dae/component/routing"
 )
 
 type RoutingMatcher struct {
-	lpmArrayMap   *ebpf.Map
+	lpmMatcher    []*trie.Trie
 	domainMatcher routing.DomainMatcher // All domain matchSets use one DomainMatcher.
 
 	matches []bpfMatchSet
@@ -38,19 +38,12 @@ func (m *RoutingMatcher) Match(
 	if len(sourceAddr) != net.IPv6len || len(destAddr) != net.IPv6len || len(mac) != net.IPv6len {
 		return 0, 0, false, fmt.Errorf("bad address length")
 	}
-	lpmKeys := make([]*_bpfLpmKey, consts.MatchType_Mac+1)
-	lpmKeys[consts.MatchType_IpSet] = &_bpfLpmKey{
-		PrefixLen: 128,
-		Data:      common.Ipv6ByteSliceToUint32Array(destAddr),
-	}
-	lpmKeys[consts.MatchType_SourceIpSet] = &_bpfLpmKey{
-		PrefixLen: 128,
-		Data:      common.Ipv6ByteSliceToUint32Array(sourceAddr),
-	}
-	lpmKeys[consts.MatchType_Mac] = &_bpfLpmKey{
-		PrefixLen: 128,
-		Data:      common.Ipv6ByteSliceToUint32Array(mac),
-	}
+
+	bin128s := make([]string, consts.MatchType_Mac+1)
+	bin128s[consts.MatchType_IpSet] = trie.Prefix2bin128(netip.PrefixFrom(netip.AddrFrom16(*(*[16]byte)(destAddr)), 128))
+	bin128s[consts.MatchType_SourceIpSet] = trie.Prefix2bin128(netip.PrefixFrom(netip.AddrFrom16(*(*[16]byte)(sourceAddr)), 128))
+	bin128s[consts.MatchType_Mac] = trie.Prefix2bin128(netip.PrefixFrom(netip.AddrFrom16(*(*[16]byte)(mac)), 128))
+
 	var domainMatchBitmap []uint32
 	if domain != "" {
 		domainMatchBitmap = m.domainMatcher.MatchDomainBitmap(domain)
@@ -65,19 +58,10 @@ func (m *RoutingMatcher) Match(
 		switch consts.MatchType(match.Type) {
 		case consts.MatchType_IpSet, consts.MatchType_SourceIpSet, consts.MatchType_Mac:
 			lpmIndex := uint32(binary.LittleEndian.Uint16(match.Value[:]))
-			var lpm *ebpf.Map
-			if err = m.lpmArrayMap.Lookup(lpmIndex, &lpm); err != nil {
-				//logrus.Debugln("m.lpmArrayMap.Lookup:", err)
-				break
+			m := m.lpmMatcher[lpmIndex]
+			if m.HasPrefix(bin128s[int(match.Type)]) {
+				goodSubrule = true
 			}
-			var v uint32
-			if err = lpm.Lookup(*lpmKeys[int(match.Type)], &v); err != nil {
-				_ = lpm.Close()
-				//logrus.Debugln("lpm.Lookup:", err, lpmKeys[int(match.Type)], match.Type, destAddr)
-				break
-			}
-			_ = lpm.Close()
-			goodSubrule = true
 		case consts.MatchType_DomainSet:
 			if domainMatchBitmap != nil && (domainMatchBitmap[i/32]>>(i%32))&1 > 0 {
 				goodSubrule = true

--- a/control/routing_matcher_userspace.go
+++ b/control/routing_matcher_userspace.go
@@ -59,7 +59,7 @@ func (m *RoutingMatcher) Match(
 		case consts.MatchType_IpSet, consts.MatchType_SourceIpSet, consts.MatchType_Mac:
 			lpmIndex := uint32(binary.LittleEndian.Uint16(match.Value[:]))
 			m := m.lpmMatcher[lpmIndex]
-			if m.HasPrefix(bin128s[int(match.Type)]) {
+			if m.HasPrefix(bin128s[match.Type]) {
 				goodSubrule = true
 			}
 		case consts.MatchType_DomainSet:

--- a/pkg/trie/trie.go
+++ b/pkg/trie/trie.go
@@ -92,23 +92,26 @@ type Trie struct {
 }
 
 func Prefix2bin128(prefix netip.Prefix) (bin128 string) {
-	bits := prefix.Bits()
+	n := prefix.Bits()
+	if n == -1 {
+		panic("! BadPrefix: " + prefix.String())
+	}
 	if prefix.Addr().Is4() {
-		bits += 96
+		n += 96
 	}
 	ip := prefix.Addr().As16()
 	buf := buffer.NewBuffer(128)
 	defer buf.Put()
 loop:
 	for i := 0; i < len(ip); i++ {
-		for j := 0; j < 8; j++ {
+		for j := 7; j >= 0; j-- {
 			if (ip[i]>>j)&1 == 1 {
 				_ = buf.WriteByte('1')
 			} else {
 				_ = buf.WriteByte('0')
 			}
-			bits--
-			if bits == 0 {
+			n--
+			if n == 0 {
 				break loop
 			}
 		}


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

`domain++` triggers userspace slow IP routing. Userspace routing is implemented by reading kernel eBpf maps and almost amazing `15ms` for every IP rule. This PR optimizes it.

### Checklist

- [x] The Pull Request has been fully tested

### Full changelog

1. Replace matching via kernel maps with matching via trie in userspace.
1. Fix a damn critical problem in IP trie building.