### PR TITLE
feat(juicity): support certificate pinning

### DIFF
--- a/common/utils.go
+++ b/common/utils.go
@@ -8,6 +8,7 @@ package common
 import (
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
@@ -494,4 +495,17 @@ func StringSet(list []string) map[string]struct{} {
 		m[s] = struct{}{}
 	}
 	return m
+}
+
+func GenerateCertChainHash(rawCerts [][]byte) (chainHash []byte) {
+	for _, cert := range rawCerts {
+		certHash := sha256.Sum256(cert)
+		if chainHash == nil {
+			chainHash = certHash[:]
+		} else {
+			newHash := sha256.Sum256(append(chainHash, certHash[:]...))
+			chainHash = newHash[:]
+		}
+	}
+	return chainHash
 }

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/miekg/dns v1.1.55
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
-	github.com/mzz2017/softwind v0.0.0-20230730190454-1b4f59056283
+	github.com/mzz2017/softwind v0.0.0-20230803152605-5f1f6bc06934
 	github.com/okzk/sdnotify v0.0.0-20180710141335-d9becc38acbd
 	github.com/safchain/ethtool v0.3.0
 	github.com/sirupsen/logrus v1.9.3
@@ -34,7 +34,7 @@ require (
 	github.com/golang/mock v1.6.0 // indirect
 	github.com/google/pprof v0.0.0-20230705174524-200ffdc848b8 // indirect
 	github.com/klauspost/compress v1.16.7 // indirect
-	github.com/mzz2017/quic-go v0.0.0-20230730161358-da6d530ddb18 // indirect
+	github.com/mzz2017/quic-go v0.0.0-20230731153658-2aabc7c97220 // indirect
 	github.com/onsi/ginkgo/v2 v2.11.0 // indirect
 	github.com/quic-go/qtls-go1-20 v0.3.0 // indirect
 	golang.org/x/mod v0.12.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -89,10 +89,10 @@ github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/mzz2017/disk-bloom v1.0.1 h1:rEF9MiXd9qMW3ibRpqcerLXULoTgRlM21yqqJl1B90M=
 github.com/mzz2017/disk-bloom v1.0.1/go.mod h1:JLHETtUu44Z6iBmsqzkOtFlRvXSlKnxjwiBRDapizDI=
-github.com/mzz2017/quic-go v0.0.0-20230730161358-da6d530ddb18 h1:SzaoU9jIglF82Qp2rmPhsXhdtgOYiTwmxbd85qa5+Gs=
-github.com/mzz2017/quic-go v0.0.0-20230730161358-da6d530ddb18/go.mod h1:+8o4sdYYZCkNfMGiP3oKstpdHeSDFJy84A68evIzhw4=
-github.com/mzz2017/softwind v0.0.0-20230730190454-1b4f59056283 h1:nmDedxylxjWN8CW4xxa4krkZknijTA/qHgRk849o8zs=
-github.com/mzz2017/softwind v0.0.0-20230730190454-1b4f59056283/go.mod h1:H5th8OX4bXcksqNjwKhyisZS4lmO1ZezAbcoIL3P1dU=
+github.com/mzz2017/quic-go v0.0.0-20230731153658-2aabc7c97220 h1:StI6iNucfDVrm54yhrHL0Dr1vKC1nBqkok2Itkypvdk=
+github.com/mzz2017/quic-go v0.0.0-20230731153658-2aabc7c97220/go.mod h1:+8o4sdYYZCkNfMGiP3oKstpdHeSDFJy84A68evIzhw4=
+github.com/mzz2017/softwind v0.0.0-20230803152605-5f1f6bc06934 h1:IAaVbSfNiYP/TuJ4n686SeAwcs+PMvKdzJM5R4Y1rhM=
+github.com/mzz2017/softwind v0.0.0-20230803152605-5f1f6bc06934/go.mod h1:TopiWHnL2ty4V4AkNM1nNVdbLlASWdQqploagf4tcKc=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Sometimes, we want to use a self-signed certificate without trusting it in the system. This PR implements Certificate Pinning to solve it.

See: <https://github.com/juicity/juicity/pull/61>

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- Support the `pinned_certchain_sha256` param of juicity.

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

N/A

### Test Result

<!--- Attach test result here. -->
