### PR TITLE
ci(pr-build): don't trigger workflow for draft PRs

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -26,6 +26,7 @@ on:
 
 jobs:
   pre-actions:
+    if: ${{ github.event.pull_request.draft == false }}
     uses: daeuniverse/ci-seed-jobs/.github/workflows/pre-actions.yml@master
     with:
       repository: ${{ github.repository }}
@@ -34,6 +35,7 @@ jobs:
     secrets: inherit
 
   build:
+    if: ${{ github.event.pull_request.draft == false }}
     uses: daeuniverse/dae/.github/workflows/seed-build.yml@main
     with:
       ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Do not trigger pr-build workflow for draft PRs

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- ci(pr-build): don't trigger workflow for draft PRs

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

NA

### Test Result

<!--- Attach test result here. -->

<img width="1485" alt="CleanShot 2023-07-14 at 11 40 35@2x" src="https://github.com/daeuniverse/dae/assets/31861128/64557f7d-26bf-4312-912b-c0abbf349e06">

<img width="1171" alt="CleanShot 2023-07-14 at 11 41 18@2x" src="https://github.com/daeuniverse/dae/assets/31861128/bb163d9e-a379-4c54-8c2f-16f22b807f20">

