### PR TITLE
chore: suppress LinkSubscribe error

### DIFF
--- a/control/control_plane_core.go
+++ b/control/control_plane_core.go
@@ -312,7 +312,7 @@ func (c *controlPlaneCore) addLinkCb(_ifname string, rtmType uint16, cb func()) 
 	done := make(chan struct{})
 	if e := netlink.LinkSubscribeWithOptions(ch, done, netlink.LinkSubscribeOptions{
 		ErrorCallback: func(err error) {
-			c.log.Warnln("LinkSubscribe:", err)
+			c.log.Debug("LinkSubscribe:", err)
 		},
 		ListExisting: true,
 	}); e != nil {


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

<img width="475" alt="image" src="https://github.com/daeuniverse/dae/assets/30586220/0379f3fa-5bf4-4c0c-9630-9237ee47e9f1">

This error doesn't matter, so it can be suppressed.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- Downgrade the log level of this error to `debug`.

