### PR TITLE
ci(generate-changelogs): add control on whether to write to issue page

### DIFF
--- a/.github/workflows/generate-changelogs.yml
+++ b/.github/workflows/generate-changelogs.yml
@@ -10,6 +10,10 @@ on:
       future_release_tag:
         required: true
         description: future release tag
+      write_to_issue:
+        required: true
+        description: export changelogs to an issue page
+        default: true
 
 jobs:
   build:
@@ -35,6 +39,7 @@ jobs:
           echo "${{ steps.changelog.outputs.changelogs }}"
 
       - name: Create an issue with proposed changelogs
+        if: ${{ inputs.write_to_issue }}
         uses: dacbd/create-issue-action@main
         with:
           token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/generate-changelogs.yml
+++ b/.github/workflows/generate-changelogs.yml
@@ -39,7 +39,7 @@ jobs:
           echo "${{ steps.changelog.outputs.changelogs }}"
 
       - name: Create an issue with proposed changelogs
-        if: ${{ inputs.write_to_issue }}
+        if: ${{ inputs.write_to_issue == 'true' }}
         uses: dacbd/create-issue-action@main
         with:
           token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Add control on whether to export/write release changelogs to a GitHub issue.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- ci(generate-changelogs): control whether to write to issue page

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

NA

### Test Result

Successful Workflow Run: https://github.com/daeuniverse/dae/actions/runs/5430237700/jobs/9875838196
