### PR TITLE
optimize(vmess): auto choose cipher instead of aes-128-gcm

### DIFF
--- a/component/outbound/dialer/v2ray/cipher.go
+++ b/component/outbound/dialer/v2ray/cipher.go
@@ -1,0 +1,26 @@
+package v2ray
+
+import (
+	"runtime"
+
+	"golang.org/x/sys/cpu"
+)
+
+var (
+	hasGCMAsmAMD64 = cpu.X86.HasAES && cpu.X86.HasPCLMULQDQ
+	hasGCMAsmARM64 = cpu.ARM64.HasAES && cpu.ARM64.HasPMULL
+	// Keep in sync with crypto/aes/cipher_s390x.go.
+	hasGCMAsmS390X = cpu.S390X.HasAES && cpu.S390X.HasAESCBC && cpu.S390X.HasAESCTR &&
+		(cpu.S390X.HasGHASH || cpu.S390X.HasAESGCM)
+
+	hasAESGCMHardwareSupport = runtime.GOARCH == "amd64" && hasGCMAsmAMD64 ||
+		runtime.GOARCH == "arm64" && hasGCMAsmARM64 ||
+		runtime.GOARCH == "s390x" && hasGCMAsmS390X
+)
+
+func getAutoCipher() string {
+	if hasAESGCMHardwareSupport {
+		return "aes-128-gcm"
+	}
+	return "chacha20-ietf-poly1305"
+}

--- a/component/outbound/dialer/v2ray/v2ray.go
+++ b/component/outbound/dialer/v2ray/v2ray.go
@@ -175,7 +175,7 @@ func (s *V2Ray) Dialer(option *dialer.GlobalOption, iOption dialer.InstanceOptio
 
 	if d, err = protocol.NewDialer(s.Protocol, d, protocol.Header{
 		ProxyAddress: net.JoinHostPort(s.Add, s.Port),
-		Cipher:       "aes-128-gcm",
+		Cipher:       getAutoCipher(),
 		Password:     s.ID,
 		IsClient:     true,
 		//Flags:        protocol.Flags_VMess_UsePacketAddr,


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

We should choose chacha20-poly1305 for `vmess` users without AES hardware acceleration.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae
