### PR TITLE
fix/optimize/refactor(udp): fix potential stuck UDP and optimize reroute logic

### DIFF
--- a/common/consts/dialer.go
+++ b/common/consts/dialer.go
@@ -7,6 +7,7 @@ package consts
 
 import (
 	"net/netip"
+	"time"
 
 	"golang.org/x/sys/unix"
 )
@@ -23,6 +24,7 @@ const (
 
 const (
 	UdpCheckLookupHost = "connectivitycheck.gstatic.com."
+	DefaultDialTimeout = 8 * time.Second
 )
 
 type L4ProtoStr string

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -369,7 +369,6 @@ func NewControlPlane(
 		sniffingTimeout:   sniffingTimeout,
 		tproxyPortProtect: global.TproxyPortProtect,
 		soMarkFromDae:     global.SoMarkFromDae,
-		udpEndpointPool:   NewUdpEndpointPool(),
 	}
 	defer func() {
 		if err != nil {

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -48,8 +48,6 @@ type ControlPlane struct {
 	deferFuncs []func() error
 	listenIp   string
 
-	udpEndpointPool *UdpEndpointPool
-
 	// TODO: add mutex?
 	outbounds []*outbound.DialerGroup
 

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -48,6 +48,8 @@ type ControlPlane struct {
 	deferFuncs []func() error
 	listenIp   string
 
+	udpEndpointPool *UdpEndpointPool
+
 	// TODO: add mutex?
 	outbounds []*outbound.DialerGroup
 
@@ -369,6 +371,7 @@ func NewControlPlane(
 		sniffingTimeout:   sniffingTimeout,
 		tproxyPortProtect: global.TproxyPortProtect,
 		soMarkFromDae:     global.SoMarkFromDae,
+		udpEndpointPool:   NewUdpEndpointPool(),
 	}
 	defer func() {
 		if err != nil {

--- a/control/tcp.go
+++ b/control/tcp.go
@@ -6,6 +6,7 @@
 package control
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/netip"
@@ -185,8 +186,12 @@ func (c *ControlPlane) RouteDialTcp(p *RouteDialParam) (conn netproxy.Conn, err 
 			"mac":      Mac2String(routingResult.Mac[:]),
 		}).Infof("%v <-> %v", RefineSourceToShow(src, dst.Addr(), consts.LanWanFlag_NotApplicable), dialTarget)
 	}
-
-	return d.Dial(common.MagicNetwork("tcp", routingResult.Mark), dialTarget)
+	ctx, cancel := context.WithTimeout(context.TODO(), consts.DefaultDialTimeout)
+	defer cancel()
+	cd := netproxy.ContextDialer{
+		Dialer: d,
+	}
+	return cd.DialContext(ctx, common.MagicNetwork("tcp", routingResult.Mark), dialTarget)
 }
 
 type WriteCloser interface {

--- a/control/udp.go
+++ b/control/udp.go
@@ -193,7 +193,7 @@ getNew:
 		}).Warnln("Touch max retry limit.")
 		return fmt.Errorf("touch max retry limit")
 	}
-	ue, isNew, err := c.udpEndpointPool.GetOrCreate(realSrc, &UdpEndpointOptions{
+	ue, isNew, err := DefaultUdpEndpointPool.GetOrCreate(realSrc, &UdpEndpointOptions{
 		// Handler handles response packets and send it to the client.
 		Handler: func(data []byte, from netip.AddrPort) (err error) {
 			// Do not return conn-unrelated err in this func.

--- a/control/udp.go
+++ b/control/udp.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/daeuniverse/dae/common"
 	"github.com/daeuniverse/dae/common/consts"
+	ob "github.com/daeuniverse/dae/component/outbound"
 	"github.com/daeuniverse/dae/component/outbound/dialer"
 	"github.com/daeuniverse/dae/component/sniffing"
 	internal "github.com/daeuniverse/dae/pkg/ebpf_internal"
@@ -30,6 +31,12 @@ const (
 	DnsNatTimeout     = 17 * time.Second // RFC 5452
 	MaxRetry          = 2
 )
+
+type DialOption struct {
+	Target   string
+	Dialer   *dialer.Dialer
+	Outbound *ob.DialerGroup
+}
 
 func ChooseNatTimeout(data []byte, sniffDns bool) (dmsg *dnsmessage.Msg, timeout time.Duration) {
 	if sniffDns {
@@ -139,42 +146,8 @@ func (c *ControlPlane) handlePkt(lConn *net.UDPConn, data []byte, src, pktDst, r
 			return err
 		}
 	}
-
-	// Get outbound.
-	outboundIndex := consts.OutboundIndex(routingResult.Outbound)
-	if c.dialMode == consts.DialMode_DomainCao && domain != "" {
-		outboundIndex = consts.OutboundControlPlaneRouting
-	}
-
-	dialTarget, shouldReroute, dialIp := c.ChooseDialTarget(outboundIndex, realDst, domain)
-	if shouldReroute {
-		outboundIndex = consts.OutboundControlPlaneRouting
-	}
-
 	if routingResult.Must > 0 {
 		isDns = false // Regard as plain traffic.
-	}
-	switch outboundIndex {
-	case consts.OutboundDirect:
-	case consts.OutboundControlPlaneRouting:
-		if isDns {
-			// Routing of DNS packets are managed by DNS controller.
-			break
-		}
-
-		if outboundIndex, routingResult.Mark, _, err = c.Route(realSrc, realDst, domain, consts.L4ProtoType_TCP, routingResult); err != nil {
-			return err
-		}
-		routingResult.Outbound = uint8(outboundIndex)
-		if c.log.IsLevelEnabled(logrus.TraceLevel) {
-			c.log.Tracef("outbound: %v => %v",
-				consts.OutboundControlPlaneRouting.String(),
-				outboundIndex.String(),
-			)
-		}
-		// Reset dialTarget.
-		dialTarget, _, dialIp = c.ChooseDialTarget(outboundIndex, realDst, domain)
-	default:
 	}
 	if routingResult.Mark == 0 {
 		routingResult.Mark = c.soMarkFromDae
@@ -190,23 +163,6 @@ func (c *ControlPlane) handlePkt(lConn *net.UDPConn, data []byte, src, pktDst, r
 		})
 	}
 
-	if int(outboundIndex) >= len(c.outbounds) {
-		return fmt.Errorf("outbound %v out of range [0, %v]", outboundIndex, len(c.outbounds)-1)
-	}
-	outbound := c.outbounds[outboundIndex]
-
-	// Select dialer from outbound (dialer group).
-	networkType := &dialer.NetworkType{
-		L4Proto:   consts.L4ProtoStr_UDP,
-		IpVersion: consts.IpVersionFromAddr(realDst.Addr()),
-		IsDns:     true, // UDP relies on DNS check result.
-	}
-	strictIpVersion := dialIp
-	dialerForNew, _, err := outbound.Select(networkType, strictIpVersion)
-	if err != nil {
-		return fmt.Errorf("failed to select dialer from group %v (%v, dns?:%v,from: %v): %w", outbound.Name, networkType.StringWithoutDns(), isDns, realSrc.String(), err)
-	}
-
 	// Dial and send.
 	// TODO: Rewritten domain should not use full-cone (such as VMess Packet Addr).
 	// 		Maybe we should set up a mapping for UDP: Dialer + Target Domain => Remote Resolved IP.
@@ -215,6 +171,17 @@ func (c *ControlPlane) handlePkt(lConn *net.UDPConn, data []byte, src, pktDst, r
 	// Get udp endpoint.
 	var ue *UdpEndpoint
 	retry := 0
+	networkType := &dialer.NetworkType{
+		L4Proto:   consts.L4ProtoStr_UDP,
+		IpVersion: consts.IpVersionFromAddr(realDst.Addr()),
+		IsDns:     true, // UDP relies on DNS check result.
+	}
+	// Get outbound.
+	outboundIndex := consts.OutboundIndex(routingResult.Outbound)
+	if c.dialMode == consts.DialMode_DomainCao && domain != "" {
+		outboundIndex = consts.OutboundControlPlaneRouting
+	}
+	dialTarget, shouldReroute, dialIp := c.ChooseDialTarget(outboundIndex, realDst, domain)
 getNew:
 	if retry > MaxRetry {
 		c.log.WithFields(logrus.Fields{
@@ -232,16 +199,59 @@ getNew:
 			return sendPkt(data, from, realSrc, src, lConn, lanWanFlag)
 		},
 		NatTimeout: natTimeout,
-		Dialer:     dialerForNew,
 		Network:    common.MagicNetwork("udp", routingResult.Mark),
-		Target:     dialTarget,
+		GetDialOption: func() (option *DialOption, err error) {
+			if shouldReroute {
+				outboundIndex = consts.OutboundControlPlaneRouting
+			}
+
+			switch outboundIndex {
+			case consts.OutboundDirect:
+			case consts.OutboundControlPlaneRouting:
+				if isDns {
+					// Routing of DNS packets are managed by DNS controller.
+					break
+				}
+
+				if outboundIndex, routingResult.Mark, _, err = c.Route(realSrc, realDst, domain, consts.L4ProtoType_TCP, routingResult); err != nil {
+					return nil, err
+				}
+				routingResult.Outbound = uint8(outboundIndex)
+				if c.log.IsLevelEnabled(logrus.TraceLevel) {
+					c.log.Tracef("outbound: %v => %v",
+						consts.OutboundControlPlaneRouting.String(),
+						outboundIndex.String(),
+					)
+				}
+				// Reset dialTarget.
+				dialTarget, _, dialIp = c.ChooseDialTarget(outboundIndex, realDst, domain)
+			default:
+			}
+
+			if int(outboundIndex) >= len(c.outbounds) {
+				return nil, fmt.Errorf("outbound %v out of range [0, %v]", outboundIndex, len(c.outbounds)-1)
+			}
+			outbound := c.outbounds[outboundIndex]
+
+			// Select dialer from outbound (dialer group).
+			strictIpVersion := dialIp
+			dialerForNew, _, err := outbound.Select(networkType, strictIpVersion)
+			if err != nil {
+				return nil, fmt.Errorf("failed to select dialer from group %v (%v, dns?:%v,from: %v): %w", outbound.Name, networkType.StringWithoutDns(), isDns, realSrc.String(), err)
+			}
+			return &DialOption{
+				Target:   dialTarget,
+				Dialer:   dialerForNew,
+				Outbound: outbound,
+			}, nil
+		},
 	})
 	if err != nil {
-		return fmt.Errorf("failed to GetOrCreate (policy: %v): %w", outbound.GetSelectionPolicy(), err)
+		return fmt.Errorf("failed to GetOrCreate: %w", err)
 	}
 
 	// If the udp endpoint has been not alive, remove it from pool and get a new one.
-	if !isNew && outbound.GetSelectionPolicy() != consts.DialerSelectionPolicy_Fixed && !ue.Dialer.MustGetAlive(networkType) {
+	if !isNew && ue.Outbound.GetSelectionPolicy() != consts.DialerSelectionPolicy_Fixed && !ue.Dialer.MustGetAlive(networkType) {
 
 		if c.log.IsLevelEnabled(logrus.DebugLevel) {
 			c.log.WithFields(logrus.Fields{
@@ -282,8 +292,8 @@ getNew:
 		if c.log.IsLevelEnabled(logrus.InfoLevel) {
 			fields := logrus.Fields{
 				"network":  networkType.StringWithoutDns(),
-				"outbound": outbound.Name,
-				"policy":   outbound.GetSelectionPolicy(),
+				"outbound": ue.Outbound.Name,
+				"policy":   ue.Outbound.GetSelectionPolicy(),
 				"dialer":   ue.Dialer.Property().Name,
 				"domain":   domain,
 				"ip":       RefineAddrPortToShow(realDst),

--- a/control/udp_endpoint.go
+++ b/control/udp_endpoint.go
@@ -6,11 +6,13 @@
 package control
 
 import (
+	"context"
 	"fmt"
 	"net/netip"
 	"sync"
 	"time"
 
+	"github.com/daeuniverse/dae/common/consts"
 	"github.com/daeuniverse/dae/component/outbound"
 	"github.com/daeuniverse/dae/component/outbound/dialer"
 	"github.com/mzz2017/softwind/netproxy"
@@ -71,14 +73,12 @@ func (ue *UdpEndpoint) Close() error {
 
 // UdpEndpointPool is a full-cone udp conn pool
 type UdpEndpointPool struct {
-	pool map[netip.AddrPort]*UdpEndpoint
-	mu   sync.Mutex
+	pool        sync.Map
+	createMuMap sync.Map
 }
 type UdpEndpointOptions struct {
 	Handler    UdpHandler
 	NatTimeout time.Duration
-	// Network is useful for MagicNetwork
-	Network string
 	// GetTarget is useful only if the underlay does not support Full-cone.
 	GetDialOption func() (option *DialOption, err error)
 }
@@ -86,30 +86,31 @@ type UdpEndpointOptions struct {
 var DefaultUdpEndpointPool = NewUdpEndpointPool()
 
 func NewUdpEndpointPool() *UdpEndpointPool {
-	return &UdpEndpointPool{
-		pool: make(map[netip.AddrPort]*UdpEndpoint),
-	}
+	return &UdpEndpointPool{}
 }
 
 func (p *UdpEndpointPool) Remove(lAddr netip.AddrPort, udpEndpoint *UdpEndpoint) (err error) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	if ue, ok := p.pool[lAddr]; ok {
+	if ue, ok := p.pool.LoadAndDelete(lAddr); ok {
 		if ue != udpEndpoint {
 			return fmt.Errorf("target udp endpoint is not in the pool")
 		}
-		ue.Close()
-		delete(p.pool, lAddr)
+		ue.(*UdpEndpoint).Close()
 	}
 	return nil
 }
 
 func (p *UdpEndpointPool) GetOrCreate(lAddr netip.AddrPort, createOption *UdpEndpointOptions) (udpEndpoint *UdpEndpoint, isNew bool, err error) {
-	// TODO: fine-grained lock.
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	ue, ok := p.pool[lAddr]
+	_ue, ok := p.pool.Load(lAddr)
+begin:
 	if !ok {
+		createMu, _ := p.createMuMap.LoadOrStore(lAddr, &sync.Mutex{})
+		createMu.(*sync.Mutex).Lock()
+		defer createMu.(*sync.Mutex).Unlock()
+		defer p.createMuMap.Delete(lAddr)
+		_ue, ok = p.pool.Load(lAddr)
+		if ok {
+			goto begin
+		}
 		// Create an UdpEndpoint.
 		if createOption == nil {
 			createOption = &UdpEndpointOptions{}
@@ -125,21 +126,23 @@ func (p *UdpEndpointPool) GetOrCreate(lAddr netip.AddrPort, createOption *UdpEnd
 		if err != nil {
 			return nil, false, err
 		}
-		udpConn, err := dialOption.Dialer.Dial(createOption.Network, dialOption.Target)
+		cd := netproxy.ContextDialer{
+			Dialer: dialOption.Dialer,
+		}
+		ctx, cancel := context.WithTimeout(context.TODO(), consts.DefaultDialTimeout)
+		defer cancel()
+		udpConn, err := cd.DialContext(ctx, dialOption.Network, dialOption.Target)
 		if err != nil {
 			return nil, true, err
 		}
 		if _, ok = udpConn.(netproxy.PacketConn); !ok {
 			return nil, true, fmt.Errorf("protocol does not support udp")
 		}
-		ue = &UdpEndpoint{
+		ue := &UdpEndpoint{
 			conn: udpConn.(netproxy.PacketConn),
 			deadlineTimer: time.AfterFunc(createOption.NatTimeout, func() {
-				p.mu.Lock()
-				defer p.mu.Unlock()
-				if ue, ok := p.pool[lAddr]; ok {
-					ue.Close()
-					delete(p.pool, lAddr)
+				if ue, ok := p.pool.LoadAndDelete(lAddr); ok {
+					ue.(*UdpEndpoint).Close()
 				}
 			}),
 			handler:    createOption.Handler,
@@ -147,15 +150,17 @@ func (p *UdpEndpointPool) GetOrCreate(lAddr netip.AddrPort, createOption *UdpEnd
 			Dialer:     dialOption.Dialer,
 			Outbound:   dialOption.Outbound,
 		}
-		p.pool[lAddr] = ue
+		_ue = ue
+		p.pool.Store(lAddr, ue)
 		// Receive UDP messages.
 		go ue.start()
 		isNew = true
 	} else {
+		ue := _ue.(*UdpEndpoint)
 		// Postpone the deadline.
 		ue.mu.Lock()
 		ue.deadlineTimer.Reset(ue.NatTimeout)
 		ue.mu.Unlock()
 	}
-	return ue, isNew, nil
+	return _ue.(*UdpEndpoint), isNew, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/miekg/dns v1.1.55
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
-	github.com/mzz2017/softwind v0.0.0-20230708102709-26ff44839573
+	github.com/mzz2017/softwind v0.0.0-20230710174933-ee56db43b74f
 	github.com/okzk/sdnotify v0.0.0-20180710141335-d9becc38acbd
 	github.com/safchain/ethtool v0.3.0
 	github.com/sirupsen/logrus v1.9.3

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/miekg/dns v1.1.55
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
-	github.com/mzz2017/softwind v0.0.0-20230710174933-ee56db43b74f
+	github.com/mzz2017/softwind v0.0.0-20230710175107-0107af8a1d26
 	github.com/okzk/sdnotify v0.0.0-20180710141335-d9becc38acbd
 	github.com/safchain/ethtool v0.3.0
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/mzz2017/disk-bloom v1.0.1 h1:rEF9MiXd9qMW3ibRpqcerLXULoTgRlM21yqqJl1B
 github.com/mzz2017/disk-bloom v1.0.1/go.mod h1:JLHETtUu44Z6iBmsqzkOtFlRvXSlKnxjwiBRDapizDI=
 github.com/mzz2017/quic-go v0.0.0-20230706143320-cc858d4932b7 h1:9zmZilN02x3byMB2X3x+B4iyKHkucv70WA4hsyZkjo8=
 github.com/mzz2017/quic-go v0.0.0-20230706143320-cc858d4932b7/go.mod h1:3H6d55CEofIWWr3gQThiB27+hA3WG5tATtPovzEYPAA=
-github.com/mzz2017/softwind v0.0.0-20230708102709-26ff44839573 h1:fDndoUP5FyJKZM0LJ9nqZJhZF9eLhgfG46xwxO4UHww=
-github.com/mzz2017/softwind v0.0.0-20230708102709-26ff44839573/go.mod h1:Fz8fgR7/dbnfR6RLpeOMkUDyebq4xShdmjj+cE5jnJ4=
+github.com/mzz2017/softwind v0.0.0-20230710174933-ee56db43b74f h1:DayKJ8qyjUBZpqv+aIrV5ebQwOYjwMvTaKTl6sUgh7Y=
+github.com/mzz2017/softwind v0.0.0-20230710174933-ee56db43b74f/go.mod h1:Fz8fgR7/dbnfR6RLpeOMkUDyebq4xShdmjj+cE5jnJ4=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/mzz2017/disk-bloom v1.0.1 h1:rEF9MiXd9qMW3ibRpqcerLXULoTgRlM21yqqJl1B
 github.com/mzz2017/disk-bloom v1.0.1/go.mod h1:JLHETtUu44Z6iBmsqzkOtFlRvXSlKnxjwiBRDapizDI=
 github.com/mzz2017/quic-go v0.0.0-20230706143320-cc858d4932b7 h1:9zmZilN02x3byMB2X3x+B4iyKHkucv70WA4hsyZkjo8=
 github.com/mzz2017/quic-go v0.0.0-20230706143320-cc858d4932b7/go.mod h1:3H6d55CEofIWWr3gQThiB27+hA3WG5tATtPovzEYPAA=
-github.com/mzz2017/softwind v0.0.0-20230710174933-ee56db43b74f h1:DayKJ8qyjUBZpqv+aIrV5ebQwOYjwMvTaKTl6sUgh7Y=
-github.com/mzz2017/softwind v0.0.0-20230710174933-ee56db43b74f/go.mod h1:Fz8fgR7/dbnfR6RLpeOMkUDyebq4xShdmjj+cE5jnJ4=
+github.com/mzz2017/softwind v0.0.0-20230710175107-0107af8a1d26 h1:kVjALMAhr+rYw77TfrpD8VNIRbZ2/2pN1AYWBcL6eqM=
+github.com/mzz2017/softwind v0.0.0-20230710175107-0107af8a1d26/go.mod h1:Fz8fgR7/dbnfR6RLpeOMkUDyebq4xShdmjj+cE5jnJ4=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

#### Fix

The stuck UDP dialing would block all other UDP dialing. This causes UDP to fail to work. This PR fixes it.

Range:

1. This problem impacts all previous versions.
2. This problem only impacts UDP except DNS.

#### Optimize

`domain++` may reroute every UDP packet, which may consume many resources and result in unexpected results.

This PR optimizes it. If a UDP connection has already been established, we shouldn't reroute it (find another outbound/dialer) while we should reuse the dialer to write a request.

### Changelogs

- Force to give 8s timeout for TCP/UDP dialers.
- Use fine-grained lock for UDP.
- Only re-route for the new UDP connection.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOG
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

