### PR TITLE
ci(pr-build): add pr.ready_for_review trigger

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -14,7 +14,7 @@ run-name:  "#${{ github.event.pull_request.number }} - ${{ github.event.pull_req
 
 on:
   pull_request:
-    types: [ opened, synchronize, reopened ]
+    types: [ opened, synchronize, reopened, ready_for_review ]
     paths:
       - "**/*.go"
       - "**/*.c"


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Add `pr.ready_for_review` trigger in `PR Build (Preview)`. It should trigger PR build when a drafted PR converts to `ready for review` state.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- ci(pr-build): add pr.ready_for_review trigger

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

NA

### Test Result

<!--- Attach test result here. -->

NA