### PR TITLE
optimize: force to choose one if there is only one node in the group

### DIFF
--- a/component/outbound/dialer_group.go
+++ b/component/outbound/dialer_group.go
@@ -228,7 +228,6 @@ func (g *DialerGroup) Select(networkType *dialer.NetworkType, strictIpVersion bo
 	}
 	if errors.Is(err, NoAliveDialerError) && len(g.Dialers) == 1 {
 		// There is only one dialer in this group. Just choose it instead of return error.
-		g.log.WithError(err).WithField("group", g.Name).Debug("Force to choose due to only one node in this group")
 		return g._select(networkType, &DialerSelectionPolicy{
 			Policy:     consts.DialerSelectionPolicy_Fixed,
 			FixedIndex: 0,


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Should fallback to `fixed(0)` if there is only one node in this group and even if it not alive.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- Change the logic in node `select`.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

N/A

### Test Result

<!--- Attach test result here. -->
N/A