### PR TITLE
chore(geodata): change back to v2fly geodata

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,8 +122,8 @@ jobs:
           make
           cp ./install/dae.service ./build/
           cp ./example.dae ./build/
-          curl -L -o ./build/geoip.dat https://github.com/v2ray/geoip/releases/latest/download/geoip.dat
-          curl -L -o ./build/geosite.dat https://github.com/v2ray/domain-list-community/releases/latest/download/dlc.dat
+          curl -L -o ./build/geoip.dat https://github.com/v2fly/geoip/releases/latest/download/geoip.dat
+          curl -L -o ./build/geosite.dat https://github.com/v2fly/domain-list-community/releases/latest/download/dlc.dat
 
       - name: Smoking test
         if: matrix.goarch == 'amd64' && matrix.goamd64 == 'v1'

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -110,8 +110,8 @@ jobs:
           make
           cp ./install/dae.service ./build/
           cp ./example.dae ./build/
-          curl -L -o ./build/geoip.dat https://github.com/v2ray/geoip/releases/latest/download/geoip.dat
-          curl -L -o ./build/geosite.dat https://github.com/v2ray/domain-list-community/releases/latest/download/dlc.dat
+          curl -L -o ./build/geoip.dat https://github.com/v2fly/geoip/releases/latest/download/geoip.dat
+          curl -L -o ./build/geosite.dat https://github.com/v2fly/domain-list-community/releases/latest/download/dlc.dat
 
       - name: Smoking test
         if: matrix.goarch == 'amd64' && matrix.goamd64 == 'v1'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,8 +110,8 @@ jobs:
           make
           cp ./install/dae.service ./build/
           cp ./example.dae ./build/
-          curl -L -o ./build/geoip.dat https://github.com/v2ray/geoip/releases/latest/download/geoip.dat
-          curl -L -o ./build/geosite.dat https://github.com/v2ray/domain-list-community/releases/latest/download/dlc.dat
+          curl -L -o ./build/geoip.dat https://github.com/v2fly/geoip/releases/latest/download/geoip.dat
+          curl -L -o ./build/geosite.dat https://github.com/v2fly/domain-list-community/releases/latest/download/dlc.dat
 
       - name: Smoking test
         if: matrix.goarch == 'amd64' && matrix.goamd64 == 'v1'

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ RUN make OUTPUT=dae GOFLAGS="-buildvcs=false" CC=clang CGO_ENABLED=0
 FROM alpine
 RUN mkdir -p /usr/local/share/dae/
 RUN mkdir -p /etc/dae/
-RUN wget -O /usr/local/share/dae/geoip.dat https://github.com/v2rayA/dist-v2ray-rules-dat/raw/master/geoip.dat
-RUN wget -O /usr/local/share/dae/geosite.dat https://github.com/v2rayA/dist-v2ray-rules-dat/raw/master/geosite.dat
+RUN wget -O /usr/local/share/dae/geoip.dat https://github.com/v2ray/geoip/releases/latest/download/geoip.dat
+RUN wget -O /usr/local/share/dae/geosite.dat https://github.com/v2ray/domain-list-community/releases/latest/download/dlc.dat
 COPY --from=builder /build/dae /usr/local/bin
 COPY --from=builder /build/install/empty.dae /etc/dae/config.dae
 RUN chmod 0600 /etc/dae/config.dae

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ RUN make OUTPUT=dae GOFLAGS="-buildvcs=false" CC=clang CGO_ENABLED=0
 FROM alpine
 RUN mkdir -p /usr/local/share/dae/
 RUN mkdir -p /etc/dae/
-RUN wget -O /usr/local/share/dae/geoip.dat https://github.com/v2ray/geoip/releases/latest/download/geoip.dat
-RUN wget -O /usr/local/share/dae/geosite.dat https://github.com/v2ray/domain-list-community/releases/latest/download/dlc.dat
+RUN wget -O /usr/local/share/dae/geoip.dat https://github.com/v2fly/geoip/releases/latest/download/geoip.dat
+RUN wget -O /usr/local/share/dae/geosite.dat https://github.com/v2fly/domain-list-community/releases/latest/download/dlc.dat
 COPY --from=builder /build/dae /usr/local/bin
 COPY --from=builder /build/install/empty.dae /etc/dae/config.dae
 RUN chmod 0600 /etc/dae/config.dae

--- a/docs/dns.md
+++ b/docs/dns.md
@@ -41,7 +41,7 @@ dns {
 
             # DNS request name (omit suffix dot '.').
             qname(geosite:category-ads-all) -> reject
-            qname(geosite:google@cn) -> alidns # Also see: https://github.com/v2ray/domain-list-community#attributes
+            qname(geosite:google@cn) -> alidns # Also see: https://github.com/v2fly/domain-list-community#attributes
             qname(suffix: abc.com, keyword: google) -> googledns
             qname(full: ok.com, regex: '^yes') -> googledns
             # DNS request type

--- a/docs/getting-started/build-by-yourself.md
+++ b/docs/getting-started/build-by-yourself.md
@@ -36,13 +36,13 @@ make GOFLAGS="-buildvcs=false" \
 
 ### Runtime Dependencies
 
-For traffic splitting, dae relies on the following data sources, [geoip.dat](https://github.com/v2ray/geoip/releases/latest) and [geosite.dat](https://github.com/v2fly/domain-list-community/releases/latest).
+For traffic splitting, dae relies on the following data sources, [geoip.dat](https://github.com/v2fly/geoip/releases/latest) and [geosite.dat](https://github.com/v2fly/domain-list-community/releases/latest).
 
 ```shell
 mkdir -p /usr/local/share/dae/
 pushd /usr/local/share/dae/
-curl -L -o geoip.dat https://github.com/v2ray/geoip/releases/latest/download/geoip.dat
-curl -L -o geosite.dat https://github.com/v2ray/domain-list-community/releases/latest/download/dlc.dat
+curl -L -o geoip.dat https://github.com/v2fly/geoip/releases/latest/download/geoip.dat
+curl -L -o geosite.dat https://github.com/v2fly/domain-list-community/releases/latest/download/dlc.dat
 popd
 ```
 

--- a/docs/getting-started/run-as-daemon.md
+++ b/docs/getting-started/run-as-daemon.md
@@ -10,13 +10,13 @@ dae can run as a daemon (systemd) service so that it can run at boot.
 
 ### Optional Geo Data Files
 
-For more convenient traffic split, dae relies on the following data sources, [geoip.dat](https://github.com/v2ray/geoip/releases/latest) and [geosite.dat](https://github.com/v2fly/domain-list-community/releases/latest).
+For more convenient traffic split, dae relies on the following data sources, [geoip.dat](https://github.com/v2fly/geoip/releases/latest) and [geosite.dat](https://github.com/v2fly/domain-list-community/releases/latest).
 
 ```shell
 mkdir -p /usr/local/share/dae/
 pushd /usr/local/share/dae/
-curl -L -o geoip.dat https://github.com/v2ray/geoip/releases/latest/download/geoip.dat
-curl -L -o geosite.dat https://github.com/v2ray/domain-list-community/releases/latest/download/dlc.dat
+curl -L -o geoip.dat https://github.com/v2fly/geoip/releases/latest/download/geoip.dat
+curl -L -o geosite.dat https://github.com/v2fly/domain-list-community/releases/latest/download/dlc.dat
 popd
 ```
 


### PR DESCRIPTION
This reverts commit 962018d14b4d886a4335ce475155a62983997144.

<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

`v2fly`'s geodata is the least problematic.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae
