### PR TITLE
ci(generate-changelogs): set dry_run as true

### DIFF
--- a/.github/workflows/generate-changelogs.yml
+++ b/.github/workflows/generate-changelogs.yml
@@ -13,7 +13,7 @@ on:
       write_to_issue:
         required: true
         description: export changelogs to an issue page
-        default: true
+        default: false
 
 jobs:
   build:


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Prevent writing changelogs to GitHub issues. The default value is set to `false`

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- ci(generate-changelogs): set dry_run as true

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

NA.
