### PR TITLE
ci: separate release build from main build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,6 @@ on:
       - "go.sum"
       - ".github/workflows/build.yml"
       - "Makefile"
-  release:
-    types: [ prereleased ]
   pull_request:
     types: [ opened, synchronize, reopened ]
     paths:
@@ -68,6 +66,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
       - name: Get the version
         id: get_version
         env:
@@ -84,6 +83,7 @@ jobs:
           fi
           echo "VERSION=$version" >> $GITHUB_OUTPUT
           echo "VERSION=$version" >> $GITHUB_ENV
+
       - name: Show workflow information
         id: get_filename
         run: |
@@ -91,30 +91,24 @@ jobs:
           echo "GOOS: $GOOS, GOARCH: $GOARCH, RELEASE_NAME: $_NAME"
           echo "ASSET_NAME=$_NAME" >> $GITHUB_OUTPUT
           echo "ASSET_NAME=$_NAME" >> $GITHUB_ENV
+
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
           go-version: '^1.19'
+
       - name: Install Dependencies
         run: |
           sudo apt-get update -y
           sudo apt-get install -y clang llvm
+
       - name: Get project dependencies
         run: |
           git submodule update --init --recursive
           GOMODCACHE="${PWD}"/go-mod go mod download -modcacherw
           find ./go-mod/ -maxdepth 1 ! -name "cache" ! -name "go-mod" -exec rm -rf {} \;
           sed -i 's/#export GOMODCACHE=$(PWD)\/go-mod/export GOMODCACHE=$(PWD)\/go-mod/' Makefile
-      - name: Create full source ZIP archive and Signature
-        if: github.event_name == 'release' && matrix.goarch == 'amd64' && matrix.goamd64 == 'v1'
-        run: |
-          zip -9vr dae-full-src.zip . -x .git/\*
-          FILE=./dae-full-src.zip
-          DGST=$FILE.dgst
-          md5sum        $FILE >>$DGST
-          shasum -a 1   $FILE >>$DGST
-          shasum -a 256 $FILE >>$DGST
-          shasum -a 512 $FILE >>$DGST
+
       - name: Build dae
         run: |
           mkdir -p ./build/
@@ -128,6 +122,7 @@ jobs:
           cp ./example.dae ./build/
           curl -L -o ./build/geoip.dat https://github.com/v2ray/geoip/releases/latest/download/geoip.dat
           curl -L -o ./build/geosite.dat https://github.com/v2ray/domain-list-community/releases/latest/download/dlc.dat
+
       - name: Smoking test
         if: matrix.goarch == 'amd64' && matrix.goamd64 == 'v1'
         run: ./build/dae-$ASSET_NAME --version
@@ -143,28 +138,10 @@ jobs:
           shasum -a 1   $FILE >>$DGST
           shasum -a 256 $FILE >>$DGST
           shasum -a 512 $FILE >>$DGST
