### PR TITLE
optimize: pull subscriptions using custom UA

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/daeuniverse/dae/config"
 	"github.com/spf13/cobra"
 )
 
@@ -16,6 +17,10 @@ var (
 		},
 	}
 )
+
+func init() {
+	config.Version = Version
+}
 
 // Execute executes the root command.
 func Execute() error {

--- a/common/subscription/subscription.go
+++ b/common/subscription/subscription.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/daeuniverse/dae/common"
+	"github.com/daeuniverse/dae/config"
 	"github.com/sirupsen/logrus"
 )
 
@@ -149,6 +150,7 @@ func ResolveSubscription(log *logrus.Logger, client *http.Client, configDir stri
 	log.Debugf("ResolveSubscription: %v", subscription)
 	var (
 		b    []byte
+		req  *http.Request
 		resp *http.Response
 	)
 	switch u.Scheme {
@@ -160,7 +162,11 @@ func ResolveSubscription(log *logrus.Logger, client *http.Client, configDir stri
 		goto resolve
 	default:
 	}
-	resp, err = client.Get(subscription)
+	req, err = http.NewRequest("GET", subscription, nil)
+	if err != nil {
+		return "", nil, err
+	}
+	req.Header.Set("User-Agent", fmt.Sprintf("dae/%v (like v2rayA/1.0 WebRequestHelper) (like v2rayN/1.0 WebRequestHelper)", config.Version))
 	if err != nil {
 		return "", nil, err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,10 @@ import (
 	"github.com/daeuniverse/dae/pkg/config_parser"
 )
 
+var (
+	Version string
+)
+
 type Global struct {
 	TproxyPort        uint16 `mapstructure:"tproxy_port" default:"12345"`
 	TproxyPortProtect bool   `mapstructure:"tproxy_port_protect" default:"true"`


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

<img width="493" alt="image" src="https://github.com/daeuniverse/dae/assets/30586220/7f5cd9b4-76bd-40bd-be24-407833bdfe2f">

This behavior of PR keeps in sync with dae-wing.

```
dae/<DAE_VERSION> (like v2rayA/1.0 WebRequestHelper) (like v2rayN/1.0 WebRequestHelper)
```

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae
