### PR TITLE
fix: should allow fallbacking ip version if dialing domain

### DIFF
--- a/common/consts/ebpf.go
+++ b/common/consts/ebpf.go
@@ -131,6 +131,16 @@ const (
 	IpVersion_X IpVersionType = 3
 )
 
+func (v IpVersionType) ToIpVersionStr() IpVersionStr {
+	switch v {
+	case IpVersion_4:
+		return IpVersionStr_4
+	case IpVersion_6:
+		return IpVersionStr_6
+	}
+	panic("unsupported ipversion")
+}
+
 var (
 	BasicFeatureVersion = internal.Version{5, 2, 0}
 	// Deprecated: Ftrace does not support arm64 yet (Linux 6.2).

--- a/control/connectivity.go
+++ b/control/connectivity.go
@@ -24,12 +24,15 @@ func FormatL4Proto(l4proto uint8) string {
 	return strconv.Itoa(int(l4proto))
 }
 
-func (c *controlPlaneCore) OutboundAliveChangeCallback(outbound uint8) func(alive bool, networkType *dialer.NetworkType, isInit bool) {
+func (c *controlPlaneCore) outboundAliveChangeCallback(outbound uint8, dryrun bool) func(alive bool, networkType *dialer.NetworkType, isInit bool) {
 	return func(alive bool, networkType *dialer.NetworkType, isInit bool) {
 		select {
 		case <-c.closed.Done():
 			return
 		default:
+		}
+		if !isInit && dryrun {
+			return
 		}
 		if !isInit || c.log.IsLevelEnabled(logrus.TraceLevel) {
 			strAlive := "NOT ALIVE"

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -248,19 +248,30 @@ func NewControlPlane(
 		TlsImplementation: global.TlsImplementation,
 		UtlsImitate:       global.UtlsImitate,
 	}
+
+	// Dial mode.
+	dialMode, err := consts.ParseDialMode(global.DialMode)
+	if err != nil {
+		return nil, err
+	}
+	sniffingTimeout := global.SniffingTimeout
+	if dialMode == consts.DialMode_Ip {
+		sniffingTimeout = 0
+	}
+	disableKernelAliveCallback := dialMode != consts.DialMode_Ip
 	outbounds := []*outbound.DialerGroup{
 		outbound.NewDialerGroup(option, consts.OutboundDirect.String(),
 			[]*dialer.Dialer{dialer.NewDirectDialer(option, true)},
 			outbound.DialerSelectionPolicy{
 				Policy:     consts.DialerSelectionPolicy_Fixed,
 				FixedIndex: 0,
-			}, core.OutboundAliveChangeCallback(0)),
+			}, core.outboundAliveChangeCallback(0, disableKernelAliveCallback)),
 		outbound.NewDialerGroup(option, consts.OutboundBlock.String(),
 			[]*dialer.Dialer{dialer.NewBlockDialer(option, func() { /*Dialer Outbound*/ })},
 			outbound.DialerSelectionPolicy{
 				Policy:     consts.DialerSelectionPolicy_Fixed,
 				FixedIndex: 0,
-			}, core.OutboundAliveChangeCallback(1)),
+			}, core.outboundAliveChangeCallback(1, disableKernelAliveCallback)),
 	}
 
 	// Filter out groups.
@@ -290,7 +301,8 @@ func NewControlPlane(
 			log.Infoln("\t<Empty>")
 		}
 		// Create dialer group and append it to outbounds.
-		dialerGroup := outbound.NewDialerGroup(option, group.Name, dialers, *policy, core.OutboundAliveChangeCallback(uint8(len(outbounds))))
+		dialerGroup := outbound.NewDialerGroup(option, group.Name, dialers, *policy,
+			core.outboundAliveChangeCallback(uint8(len(outbounds)), disableKernelAliveCallback))
 		outbounds = append(outbounds, dialerGroup)
 	}
 
@@ -339,16 +351,7 @@ func NewControlPlane(
 		return nil, fmt.Errorf("RoutingMatcherBuilder.BuildUserspace: %w", err)
 	}
 