+
       - name: Upload files to Artifacts
         uses: actions/upload-artifact@v3
         with:
           name: dae-${{ steps.get_filename.outputs.ASSET_NAME }}.zip
           path: build/*
 
-      - name: Upload full source to GitHub release
-        uses: svenstaro/upload-release-action@v2
-        if: github.event_name == 'release' && matrix.goarch == 'amd64' && matrix.goamd64 == 'v1'
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file_glob: true
-          file: dae-full-src.zip*
-          overwrite: true
-          tag: ${{ github.ref }}
-
-      - name: Upload files to GitHub release
-        uses: svenstaro/upload-release-action@v2
-        if: github.event_name == 'release'
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file_glob: true
-          file: dae-${{ steps.get_filename.outputs.ASSET_NAME }}.zip*
-          overwrite: true
-          tag: ${{ github.ref }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,173 @@
+name: Publish Pre-release
+run-name: Publish prerelease ${{ inputs.tag }} by @${{ github.actor }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        type: string
+        required: true
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        goos: [ linux ]
+        goarch: [ arm64, 386, riscv64, mips64, mips64le, mipsle, mips ]
+        include:
+          # BEGIN Linux ARM 5 6 7
+          - goos: linux
+            goarch: arm
+            goarm: 7
+          - goos: linux
+            goarch: arm
+            goarm: 6
+          - goos: linux
+            goarch: arm
+            goarm: 5
+          # END Linux ARM 5 6 7
+          # BEGIN Linux AMD64 v1 v2 v3
+          - goos: linux
+            goarch: amd64
+            goamd64: v1
+          - goos: linux
+            goarch: amd64
+            goamd64: v2
+          - goos: linux
+            goarch: amd64
+            goamd64: v3
+          # END Linux AMD64 v1 v2 v3
+      fail-fast: false
+
+    runs-on: ubuntu-22.04
+    env:
+      GOOS: ${{ matrix.goos }}
+      GOARCH: ${{ matrix.goarch }}
+      GOARM: ${{ matrix.goarm }}
+      GOAMD64: ${{ matrix.goamd64 }}
+      CGO_ENABLED: 0
+
+    steps:
+      - name: Checkout codebase
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get the version
+        id: get_version
+        env:
+          REF: ${{ inputs.tag }}
+        run: |
+          version=${REF}
+          echo "VERSION=$version" >> $GITHUB_OUTPUT
+          echo "VERSION=$version" >> $GITHUB_ENV
+
+      - name: Show workflow information
+        id: get_filename
+        run: |
+          export _NAME=$(jq ".[\"$GOOS-$GOARCH$GOARM$GOAMD64\"].friendlyName" -r < install/friendly-filenames.json)
+          echo "GOOS: $GOOS, GOARCH: $GOARCH, RELEASE_NAME: $_NAME"
+          echo "ASSET_NAME=$_NAME" >> $GITHUB_OUTPUT
+          echo "ASSET_NAME=$_NAME" >> $GITHUB_ENV
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '^1.19'
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y clang llvm
+
+      - name: Get project dependencies
+        run: |
+          git submodule update --init --recursive
+          GOMODCACHE="${PWD}"/go-mod go mod download -modcacherw
+          find ./go-mod/ -maxdepth 1 ! -name "cache" ! -name "go-mod" -exec rm -rf {} \;
+          sed -i 's/#export GOMODCACHE=$(PWD)\/go-mod/export GOMODCACHE=$(PWD)\/go-mod/' Makefile
+
+      - name: Create full source ZIP archive and Signature
+        if: matrix.goarch == 'arm64'
+        run: |
+          zip -9vr dae-full-src.zip . -x .git/\*
+          FILE=./dae-full-src.zip
+          echo "$(md5sum $FILE)""  md5" >> $FILE.dgst
+          echo "$(shasum -a 1 $FILE)""  sha1" >> $FILE.dgst
+          echo "$(shasum -a 256 $FILE)""  sha256" >> $FILE.dgst
+          echo "$(shasum -a 512 $FILE)""  sha512" >> $FILE.dgst
+  
+      - name: Build dae
+        run: |
+          mkdir -p ./build/
+          export CGO_ENABLED=0
+          export GOFLAGS="-trimpath -modcacherw"
+          export CFLAGS="-D__REMOVE_BPF_PRINTK"
+          export OUTPUT=build/dae-$ASSET_NAME
+          export VERSION=${{ steps.get_version.outputs.VERSION }}
+          make
+          cp ./install/dae.service ./build/
+          cp ./example.dae ./build/
+          curl -L -o ./build/geoip.dat https://github.com/v2ray/geoip/releases/latest/download/geoip.dat
+          curl -L -o ./build/geosite.dat https://github.com/v2ray/domain-list-community/releases/latest/download/dlc.dat
+
+      - name: Smoking test
+        if: matrix.goarch == 'amd64' && matrix.goamd64 == 'v1'
+        run: ./build/dae-$ASSET_NAME --version
+
+      - name: Create binary ZIP archive and Signature
+        run: |
+          pushd build || exit 1
+          zip -9vr ../dae-$ASSET_NAME.zip .
+          popd || exit 1
+          FILE=./dae-$ASSET_NAME.zip
+          echo "$(md5sum $FILE)""  md5" >> $FILE.dgst
+          echo "$(shasum -a 1 $FILE)""  sha1" >> $FILE.dgst
+          echo "$(shasum -a 256 $FILE)""  sha256" >> $FILE.dgst
+          echo "$(shasum -a 512 $FILE)""  sha512" >> $FILE.dgst
+
+#       - name: Upload full source to Artifacts
+#         if: matrix.goarch == 'arm64'
+#         uses: actions/upload-artifact@v3
+#         with:
+#           name: dae-full-src.zip
+#           path: dae-full-src.zip
+
+      - name: Upload files to Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: dae-${{ steps.get_filename.outputs.ASSET_NAME }}.zip
+          path: ./*.zip*
+
+  upload-release:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: release/
+
+      - name: Prepare files for upload
+        run: |
+          cp release/*/*.zip ./
+          cp release/*/*.zip.dgst ./
+          echo "Show files are going to upload..."
+          ls -lh | grep ".zip"
+
+      - name: Upload full source to GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ inputs.tag }}
+          files: |
+            dae-full-src.zip
+          prerelease: true
+
+      - name: Upload full source and artifacts to GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ inputs.tag }}
+          files: |
+            *zip
+            *dgst
+          prerelease: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,164 @@
+name: Publish Release
+run-name: Publish release ${{ inputs.tag }} by @${{ github.actor }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        type: string
+        required: true
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        goos: [ linux ]
+        goarch: [ arm64, 386, riscv64, mips64, mips64le, mipsle, mips ]
+        include:
+          # BEGIN Linux ARM 5 6 7
+          - goos: linux
+            goarch: arm
+            goarm: 7
+          - goos: linux
+            goarch: arm
+            goarm: 6
+          - goos: linux
+            goarch: arm
+            goarm: 5
+          # END Linux ARM 5 6 7
+          # BEGIN Linux AMD64 v1 v2 v3
+          - goos: linux
+            goarch: amd64
+            goamd64: v1
+          - goos: linux
+            goarch: amd64
+            goamd64: v2
+          - goos: linux
+            goarch: amd64
+            goamd64: v3
+          # END Linux AMD64 v1 v2 v3
+      fail-fast: false
+
+    runs-on: ubuntu-22.04
+    env:
+      GOOS: ${{ matrix.goos }}
+      GOARCH: ${{ matrix.goarch }}
+      GOARM: ${{ matrix.goarm }}
+      GOAMD64: ${{ matrix.goamd64 }}
+      CGO_ENABLED: 0
+
+    steps:
+      - name: Checkout codebase
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get the version
+        id: get_version
+        env:
+          REF: ${{ inputs.tag }}
+        run: |
+          version=${REF}
+          echo "VERSION=$version" >> $GITHUB_OUTPUT
+          echo "VERSION=$version" >> $GITHUB_ENV
+
+      - name: Show workflow information
+        id: get_filename
+        run: |
+          export _NAME=$(jq ".[\"$GOOS-$GOARCH$GOARM$GOAMD64\"].friendlyName" -r < install/friendly-filenames.json)
+          echo "GOOS: $GOOS, GOARCH: $GOARCH, RELEASE_NAME: $_NAME"
+          echo "ASSET_NAME=$_NAME" >> $GITHUB_OUTPUT
+          echo "ASSET_NAME=$_NAME" >> $GITHUB_ENV
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '^1.19'
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y clang llvm
+
+      - name: Get project dependencies
+        run: |
+          git submodule update --init --recursive
+          GOMODCACHE="${PWD}"/go-mod go mod download -modcacherw
+          find ./go-mod/ -maxdepth 1 ! -name "cache" ! -name "go-mod" -exec rm -rf {} \;
+          sed -i 's/#export GOMODCACHE=$(PWD)\/go-mod/export GOMODCACHE=$(PWD)\/go-mod/' Makefile
+
+      - name: Create full source ZIP archive and Signature
+        if: matrix.goarch == 'arm64'
+        run: |
+          zip -9vr dae-full-src.zip . -x .git/\*
+          FILE=./dae-full-src.zip
+          echo "$(md5sum $FILE)""  md5" >> $FILE.dgst
+          echo "$(shasum -a 1 $FILE)""  sha1" >> $FILE.dgst
+          echo "$(shasum -a 256 $FILE)""  sha256" >> $FILE.dgst
+          echo "$(shasum -a 512 $FILE)""  sha512" >> $FILE.dgst
+  
+      - name: Build dae
+        run: |
+          mkdir -p ./build/
+          export CGO_ENABLED=0
+          export GOFLAGS="-trimpath -modcacherw"
+          export CFLAGS="-D__REMOVE_BPF_PRINTK"
+          export OUTPUT=build/dae-$ASSET_NAME
+          export VERSION=${{ steps.get_version.outputs.VERSION }}
+          make
+          cp ./install/dae.service ./build/
+          cp ./example.dae ./build/
+          curl -L -o ./build/geoip.dat https://github.com/v2ray/geoip/releases/latest/download/geoip.dat
+          curl -L -o ./build/geosite.dat https://github.com/v2ray/domain-list-community/releases/latest/download/dlc.dat
+
+      - name: Smoking test
+        if: matrix.goarch == 'amd64' && matrix.goamd64 == 'v1'
+        run: ./build/dae-$ASSET_NAME --version
+
+      - name: Create binary ZIP archive and Signature
+        run: |
+          pushd build || exit 1
+          zip -9vr ../dae-$ASSET_NAME.zip .
+          popd || exit 1
+          FILE=./dae-$ASSET_NAME.zip
+          echo "$(md5sum $FILE)""  md5" >> $FILE.dgst
+          echo "$(shasum -a 1 $FILE)""  sha1" >> $FILE.dgst
+          echo "$(shasum -a 256 $FILE)""  sha256" >> $FILE.dgst
+          echo "$(shasum -a 512 $FILE)""  sha512" >> $FILE.dgst
+
+      - name: Upload files to Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: dae-${{ steps.get_filename.outputs.ASSET_NAME }}.zip
+          path: ./*.zip*
+
+  upload-release:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: release/
+
+      - name: Prepare files for upload
+        run: |
+          cp release/*/*.zip ./
+          cp release/*/*.zip.dgst ./
+          echo "Show files are going to upload..."
+          ls -lh | grep ".zip"
+
+      - name: Upload full source to GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ inputs.tag }}
+          files: |
+            dae-full-src.zip
+
+      - name: Upload full source and artifacts to GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ inputs.tag }}
+          files: |
+            *zip
+            *dgst


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Separate release builds from main build. Changes are proposed by @MarksonHon and @kunish followed by the existing release workflows in `daed` - https://github.com/daeuniverse/daed/blob/main/.github/workflows/prerelease.yml

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- ci(build): detach release-related steps and trigger
- ci: add prerelease workflow
- ci: add release workflow

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

Resolved [Separate release build from regular build] in #156 
