### PR TITLE
ci(daily-build): update cron schedule

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -13,8 +13,8 @@ name: Daily Build (Stable)
 
 on:
   schedule:
-    # At 00:00 (UTC+8) every day
-    - cron: "0 8 * * *"
+    # At (UTC+8 0:00 | UTC+0 16:00) every day
+    - cron: "0 16 * * *"
 
 jobs:
   pre-actions:


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

As the title suggests. Sets default cron trigger at `UTC+8 00:00AM`

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- ci(daily-build): update cron schedule

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

NA