### PR TITLE
fix: should gracefully exit if failed to listen when reloading

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -121,6 +121,10 @@ loop:
 		switch sig {
 		case nil:
 			if reloading {
+				if listener == nil {
+					// Failed to listen. Exit.
+					break loop
+				}
 				// Serve.
 				reloading = false
 				log.Warnln("[Reload] Serve")


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Raised from dae-wing. It reloads dae at start, and if at this time dae fails in listen, dae will panic.

### Checklist

- [x] The Pull Request has been fully tested

### Full changelog

- Add a check in the reloading procedure.