-	/// Dial mode.
-	dialMode, err := consts.ParseDialMode(global.DialMode)
-	if err != nil {
-		return nil, err
-	}
-	sniffingTimeout := global.SniffingTimeout
-	if dialMode == consts.DialMode_Ip {
-		sniffingTimeout = 0
-	}
-
+	// New control plane.
 	ctx, cancel := context.WithCancel(context.Background())
 	plane := &ControlPlane{
 		log:               log,
@@ -553,7 +556,7 @@ func (c *ControlPlane) dnsUpstreamReadyCallback(dnsUpstream *dns.Upstream) (err 
 	return nil
 }
 
-func (c *ControlPlane) ChooseDialTarget(outbound consts.OutboundIndex, dst netip.AddrPort, domain string) (dialTarget string, shouldReroute bool) {
+func (c *ControlPlane) ChooseDialTarget(outbound consts.OutboundIndex, dst netip.AddrPort, domain string) (dialTarget string, shouldReroute bool, dialIp bool) {
 	dialMode := consts.DialMode_Ip
 
 	if !outbound.IsReserved() && domain != "" {
@@ -601,6 +604,7 @@ func (c *ControlPlane) ChooseDialTarget(outbound consts.OutboundIndex, dst netip
 	switch dialMode {
 	case consts.DialMode_Ip:
 		dialTarget = dst.String()
+		dialIp = true
 	case consts.DialMode_Domain:
 		if strings.HasPrefix(domain, "[") && strings.HasSuffix(domain, "]") {
 			// Sniffed domain may be like `[2606:4700:20::681a:d1f]`. We should remove the brackets.
@@ -609,6 +613,7 @@ func (c *ControlPlane) ChooseDialTarget(outbound consts.OutboundIndex, dst netip
 		if _, err := netip.ParseAddr(domain); err == nil {
 			// domain is IPv4 or IPv6 (has colon)
 			dialTarget = net.JoinHostPort(domain, strconv.Itoa(int(dst.Port())))
+			dialIp = true
 
 		} else if _, _, err := net.SplitHostPort(domain); err == nil {
 			// domain is already domain:port
@@ -622,7 +627,7 @@ func (c *ControlPlane) ChooseDialTarget(outbound consts.OutboundIndex, dst netip
 			"to":   dialTarget,
 		}).Debugln("Rewrite dial target to domain")
 	}
-	return dialTarget, shouldReroute
+	return dialTarget, shouldReroute, dialIp
 }
 
 type Listener struct {
@@ -852,7 +857,8 @@ func (c *ControlPlane) chooseBestDnsDialer(
 				return nil, fmt.Errorf("bad outbound index: %v", outboundIndex)
 			}
 			dialerGroup := c.outbounds[outboundIndex]
-			d, latency, err := dialerGroup.Select(&networkType)
+			// DNS always dial IP.
+			d, latency, err := dialerGroup.Select(&networkType, true)
 			if err != nil {
 				continue
 			}

--- a/control/tcp.go
+++ b/control/tcp.go
@@ -82,7 +82,7 @@ destRetrieved:
 		outboundIndex = consts.OutboundControlPlaneRouting
 	}
 
-	dialTarget, shouldReroute := c.ChooseDialTarget(outboundIndex, dst, domain)
+	dialTarget, shouldReroute, dialIp := c.ChooseDialTarget(outboundIndex, dst, domain)
 	if shouldReroute {
 		outboundIndex = consts.OutboundControlPlaneRouting
 	}
@@ -102,7 +102,7 @@ destRetrieved:
 			)
 		}
 		// Reset dialTarget.
-		dialTarget, _ = c.ChooseDialTarget(outboundIndex, dst, domain)
+		dialTarget, _, dialIp = c.ChooseDialTarget(outboundIndex, dst, domain)
 	default:
 	}
 	if routingResult.Mark == 0 {
@@ -118,7 +118,8 @@ destRetrieved:
 		IpVersion: consts.IpVersionFromAddr(dst.Addr()),
 		IsDns:     false,
 	}
-	d, _, err := outbound.Select(networkType)
+	strictIpVersion := dialIp
+	d, _, err := outbound.Select(networkType, strictIpVersion)
 	if err != nil {
 		return fmt.Errorf("failed to select dialer from group %v (%v): %w", outbound.Name, networkType.String(), err)
 	}

--- a/control/udp.go
+++ b/control/udp.go
@@ -146,7 +146,7 @@ func (c *ControlPlane) handlePkt(lConn *net.UDPConn, data []byte, src, pktDst, r
 		outboundIndex = consts.OutboundControlPlaneRouting
 	}
 
-	dialTarget, shouldReroute := c.ChooseDialTarget(outboundIndex, realDst, domain)
+	dialTarget, shouldReroute, dialIp := c.ChooseDialTarget(outboundIndex, realDst, domain)
 	if shouldReroute {
 		outboundIndex = consts.OutboundControlPlaneRouting
 	}
@@ -173,7 +173,7 @@ func (c *ControlPlane) handlePkt(lConn *net.UDPConn, data []byte, src, pktDst, r
 			)
 		}
 		// Reset dialTarget.
-		dialTarget, _ = c.ChooseDialTarget(outboundIndex, realDst, domain)
+		dialTarget, _, dialIp = c.ChooseDialTarget(outboundIndex, realDst, domain)
 	default:
 	}
 	if routingResult.Mark == 0 {
@@ -201,7 +201,8 @@ func (c *ControlPlane) handlePkt(lConn *net.UDPConn, data []byte, src, pktDst, r
 		IpVersion: consts.IpVersionFromAddr(realDst.Addr()),
 		IsDns:     true, // UDP relies on DNS check result.
 	}
-	dialerForNew, _, err := outbound.Select(networkType)
+	strictIpVersion := dialIp
+	dialerForNew, _, err := outbound.Select(networkType, strictIpVersion)
 	if err != nil {
 		return fmt.Errorf("failed to select dialer from group %v (%v, dns?:%v,from: %v): %w", outbound.Name, networkType.StringWithoutDns(), isDns, realSrc.String(), err)
 	}


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

If the local host has IPv6 addresses but the remote proxy does not, `dae` drops all the IPv6 traffic onto the remote proxy. This behavior impacts lots of software that does not support happy eyeballs.

In fact, if we send the domain to the remote proxy, it will re-select ip version and this problem will be resolved.

In the past, `dae` did not support domain sniffing. The developer hope to solve this problem by happy eyeballs, but now it seems that this change needs to be optimized, and only when dialing ip instead, maintain the previous behavior.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- If `dial_mode` is not `ip`, dae removes notifying the kernel program to block the unreachable triples (group, ip version, l4 protocol).
- If the `dial` target is not an ip, dae trys to fallback to another ip version to dial.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

Fix #152
