### PR TITLE
optimize(dns): cache all qtype (not only a/aaaa)

### DIFF
--- a/control/dns_control.go
+++ b/control/dns_control.go
@@ -10,7 +10,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"github.com/daeuniverse/dae/common"
 	"io"
 	"math"
 	"net"
@@ -18,6 +17,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/daeuniverse/dae/common"
 
 	"github.com/daeuniverse/dae/common/consts"
 	"github.com/daeuniverse/dae/common/netutils"
@@ -155,11 +156,6 @@ func (c *DnsController) LookupDnsRespCache_(msg *dnsmessage.Message) (resp []byt
 	}
 	q := msg.Questions[0]
 	if msg.Response {
-		return nil
-	}
-	switch q.Type {
-	case dnsmessage.TypeA, dnsmessage.TypeAAAA:
-	default:
 		return nil
 	}
 	cache := c.LookupDnsRespCache(q.Name.String(), q.Type)


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

![图片](https://github.com/daeuniverse/dae/assets/30586220/ba7728fa-dc4b-4163-874c-98cef7b507d1)

Non `A/AAAA` DNS lookup does not use cache. This PR fixes it.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- Remove limit `A/AAAA` from looking up the cache.
