### PR TITLE
feat(config): support IgnoreZero option for config.Marhsaller

### DIFF
--- a/config/marshal.go
+++ b/config/marshal.go
@@ -38,6 +38,7 @@ func (c *Config) Marshal(indentSpace int) (b []byte, err error) {
 
 type Marshaller struct {
 	IndentSpace int
+	IgnoreZero  bool
 	buf         bytes.Buffer
 }
 
@@ -138,7 +139,7 @@ unsupported:
 }
 
 func (m *Marshaller) marshalLeaf(key string, from reflect.Value, depth int) (err error) {
-	if from.IsZero() {
+	if m.IgnoreZero && from.IsZero() {
 		// Do not marshal zero value.
 		return nil
 	}


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Sometimes, `zero value`, like bool type value `false` should not be ignored when `marshaling`. Especially, when the default value is `true` (defined in config/config.go) and we want to set it `false`, the `false` will be marshaled as `empty` which will be derivated as `true` furtherly unexpectedly in parsing.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- Add `IgnoreZero` option for `config.Marshaller`.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

Related  <https://github.com/daeuniverse/dae-wing/issues/37>.
