### PR TITLE
fix(group): policy 'fixed' parsing

### DIFF
--- a/component/outbound/dialer_selection_policy.go
+++ b/component/outbound/dialer_selection_policy.go
@@ -37,12 +37,12 @@ func NewDialerSelectionPolicyFromGroupParam(param *config.Group) (policy *Dialer
 		if f.Not {
 			return nil, fmt.Errorf("policy param does not support not operator: !%v()", f.Name)
 		}
-		if len(f.Params) > 1 || f.Params[0].Key != "" {
+		if len(f.Params) != 1 || f.Params[0].Key != "" {
 			return nil, fmt.Errorf(`invalid "%v" param format`, f.Name)
 		}
 		strIndex := f.Params[0].Val
 		index, err := strconv.Atoi(strIndex)
-		if len(f.Params) > 1 || f.Params[0].Key != "" {
+		if err != nil {
 			return nil, fmt.Errorf(`invalid "%v" param format: %w`, f.Name, err)
 		}
 		return &DialerSelectionPolicy{


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

![image](https://github.com/daeuniverse/dae/assets/30586220/28aebd92-b552-4035-8493-4bae9df11b3d)

Bad checking for this case. This image shows a situation with no parameter given.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- Check this kind of boundary in the correct way.

