### PR TITLE
chore/docs: support to unroll route loop and update troubleshooting.md

### DIFF
--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -10,6 +10,12 @@ Solution:
 
 Compile dae with CFLAG `-D__REMOVE_BPF_PRINTK`. See [build-by-yourself](build-by-yourself.md).
 
+## No network after `dae suspend`
+
+Do not set dae as the DNS in DHCP setting. For example, you can set `223.5.5.5` as DNS in your DHCP setting.
+
+Because dae will not hijack any DNS request if it was suspended.
+
 ## PVE related
 
 - [PVE NIC Hardware passthrough](https://github.com/daeuniverse/dae/issues/43)
@@ -61,3 +67,14 @@ netstat -ulpen|grep 53
 ```
 
 If does, stop the service process or change its listening port from 53 to others. Do not forget to modify `/etc/resolv.conf` to make DNS accessible (for example, with content `nameserver 223.5.5.5`, but do not use `nameserver 127.0.0.1`).
+
+## Failed to load eBPF objects
+
+> FATA[0022] load eBPF objects: field TproxyWanEgress: program tproxy_wan_egress: load program: argument list too long: 1617: (bf) r2 = r6: 1618: (85) call bpf_map_loo (truncated, 992 line(s) omitted)
+
+If you use `clang-13` to compile dae, you may encounter this problem.
+
+There are ways to resolve it:
+
+1. Method 1: Use `clang-15` or higher versions to compile dae.
+2. Method 2: Add CFLAGS `-D__UNROLL_ROUTE_LOOP` while compiling. However, it will increse memory occupation (or swap space) at the eBPF loading stage (about 180MB). For example, compile dae to arm64 using `make CGO_ENABLE=0 GOARCH=arm64 CFLAGS="-D__UNROLL_ROUTE_LOOP -D__REMOVE_BPF_PRINTK"`.

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -77,4 +77,4 @@ If you use `clang-13` to compile dae, you may encounter this problem.
 There are ways to resolve it:
 
 1. Method 1: Use `clang-15` or higher versions to compile dae.
-2. Method 2: Add CFLAGS `-D__UNROLL_ROUTE_LOOP` while compiling. However, it will increse memory occupation (or swap space) at the eBPF loading stage (about 180MB). For example, compile dae to arm64 using `make CGO_ENABLE=0 GOARCH=arm64 CFLAGS="-D__UNROLL_ROUTE_LOOP -D__REMOVE_BPF_PRINTK"`.
+2. Method 2: Add CFLAGS `-D__UNROLL_ROUTE_LOOP` while compiling. However, it will increse memory occupation (or swap space) at the eBPF loading stage (about 180MB). For example, compile dae to ARM64 using `make CGO_ENABLE=0 GOARCH=arm64 CFLAGS="-D__UNROLL_ROUTE_LOOP -D__REMOVE_BPF_PRINTK"`.

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -76,5 +76,5 @@ If you use `clang-13` to compile dae, you may encounter this problem.
 
 There are ways to resolve it:
 
-1. Method 1: Use `clang-15` or higher versions to compile dae.
+1. Method 1: Use `clang-15` or higher versions to compile dae. Or just download dae from [releases](https://github.com/daeuniverse/dae/releases).
 2. Method 2: Add CFLAGS `-D__UNROLL_ROUTE_LOOP` while compiling. However, it will increse memory occupation (or swap space) at the eBPF loading stage (about 180MB). For example, compile dae to ARM64 using `make CGO_ENABLE=0 GOARCH=arm64 CFLAGS="-D__UNROLL_ROUTE_LOOP -D__REMOVE_BPF_PRINTK"`.

--- a/hack/test/insert.sh
+++ b/hack/test/insert.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 lan=docker0
-wan=wlp5s0
+wan=ens192
 
 sudo tc qdisc add dev $lan clsact > /dev/null 2>&1
 sudo tc qdisc add dev $wan clsact > /dev/null 2>&1
@@ -9,8 +9,8 @@ set -ex
 
 sudo rm -rf /sys/fs/bpf/tc/globals/*
 
-# clang -fno-stack-protector -O2 -g -emit-llvm -c control/kern/tproxy.c -o - | llc -march=bpf -mcpu=v3 -mattr=+alu32 -filetype=obj -o foo.o
-clang -O2 -g -Wall -Werror -c control/kern/tproxy.c -target bpf -D__TARGET_ARCH_x86 -o foo.o
+# clang -fno-stack-protector -O2 -g -emit-llvm -c ../../control/kern/tproxy.c -o - | llc -march=bpf -mcpu=v3 -mattr=+alu32 -filetype=obj -o foo.o
+clang -O2 -g -Wall -Werror -c ../../control/kern/tproxy.c -target bpf -D__TARGET_ARCH_x86 -o foo.o
 sudo tc filter del dev $lan ingress
 sudo tc filter del dev $lan egress
 sudo tc filter del dev $wan ingress


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

dae will fail to load eBPF objects under the compilation of `clang-13`.

```
FATA[0022] load eBPF objects: field TproxyWanEgress: program tproxy_wan_egress: load program: argument list too long: 1617: (bf) r2 = r6: 1618: (85) call bpf_map_loo (truncated, 992 line(s) omitted)
```

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOG
- [x] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- Allow defining `__UNROLL_ROUTE_LOOP` to unroll the route loop for fewer program instructions and shorter loading time. However, enabling this brings more memory occupation.
- Add a related note into `troubleshooting.md`.
- Add a `No network after dae suspend` note into `troubleshooting.md`.

