### PR TITLE
fix: new control plane should reset grpc conn pool cache

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -18,7 +18,6 @@ import (
 	"github.com/mzz2017/softwind/netproxy"
 	"github.com/mzz2017/softwind/pkg/fastrand"
 	"github.com/mzz2017/softwind/protocol/direct"
-	"github.com/mzz2017/softwind/transport/grpc"
 
 	"github.com/daeuniverse/dae/cmd/internal"
 	"github.com/daeuniverse/dae/common"
@@ -128,9 +127,6 @@ loop:
 					break loop
 				}
 				// Serve.
-				// FIXME: Ugly code here: reset grpc clients manually.
-				grpc.CleanGlobalClientConnectionCache()
-
 				reloading = false
 				log.Warnln("[Reload] Serve")
 				readyChan := make(chan bool, 1)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/mzz2017/softwind/netproxy"
-	"github.com/mzz2017/softwind/pkg/fastrand"
-	"github.com/mzz2017/softwind/protocol/direct"
 	"net"
 	"net/http"
 	"os"
@@ -17,6 +14,11 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/mzz2017/softwind/netproxy"
+	"github.com/mzz2017/softwind/pkg/fastrand"
+	"github.com/mzz2017/softwind/protocol/direct"
+	"github.com/mzz2017/softwind/transport/grpc"
 
 	"github.com/daeuniverse/dae/cmd/internal"
 	"github.com/daeuniverse/dae/common"
@@ -126,6 +128,9 @@ loop:
 					break loop
 				}
 				// Serve.
+				// FIXME: Ugly code here: reset grpc clients manually.
+				grpc.CleanGlobalClientConnectionCache()
+
 				reloading = false
 				log.Warnln("[Reload] Serve")
 				readyChan := make(chan bool, 1)

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -35,6 +35,7 @@ import (
 	"github.com/mohae/deepcopy"
 	"github.com/mzz2017/softwind/pool"
 	"github.com/mzz2017/softwind/protocol/direct"
+	"github.com/mzz2017/softwind/transport/grpc"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/dns/dnsmessage"
 	"golang.org/x/sys/unix"
@@ -262,6 +263,8 @@ func NewControlPlane(
 	}
 
 	// Filter out groups.
+	// FIXME: Ugly code here: reset grpc clients manually.
+	grpc.CleanGlobalClientConnectionCache()
 	dialerSet := outbound.NewDialerSetFromLinks(option, tagToNodeList)
 	deferFuncs = append(deferFuncs, dialerSet.Close)
 	for _, group := range groups {

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/json-iterator/go v1.1.12
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
-	github.com/mzz2017/softwind v0.0.0-20230617041556-c341d431c575
+	github.com/mzz2017/softwind v0.0.0-20230618055635-5c79a9138694
 	github.com/okzk/sdnotify v0.0.0-20180710141335-d9becc38acbd
 	github.com/safchain/ethtool v0.0.0-20230116090318-67cc41908669
 	github.com/sirupsen/logrus v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,8 @@ github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/mzz2017/disk-bloom v1.0.1 h1:rEF9MiXd9qMW3ibRpqcerLXULoTgRlM21yqqJl1B90M=
 github.com/mzz2017/disk-bloom v1.0.1/go.mod h1:JLHETtUu44Z6iBmsqzkOtFlRvXSlKnxjwiBRDapizDI=
-github.com/mzz2017/softwind v0.0.0-20230617041556-c341d431c575 h1:SdmqtK60s2yi9qghZ0CyECRkXDOGhp2wvhFxISi1spU=
-github.com/mzz2017/softwind v0.0.0-20230617041556-c341d431c575/go.mod h1:1hn+ZsP9fLm17yEx0jyqxHkIKm5u2gBXVGIrnKsE1fY=
+github.com/mzz2017/softwind v0.0.0-20230618055635-5c79a9138694 h1:qLBM6+Xt8JxWM4gkMuBOOn9Xy1aAcQorH4vEB8ibHls=
+github.com/mzz2017/softwind v0.0.0-20230618055635-5c79a9138694/go.mod h1:1hn+ZsP9fLm17yEx0jyqxHkIKm5u2gBXVGIrnKsE1fY=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

**Problem**

We may change gRPC node configuration, but the changed configuration is hard to apply due to the long connection and connection reuse feature of gRPC.

**How to reproduce**

Context is <https://github.com/daeuniverse/dae/issues/111>. (This PR does not fix it)

If we change `allow_insecure` from false to true, and reload dae; the node remains not working.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- Upgrade softwind to support to clean the grpc connection pool. <https://github.com/mzz2017/softwind/commit/5c79a9138694865dd5ddfcdaa2074f0d4d94222a>
- Call clean func before NewDialerSetFromLinks in NewControlPlane.

