### PR TITLE
ci(trigger): separate pr_build from build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build (Stable)
 
 on:
   push:

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Get commit message
         run: |
-          echo "${{ github.event.head_commit.message }}"
+          echo "${{ github.event.workflow_run.head_commit.message }}"
 
       - name: Get the version
         id: get_version

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -1,9 +1,8 @@
-name: Build
+name: PR Build
 
 on:
-  push:
-    branches:
-      - main
+  pull_request:
+    types: [ opened, synchronize, reopened ]
     paths:
       - "**/*.go"
       - "**/*.c"
@@ -11,14 +10,13 @@ on:
       - "go.mod"
       - "go.sum"
       - ".github/workflows/build.yml"
-      - "Makefile"
 
 jobs:
   build:
     strategy:
       matrix:
         goos: [ linux ]
-        goarch: [ arm64, 386, riscv64, mips64, mips64le, mipsle, mips ]
+        goarch: [ arm64 ]
         include:
           # BEGIN Linux ARM 5 6 7
           - goos: linux
@@ -57,6 +55,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: Get commit message
+        run: |
+          echo "${{ ${{ github.event.head_commit.message }} }}"
 
       - name: Get the version
         id: get_version
@@ -137,3 +139,4 @@ jobs:
         with:
           name: dae-${{ steps.get_filename.outputs.ASSET_NAME }}.zip
           path: build/*
+

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -1,4 +1,5 @@
 name: PR Build (Preview)
+run-name:  ${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }} @${{ github.event.pull_request.head.sha }}
 
 on:
   pull_request:
@@ -56,9 +57,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get commit message
+      - name: Get event payload
         run: |
-          echo "${{ github.event.workflow_run.head_commit.message }}"
+          echo "${{ github.event.pull_request.number }}"
+          echo "${{ github.event.pull_request.title }}"
+          echo "${{ github.event.pull_request.head.sha }}"
+          echo "${{toJSON(github.event)}}"
 
       - name: Get the version
         id: get_version

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -1,5 +1,5 @@
 name: PR Build (Preview)
-run-name:  ${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }} @${{ github.event.pull_request.head.sha }}
+run-name:  "#${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }} @${{ github.event.pull_request.head.ref }}:${{ github.event.pull_request.head.sha }}"
 
 on:
   pull_request:
@@ -59,10 +59,7 @@ jobs:
 
       - name: Get event payload
         run: |
-          echo "${{ github.event.pull_request.number }}"
-          echo "${{ github.event.pull_request.title }}"
-          echo "${{ github.event.pull_request.head.sha }}"
-          echo "${{toJSON(github.event)}}"
+          echo "${{ toJSON(github.event) }}"
 
       - name: Get the version
         id: get_version

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -1,4 +1,4 @@
-name: PR Build
+name: PR Build (Preview)
 
 on:
   pull_request:

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -1,5 +1,5 @@
 name: PR Build (Preview)
-run-name:  "#${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }} @${{ github.event.pull_request.head.sha }}"
+run-name:  "#${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }} @${{ github.event.pull_request.head.ref }}:${{ github.event.pull_request.head.sha }}"
 
 on:
   pull_request:
@@ -16,9 +16,11 @@ jobs:
   context:
     runs-on: ubuntu-22.04
     steps:
-      - name: Show PR context
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
         run: |
-          echo '${{ github.event }}'
+          echo "$GITHUB_CONTEXT"
 
   build:
     strategy:

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Get commit message
         run: |
-          echo "${{ ${{ github.event.head_commit.message }} }}"
+          echo "${{ github.event.head_commit.message }}"
 
       - name: Get the version
         id: get_version

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -51,6 +51,7 @@ jobs:
       fail-fast: false
 
     runs-on: ubuntu-22.04
+    needs: [context]
     env:
       GOOS: ${{ matrix.goos }}
       GOARCH: ${{ matrix.goarch }}

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Show PR context
         run: |
-          echo '${{toJSON(github.event)}}'
+          echo '${{ github.event }}'
 
   build:
     strategy:

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -1,5 +1,5 @@
 name: PR Build (Preview)
-run-name:  "#${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }} @${{ github.event.pull_request.head.ref }}:${{ github.event.pull_request.head.sha }}"
+run-name:  "#${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }} @${{ github.event.pull_request.head.sha }}"
 
 on:
   pull_request:
@@ -13,6 +13,13 @@ on:
       - ".github/workflows/build.yml"
 
 jobs:
+  context:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Show PR context
+        run: |
+          echo '${{toJSON(github.event)}}'
+
   build:
     strategy:
       matrix:
@@ -56,10 +63,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
-      - name: Get event payload
-        run: |
-          echo "${{ toJSON(github.event) }}"
 
       - name: Get the version
         id: get_version

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 <img src="https://github.com/daeuniverse/dae/blob/main/logo.png" border="0" width="25%">
 
 <p align="left">
+    <img src="https://github.com/daeuniverse/dae/actions/workflows/build.yml/badge.svg" alt="Build"/>
     <img src="https://custom-icon-badges.herokuapp.com/github/license/daeuniverse/dae?logo=law&color=orange" alt="License"/>
     <img src="https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2Fdaeuniverse%2Fdae&count_bg=%235C3DC8&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=hits&edge_flat=false"/>
     <img src="https://custom-icon-badges.herokuapp.com/badge/version-v0.2.0rc4-blue.svg?logo=semanticrelease&logoColor=white" alt="version">


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

As part of the roadmap mentioned in #156, this PR includes proposed changes to separate `pr-based` events from the build workflow. As a result, the ONLY difference is the `trigger`. In order to move forward to achieving CI modularity, this PR is necessary.

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- docs(README): add build status badge
- ci(trigger): separate pr_build from build
- ci: add run_name followed by `#pr_number - pr_title @ pr_ref:pr_sha`
- ci: add initial job to show pr context
- ci: run `build` job after `context` job

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

As part of #156 

### Test Result

Ref: https://github.com/daeuniverse/dae/actions/runs/5494674099

<img width="947" alt="image" src="https://github.com/daeuniverse/dae/assets/31861128/8edb516f-c7ff-442e-92f6-5c507181e343">
