### PR TITLE
fix: support to bind dae to wg lan (and other tun)

### DIFF
--- a/common/consts/ebpf.go
+++ b/common/consts/ebpf.go
@@ -168,3 +168,8 @@ const (
 	LanWanFlag_IsLan
 	LanWanFlag_NotApplicable
 )
+
+const (
+	LinkType_None uint32 = iota
+	LinkType_Ethernet
+)

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -192,6 +192,7 @@ func NewControlPlane(
 	// Add clsact qdisc
 	for _, ifname := range common.Deduplicate(append(append([]string{}, global.LanInterface...), global.WanInterface...)) {
 		_ = core.addQdisc(ifname)
+		_ = core.mapLinkType(ifname)
 	}
 	// Bind to LAN
 	if len(global.LanInterface) > 0 {

--- a/control/control_plane_core.go
+++ b/control/control_plane_core.go
@@ -135,6 +135,22 @@ func getIfParamsFromLink(link netlink.Link) (ifParams bpfIfParams, err error) {
 	return ifParams, nil
 }
 
+func (c *controlPlaneCore) mapLinkType(ifname string) error {
+	link, err := netlink.LinkByName(ifname)
+	if err != nil {
+		return err
+	}
+	linkType := uint32(0xffff)
+	switch link.Attrs().EncapType {
+	case "none":
+		linkType = consts.LinkType_None
+	case "ether":
+		linkType = consts.LinkType_Ethernet
+	default:
+	}
+	return c.bpf.bpfMaps.LinktypeMap.Update(uint32(link.Attrs().Index), linkType, ebpf.UpdateAny)
+}
+
 func (c *controlPlaneCore) addQdisc(ifname string) error {
 	link, err := netlink.LinkByName(ifname)
 	if err != nil {


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

When using the dae's bind-lan functionality, the binding fails to work properly when attempting to bind a WireGuard interface. As a result, the traffic from the WireGuard interface is not being routed through the dae proxy.

See more #191.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- Support to check link type before binding to it.
- Support link type `none`.
- Refine `ebpf` code.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #191.

