### PR TITLE
fix: truncated dns resp

### DIFF
--- a/common/consts/net.go
+++ b/common/consts/net.go
@@ -1,0 +1,5 @@
+package consts
+
+const (
+	EthernetMtu = 1500
+)

--- a/control/dns_control.go
+++ b/control/dns_control.go
@@ -639,7 +639,7 @@ func (c *DnsController) dialSend(invokingDepth int, req *udpRequest, data []byte
 		}()
 
 		// We can block here because we are in a coroutine.
-		respBuf := pool.Get(512)
+		respBuf := pool.GetFullCap(consts.EthernetMtu)
 		defer pool.Put(respBuf)
 		for {
 			// Wait for response.

--- a/control/udp_endpoint.go
+++ b/control/udp_endpoint.go
@@ -11,13 +11,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/daeuniverse/dae/common/consts"
 	"github.com/daeuniverse/dae/component/outbound/dialer"
 	"github.com/mzz2017/softwind/netproxy"
 	"github.com/mzz2017/softwind/pool"
-)
-
-const (
-	EthernetMtu = 1500
 )
 
 type UdpHandler func(data []byte, from netip.AddrPort) error
@@ -34,8 +31,7 @@ type UdpEndpoint struct {
 }
 
 func (ue *UdpEndpoint) start() {
-	buf := pool.Get(EthernetMtu)
-	buf = buf[:cap(buf)]
+	buf := pool.GetFullCap(consts.EthernetMtu)
 	defer pool.Put(buf)
 	for {
 		n, from, err := ue.conn.ReadFrom(buf[:])

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/miekg/dns v1.1.55
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
-	github.com/mzz2017/softwind v0.0.0-20230708102709-26ff44839573
+	github.com/mzz2017/softwind v0.0.0-20230710142544-73a557cea4a4
 	github.com/okzk/sdnotify v0.0.0-20180710141335-d9becc38acbd
 	github.com/safchain/ethtool v0.3.0
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/mzz2017/disk-bloom v1.0.1 h1:rEF9MiXd9qMW3ibRpqcerLXULoTgRlM21yqqJl1B
 github.com/mzz2017/disk-bloom v1.0.1/go.mod h1:JLHETtUu44Z6iBmsqzkOtFlRvXSlKnxjwiBRDapizDI=
 github.com/mzz2017/quic-go v0.0.0-20230706143320-cc858d4932b7 h1:9zmZilN02x3byMB2X3x+B4iyKHkucv70WA4hsyZkjo8=
 github.com/mzz2017/quic-go v0.0.0-20230706143320-cc858d4932b7/go.mod h1:3H6d55CEofIWWr3gQThiB27+hA3WG5tATtPovzEYPAA=
-github.com/mzz2017/softwind v0.0.0-20230708102709-26ff44839573 h1:fDndoUP5FyJKZM0LJ9nqZJhZF9eLhgfG46xwxO4UHww=
-github.com/mzz2017/softwind v0.0.0-20230708102709-26ff44839573/go.mod h1:Fz8fgR7/dbnfR6RLpeOMkUDyebq4xShdmjj+cE5jnJ4=
+github.com/mzz2017/softwind v0.0.0-20230710142544-73a557cea4a4 h1:U6oSJf+dwVXpBZGi73l77igid+sOy4jgJucjSrfowFU=
+github.com/mzz2017/softwind v0.0.0-20230710142544-73a557cea4a4/go.mod h1:Fz8fgR7/dbnfR6RLpeOMkUDyebq4xShdmjj+cE5jnJ4=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

![image](https://github.com/daeuniverse/dae/assets/30586220/5c4f9cbc-b879-4677-98e5-ace4bd05a986)

If a DNS response is too big (greater than 512 Bytes), it would be truncated. So the `unpacking` would fail.

This PR enlarges the buffer size to 2048. Hope it is not expensive.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- Enlarge DNS response buffer to `2048`.
- Upgrade `softwind` to support `pool.GetFullCap`.

