### PR TITLE
feat(vmess/vless): support network h2

### DIFF
--- a/component/outbound/dialer/v2ray/v2ray.go
+++ b/component/outbound/dialer/v2ray/v2ray.go
@@ -156,7 +156,11 @@ func (s *V2Ray) Dialer(option *dialer.GlobalOption, iOption dialer.InstanceOptio
 			Host:   net.JoinHostPort(s.Add, s.Port),
 		}
 		if s.SNI != "" {
-			u.RawQuery = url.Values{"sni": []string{sni}, "allowInsecure": []string{common.BoolToString(s.AllowInsecure)}}.Encode()
+			u.RawQuery = url.Values{
+				"sni":           []string{sni},
+				"allowInsecure": []string{common.BoolToString(s.AllowInsecure)},
+				"utlsImitate":   []string{option.UtlsImitate},
+			}.Encode()
 		}
 		d, err = http.NewHTTPProxy(&u, direct.SymmetricDirect)
 		if err != nil {

--- a/component/outbound/dialer/v2ray/v2ray.go
+++ b/component/outbound/dialer/v2ray/v2ray.go
@@ -145,7 +145,7 @@ func (s *V2Ray) Dialer(option *dialer.GlobalOption, iOption dialer.InstanceOptio
 	case "http", "http2", "h2":
 		sni := s.SNI
 		if sni == "" {
-			sni = s.Host
+			sni = s.Add
 		}
 		scheme := "http"
 		if s.TLS == "tls" {
@@ -154,13 +154,16 @@ func (s *V2Ray) Dialer(option *dialer.GlobalOption, iOption dialer.InstanceOptio
 		u := url.URL{
 			Scheme: scheme,
 			Host:   net.JoinHostPort(s.Add, s.Port),
-		}
-		if s.SNI != "" {
-			u.RawQuery = url.Values{
-				"sni":           []string{sni},
-				"allowInsecure": []string{common.BoolToString(s.AllowInsecure)},
-				"utlsImitate":   []string{option.UtlsImitate},
-			}.Encode()
+			Path:   s.Path,
+			RawQuery: url.Values{
+				"sni":               []string{sni},
+				"allowInsecure":     []string{common.BoolToString(s.AllowInsecure)},
+				"tlsImplementation": []string{option.TlsImplementation},
+				"utlsImitate":       []string{option.UtlsImitate},
+				"host":              []string{s.Host},
+				"alpn":              []string{s.Alpn},
+				"transport":         []string{"1"},
+			}.Encode(),
 		}
 		d, err = http.NewHTTPProxy(&u, direct.SymmetricDirect)
 		if err != nil {

--- a/component/outbound/dialer/v2ray/v2ray.go
+++ b/component/outbound/dialer/v2ray/v2ray.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mzz2017/softwind/netproxy"
 	"github.com/mzz2017/softwind/protocol"
 	"github.com/mzz2017/softwind/protocol/direct"
+	"github.com/mzz2017/softwind/protocol/http"
 	"github.com/mzz2017/softwind/transport/grpc"
 )
 
@@ -140,6 +141,26 @@ func (s *V2Ray) Dialer(option *dialer.GlobalOption, iOption dialer.InstanceOptio
 			ServiceName:   serviceName,
 			ServerName:    sni,
 			AllowInsecure: s.AllowInsecure,
+		}
+	case "http", "http2", "h2":
+		sni := s.SNI
+		if sni == "" {
+			sni = s.Host
+		}
+		scheme := "http"
+		if s.TLS == "tls" {
+			scheme = "https"
+		}
+		u := url.URL{
+			Scheme: scheme,
+			Host:   net.JoinHostPort(s.Add, s.Port),
+		}
+		if s.SNI != "" {
+			u.RawQuery = url.Values{"sni": []string{sni}, "allowInsecure": []string{common.BoolToString(s.AllowInsecure)}}.Encode()
+		}
+		d, err = http.NewHTTPProxy(&u, direct.SymmetricDirect)
+		if err != nil {
+			return nil, err
 		}
 	default:
 		return nil, fmt.Errorf("%w: network: %v", dialer.UnexpectedFieldErr, s.Net)

--- a/docs/en/proxy-protocols.md
+++ b/docs/en/proxy-protocols.md
@@ -12,6 +12,7 @@
   - [x] WS
   - [x] TLS
   - [x] gRPC
+  - [x] h2
 - [x] Shadowsocks
   - [x] AEAD Ciphers
   - [x] Stream Ciphers

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/miekg/dns v1.1.55
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
-	github.com/mzz2017/softwind v0.0.0-20230710175107-0107af8a1d26
+	github.com/mzz2017/softwind v0.0.0-20230722080658-973f985df174
 	github.com/okzk/sdnotify v0.0.0-20180710141335-d9becc38acbd
 	github.com/safchain/ethtool v0.3.0
 	github.com/sirupsen/logrus v1.9.3
@@ -24,6 +24,7 @@ require (
 	golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df
 	golang.org/x/sys v0.10.0
 	google.golang.org/protobuf v1.31.0
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 )
 
 require (
@@ -41,7 +42,6 @@ require (
 	golang.org/x/net v0.12.0 // indirect
 	golang.org/x/tools v0.11.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230706204954-ccb25ca9f130 // indirect
-	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/mzz2017/disk-bloom v1.0.1 h1:rEF9MiXd9qMW3ibRpqcerLXULoTgRlM21yqqJl1B
 github.com/mzz2017/disk-bloom v1.0.1/go.mod h1:JLHETtUu44Z6iBmsqzkOtFlRvXSlKnxjwiBRDapizDI=
 github.com/mzz2017/quic-go v0.0.0-20230706143320-cc858d4932b7 h1:9zmZilN02x3byMB2X3x+B4iyKHkucv70WA4hsyZkjo8=
 github.com/mzz2017/quic-go v0.0.0-20230706143320-cc858d4932b7/go.mod h1:3H6d55CEofIWWr3gQThiB27+hA3WG5tATtPovzEYPAA=
-github.com/mzz2017/softwind v0.0.0-20230710175107-0107af8a1d26 h1:kVjALMAhr+rYw77TfrpD8VNIRbZ2/2pN1AYWBcL6eqM=
-github.com/mzz2017/softwind v0.0.0-20230710175107-0107af8a1d26/go.mod h1:Fz8fgR7/dbnfR6RLpeOMkUDyebq4xShdmjj+cE5jnJ4=
+github.com/mzz2017/softwind v0.0.0-20230722080658-973f985df174 h1:I4JKJSOCxUtFgiMB5VpoqdC70tncD1UkKd2Qvi5/A0o=
+github.com/mzz2017/softwind v0.0.0-20230722080658-973f985df174/go.mod h1:Fz8fgR7/dbnfR6RLpeOMkUDyebq4xShdmjj+cE5jnJ4=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

<img width="559" alt="image" src="https://github.com/daeuniverse/dae/assets/30586220/1f43b7e6-d5d6-4225-baac-7ebd67ebe4ee">

This PR supports network `h2` of VMess/VLESS.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae


### Test Result

<!--- Attach test result here. -->
<img width="361" alt="image" src="https://github.com/daeuniverse/dae/assets/30586220/15173229-605d-4e5b-9766-10befad7ca3d">
