### PR TITLE
ci(pr-build): use pr.head.sha as default ref

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -33,6 +33,6 @@ jobs:
     secrets: inherit
 
   build:
-    uses: daeuniverse/dae/.github/workflows/seed-build.yml@main
+    uses: daeuniverse/dae/.github/workflows/seed-build.yml@pr_build_fix
     with:
       ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -36,3 +36,4 @@ jobs:
     uses: daeuniverse/dae/.github/workflows/seed-build.yml@pr_build_fix
     with:
       ref: ${{ github.event.pull_request.head.sha }}
+      pr_build: true

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -35,4 +35,4 @@ jobs:
   build:
     uses: daeuniverse/dae/.github/workflows/seed-build.yml@main
     with:
-      sha: ${{ github.event.pull_request.head.sha }}
+      ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -34,3 +34,5 @@ jobs:
 
   build:
     uses: daeuniverse/dae/.github/workflows/seed-build.yml@main
+    with:
+      sha: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -37,3 +37,4 @@ jobs:
     with:
       ref: ${{ github.event.pull_request.head.sha }}
       pr_build: true
+      pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/seed-build.yml
+++ b/.github/workflows/seed-build.yml
@@ -72,7 +72,7 @@ jobs:
           REF: ${{ inputs.ref }}
         run: |
           date=$(git log -1 --format="%cd" --date=short | sed s/-//g)
-          if [ "${{ inputs.pr_build }}" = "true" ]; then
+          if [[ "${{ inputs.pr_build }}" == "true" ]]; then
             count=$(git rev-list --count HEAD)
             commit=$(git rev-parse --short origin..${REF})
           else

--- a/.github/workflows/seed-build.yml
+++ b/.github/workflows/seed-build.yml
@@ -72,12 +72,11 @@ jobs:
           REF: ${{ inputs.ref }}
         run: |
           date=$(git log -1 --format="%cd" --date=short | sed s/-//g)
+          commit=$(echo ${{ inputs.ref }} | cut -c1-6)
           if [[ "${{ inputs.pr_build }}" == "true" ]]; then
             count=$(git rev-list --count HEAD)
-            commit=$(git rev-parse --short origin..${REF})
           else
             count=$(git rev-list --count HEAD)
-            commit=$(git rev-parse --short HEAD)
           fi
           version="unstable-$date.r${count}.$commit"
           echo "VERSION=${version}" >> $GITHUB_OUTPUT

--- a/.github/workflows/seed-build.yml
+++ b/.github/workflows/seed-build.yml
@@ -71,7 +71,7 @@ jobs:
         env:
           REF: ${{ inputs.ref }}
         run: |
-          if [[ "${{ inputs.pr_build }}" ]]; then
+          if [ "${{ inputs.pr_build }}" -lt "true" ]; then
             date=$(git log -1 --format="%cd" --date=short | sed s/-//g)
             count=$(git rev-list --count HEAD)
             commit=$(git rev-parse --short origin..$REF)

--- a/.github/workflows/seed-build.yml
+++ b/.github/workflows/seed-build.yml
@@ -16,10 +16,15 @@ on:
     inputs:
       ref:
         type: string
+        required: true
         default: ${{ github.ref }}
       pr_build:
         type: boolean
+        required: false
         default: false
+      pr_number:
+        type: number
+        required: false
 
 jobs:
   build:
@@ -70,6 +75,7 @@ jobs:
         id: get_version
         env:
           REF: ${{ inputs.ref }}
+          PR: pr-${{ inputs.pr_number }}
         run: |
           date=$(git log -1 --format="%cd" --date=short | sed s/-//g)
           commit=$(echo ${{ inputs.ref }} | cut -c1-6)
@@ -78,7 +84,7 @@ jobs:
           else
             count=$(git rev-list --count HEAD)
           fi
-          version="unstable-$date.r${count}.$commit"
+          version="unstable-${date}.${PR}.r${count}.${commit}"
           echo "VERSION=${version}" >> $GITHUB_OUTPUT
           echo "VERSION=${version}" >> $GITHUB_ENV
 

--- a/.github/workflows/seed-build.yml
+++ b/.github/workflows/seed-build.yml
@@ -71,12 +71,11 @@ jobs:
         env:
           REF: ${{ inputs.ref }}
         run: |
-          if [ "${{ inputs.pr_build }}" -lt "true" ]; then
-            date=$(git log -1 --format="%cd" --date=short | sed s/-//g)
+          date=$(git log -1 --format="%cd" --date=short | sed s/-//g)
+          if [ "${{ inputs.pr_build }}" = "true" ]; then
             count=$(git rev-list --count HEAD)
             commit=$(git rev-parse --short origin..$REF)
           else
-            date=$(git log -1 --format="%cd" --date=short | sed s/-//g)
             count=$(git rev-list --count HEAD)
             commit=$(git rev-parse --short HEAD)
           fi

--- a/.github/workflows/seed-build.yml
+++ b/.github/workflows/seed-build.yml
@@ -78,7 +78,7 @@ jobs:
           PR: pr-${{ inputs.pr_number }}
         run: |
           date=$(git log -1 --format="%cd" --date=short | sed s/-//g)
-          commit=$(echo ${{ inputs.ref }} | cut -c1-6)
+          commit=$(echo ${REF} | cut -c1-6)
           if [[ "${{ inputs.pr_build }}" == "true" ]]; then
             count=$(git rev-list --count origin/main..HEAD)
           else

--- a/.github/workflows/seed-build.yml
+++ b/.github/workflows/seed-build.yml
@@ -74,7 +74,7 @@ jobs:
           date=$(git log -1 --format="%cd" --date=short | sed s/-//g)
           commit=$(echo ${{ inputs.ref }} | cut -c1-6)
           if [[ "${{ inputs.pr_build }}" == "true" ]]; then
-            count=$(git rev-list --count origin..HEAD)
+            count=$(git rev-list --count origin/main..HEAD)
           else
             count=$(git rev-list --count HEAD)
           fi

--- a/.github/workflows/seed-build.yml
+++ b/.github/workflows/seed-build.yml
@@ -13,6 +13,10 @@ name: Build
 
 on:
   workflow_call:
+    inputs:
+      ref:
+        type: string
+        default: ${{ github.ref }}
 
 jobs:
   build:
@@ -62,7 +66,7 @@ jobs:
       - name: Get the version
         id: get_version
         env:
-          REF: ${{ github.ref }}
+          REF: ${{ inputs.ref }}
         run: |
           if [[ "$REF" == "refs/tags/v"* ]]; then
             tag=$(git describe --tags $(git rev-list --tags --max-count=1))

--- a/.github/workflows/seed-build.yml
+++ b/.github/workflows/seed-build.yml
@@ -74,7 +74,7 @@ jobs:
           date=$(git log -1 --format="%cd" --date=short | sed s/-//g)
           commit=$(echo ${{ inputs.ref }} | cut -c1-6)
           if [[ "${{ inputs.pr_build }}" == "true" ]]; then
-            count=$(git rev-list --count origin..${REF})
+            count=$(git rev-list --count origin..HEAD)
           else
             count=$(git rev-list --count HEAD)
           fi

--- a/.github/workflows/seed-build.yml
+++ b/.github/workflows/seed-build.yml
@@ -71,7 +71,7 @@ jobs:
         env:
           REF: ${{ inputs.ref }}
         run: |
-          if [[ "${{ inputs.pr_build == 'true' }}" ]]; then
+          if [[ "${{ inputs.pr_build }}" ]]; then
             date=$(git log -1 --format="%cd" --date=short | sed s/-//g)
             count=$(git rev-list --count HEAD)
             commit=$(git rev-parse --short origin..$REF)

--- a/.github/workflows/seed-build.yml
+++ b/.github/workflows/seed-build.yml
@@ -74,7 +74,7 @@ jobs:
           date=$(git log -1 --format="%cd" --date=short | sed s/-//g)
           commit=$(echo ${{ inputs.ref }} | cut -c1-6)
           if [[ "${{ inputs.pr_build }}" == "true" ]]; then
-            count=$(git rev-list --count HEAD)
+            count=$(git rev-list --count origin..${REF})
           else
             count=$(git rev-list --count HEAD)
           fi

--- a/.github/workflows/seed-build.yml
+++ b/.github/workflows/seed-build.yml
@@ -74,14 +74,14 @@ jobs:
           date=$(git log -1 --format="%cd" --date=short | sed s/-//g)
           if [ "${{ inputs.pr_build }}" = "true" ]; then
             count=$(git rev-list --count HEAD)
-            commit=$(git rev-parse --short origin..$REF)
+            commit=$(git rev-parse --short origin..${REF})
           else
             count=$(git rev-list --count HEAD)
             commit=$(git rev-parse --short HEAD)
           fi
           version="unstable-$date.r${count}.$commit"
-          echo "VERSION=$version" >> $GITHUB_OUTPUT
-          echo "VERSION=$version" >> $GITHUB_ENV
+          echo "VERSION=${version}" >> $GITHUB_OUTPUT
+          echo "VERSION=${version}" >> $GITHUB_ENV
 
       - name: Show workflow information
         id: get_filename

--- a/.github/workflows/seed-build.yml
+++ b/.github/workflows/seed-build.yml
@@ -17,6 +17,9 @@ on:
       ref:
         type: string
         default: ${{ github.ref }}
+      pr_build:
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -68,15 +71,16 @@ jobs:
         env:
           REF: ${{ inputs.ref }}
         run: |
-          if [[ "$REF" == "refs/tags/v"* ]]; then
-            tag=$(git describe --tags $(git rev-list --tags --max-count=1))
-            version=${tag}
+          if [[ "${{ inputs.pr_build == 'true' }}" ]]; then
+            date=$(git log -1 --format="%cd" --date=short | sed s/-//g)
+            count=$(git rev-list --count HEAD)
+            commit=$(git rev-parse --short origin..$REF)
           else
             date=$(git log -1 --format="%cd" --date=short | sed s/-//g)
             count=$(git rev-list --count HEAD)
             commit=$(git rev-parse --short HEAD)
-            version="unstable-$date.r${count}.$commit"
           fi
+          version="unstable-$date.r${count}.$commit"
           echo "VERSION=$version" >> $GITHUB_OUTPUT
           echo "VERSION=$version" >> $GITHUB_ENV
 


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Currently, the version of artifact binaries in `pr-build` does NOT align with the latest `head sha`. This PR refactors the `seed-build` workflow and passes `ref` as inputs to the build process. In such a way, we may input ref precisely according to different scenarios.

Build (Main) uses `${{ github.ref }}`

PR Build (Preview) uses `${{ github.event.pull_request.head.sha }}`

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- ci(pr-build): use pr.head.sha instead of github.sha
- ci(seed-build): add ref as input; default is github.ref
- ci(pr-build): use ref instead of sha as input
- ci(seed-build): add pr_build inputs to differentiate type
- fix: rework commit sha parser
- ci(seed-build): add pr_number input

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

NA

### Test Result

<!--- Attach test result here. -->

https://github.com/daeuniverse/dae/actions/runs/5538510193/jobs/10108524157

<img width="879" alt="image" src="https://github.com/daeuniverse/dae/assets/31861128/ac165ba1-b20c-4e6b-b8a8-bdf77c5b3d6f">

<img width="726" alt="image" src="https://github.com/daeuniverse/dae/assets/31861128/1fc1436b-4452-4cd1-b76a-4e80ad7c6b1a">
