### PR TITLE
fix: change default `tcp_check_http_method` from CONNECT to `HEAD`

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -21,7 +21,7 @@ type Global struct {
 	// We use DirectTcpCheckUrl to check (tcp)*(ipv4/ipv6) connectivity for direct.
 	//DirectTcpCheckUrl string `mapstructure:"direct_tcp_check_url" default:"http://www.qualcomm.cn/generate_204"`
 	TcpCheckUrl               []string      `mapstructure:"tcp_check_url" default:"http://cp.cloudflare.com,1.1.1.1,2606:4700:4700::1111"`
-	TcpCheckHttpMethod        string        `mapstructure:"tcp_check_http_method" default:"CONNECT"` // Use 'CONNECT' because some server implementations bypass accounting for this kind of traffic.
+	TcpCheckHttpMethod        string        `mapstructure:"tcp_check_http_method" default:"HEAD"` // Use 'HEAD' because some server implementations bypass accounting for this kind of traffic.
 	UdpCheckDns               []string      `mapstructure:"udp_check_dns" default:"dns.google.com:53,8.8.8.8,2001:4860:4860::8888"`
 	CheckInterval             time.Duration `mapstructure:"check_interval" default:"30s"`
 	CheckTolerance            time.Duration `mapstructure:"check_tolerance" default:"0"`

--- a/config/desc.go
+++ b/config/desc.go
@@ -40,7 +40,7 @@ var GlobalDesc = Desc{
 	"so_mark_from_dae":      "If not zero, traffic sent from dae will be set SO_MARK. It is useful to avoid traffic loop with iptables tproxy rules.",
 	"log_level":             "Log level: error, warn, info, debug, trace.",
 	"tcp_check_url":         "Node connectivity check.\nHost of URL should have both IPv4 and IPv6 if you have double stack in local.\nConsidering traffic consumption, it is recommended to choose a site with anycast IP and less response.",
-	"tcp_check_http_method": "The HTTP request method to `tcp_check_url`. Use 'CONNECT' by default because some server implementations bypass accounting for this kind of traffic.",
+	"tcp_check_http_method": "The HTTP request method to `tcp_check_url`. Use 'HEAD' by default because some server implementations bypass accounting for this kind of traffic.",
 	"udp_check_dns":         "This DNS will be used to check UDP connectivity of nodes. And if dns_upstream below contains tcp, it also be used to check TCP DNS connectivity of nodes.\nThis DNS should have both IPv4 and IPv6 if you have double stack in local.",
 	"check_interval":        "Interval of connectivity check for TCP and UDP",
 	"check_tolerance":       "Group will switch node only when new_latency <= old_latency - tolerance.",

--- a/example.dae
+++ b/example.dae
@@ -43,9 +43,9 @@ global {
     #tcp_check_url: 'http://cp.cloudflare.com'
     tcp_check_url: 'http://cp.cloudflare.com,1.1.1.1,2606:4700:4700::1111'
 
-    # The HTTP request method to `tcp_check_url`. Use 'CONNECT' by default because some server implementations bypass
+    # The HTTP request method to `tcp_check_url`. Use 'HEAD' by default because some server implementations bypass
     # accounting for this kind of traffic.
-    tcp_check_http_method: CONNECT
+    tcp_check_http_method: HEAD
 
     # This DNS will be used to check UDP connectivity of nodes. And if dns_upstream below contains tcp, it also be used to check
     # TCP DNS connectivity of nodes.


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

`CONNECT` will cause unexpected status code for some domains, like gstatic.com.

The method name is mistaken and should be corrected to `HEAD`.

### Checklist

- [x] The Pull Request has been fully tested
- [x] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelog

- example.dae
- desc.go
- config.go

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

Fix #134
