### PR TITLE
fix: caddy cannot accept connections

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -102,7 +102,6 @@ jobs:
           mkdir -p ./build/
           export CGO_ENABLED=0
           export GOFLAGS="-trimpath -modcacherw"
-          export CFLAGS="-D__REMOVE_BPF_PRINTK"
           export OUTPUT=build/dae-$ASSET_NAME
           export VERSION=${{ steps.get_version.outputs.VERSION }}
           export CLANG=clang-15

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,6 @@ jobs:
           mkdir -p ./build/
           export CGO_ENABLED=0
           export GOFLAGS="-trimpath -modcacherw"
-          export CFLAGS="-D__REMOVE_BPF_PRINTK"
           export OUTPUT=build/dae-$ASSET_NAME
           export VERSION=${{ steps.get_version.outputs.VERSION }}
           export CLANG=clang-15

--- a/.github/workflows/seed-build.yml
+++ b/.github/workflows/seed-build.yml
@@ -118,7 +118,6 @@ jobs:
           mkdir -p ./build/
           export CGO_ENABLED=0
           export GOFLAGS="-trimpath -modcacherw"
-          export CFLAGS="-D__REMOVE_BPF_PRINTK"
           export OUTPUT=build/dae-$ASSET_NAME
           export VERSION=${{ steps.get_version.outputs.VERSION }}
           export CLANG=clang-15

--- a/control/bpf_utils.go
+++ b/control/bpf_utils.go
@@ -231,7 +231,7 @@ retryLoadBpf:
 		if strings.Contains(err.Error(), "no BTF found for kernel version") {
 			err = fmt.Errorf("%w: you should re-compile linux kernel with BTF configurations; see docs for more information", err)
 		} else if strings.Contains(err.Error(), "unknown func bpf_trace_printk") {
-			err = fmt.Errorf(`%w: please try to compile dae without bpf_printk; example of cross-compilation to arm64: make GOARCH=arm64 CGO_ENABLED=0 CFLAGS="-D__REMOVE_BPF_PRINTK"`, err)
+			err = fmt.Errorf(`%w: please try to compile dae without bpf_printk"`, err)
 		} else if strings.Contains(err.Error(), "unknown func bpf_probe_read") {
 			err = fmt.Errorf(`%w: please re-compile linux kernel with CONFIG_BPF_EVENTS=y and CONFIG_KPROBE_EVENTS=y"`, err)
 		}

--- a/control/kern/tproxy.c
+++ b/control/kern/tproxy.c
@@ -18,9 +18,13 @@
 // #define __DEBUG_ROUTING
 // #define __PRINT_ROUTING_RESULT
 // #define __PRINT_SETUP_PROCESS_CONNNECTION
-// #define __REMOVE_BPF_PRINTK
+// #define __DEBUG
 // #define __UNROLL_ROUTE_LOOP
 
+#ifndef __DEBUG
+#undef bpf_printk
+#define bpf_printk(...) (void)0
+#endif
 // #define likely(x) x
 // #define unlikely(x) x
 #define likely(x) __builtin_expect((x), 1)

--- a/control/kern/tproxy.c
+++ b/control/kern/tproxy.c
@@ -1362,10 +1362,6 @@ int tproxy_lan_ingress(struct __sk_buff *skb) {
 
     sk = bpf_skc_lookup_tcp(skb, &tuple, tuple_size, BPF_F_CURRENT_NETNS, 0);
     if (sk) {
-      if (tuples.dport == bpf_ntohs(445)) {
-        // samba. It is safe because the smb port cannot be customized.
-        goto sk_accept;
-      }
       if (sk->state != BPF_TCP_LISTEN) {
         is_old_conn = true;
         goto assign;
@@ -1487,6 +1483,7 @@ assign:
       bpf_printk("bpf_sk_assign: %d, perhaps you have other TPROXY programs "
                  "(such as v2ray) running?",
                  ret);
+      return TC_ACT_OK;
     } else {
       bpf_printk("bpf_sk_assign: %d", ret);
     }

--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -1,15 +1,5 @@
 # Troubleshooting
 
-## Unknown bpf_trace_printk
-
-```console
-invalid argument: unknown func bpf_trace_printk
-```
-
-Solution:
-
-Compile dae with CFLAG `-D__REMOVE_BPF_PRINTK`. See [build-by-yourself](user-guide/build-by-yourself.md).
-
 ## No network after `dae suspend`
 
 Do not set dae as the DNS in DHCP setting. For example, you can set `223.5.5.5` as DNS in your DHCP setting.
@@ -77,4 +67,4 @@ If you use `clang-13` to compile dae, you may encounter this problem.
 There are ways to resolve it:
 
 1. Method 1: Use `clang-15` or higher versions to compile dae. Or just download dae from [releases](https://github.com/daeuniverse/dae/releases).
-2. Method 2: Add CFLAGS `-D__UNROLL_ROUTE_LOOP` while compiling. However, it will increse memory occupation (or swap space) at the eBPF loading stage (about 180MB). For example, compile dae to ARM64 using `make CGO_ENABLED=0 GOARCH=arm64 CFLAGS="-D__UNROLL_ROUTE_LOOP -D__REMOVE_BPF_PRINTK"`.
+2. Method 2: Add CFLAGS `-D__UNROLL_ROUTE_LOOP` while compiling. However, it will increse memory occupation (or swap space) at the eBPF loading stage (about 180MB). For example, compile dae to ARM64 using `make CGO_ENABLED=0 GOARCH=arm64 CFLAGS="-D__UNROLL_ROUTE_LOOP"`.

--- a/docs/en/user-guide/build-by-yourself.md
+++ b/docs/en/user-guide/build-by-yourself.md
@@ -19,7 +19,6 @@ cd dae
 git submodule update --init
 ## Minimal dependency build
 make GOFLAGS="-buildvcs=false" \
-  CFLAGS="-D__REMOVE_BPF_PRINTK" \
   CC=clang
 
 ## Normal build


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Caddy and samba cannot work.

This may be some special use of their listening socket, because `bpf_assign` returns `-94` (ESOCKTNOSUPPORT).

This problem is **NOT** about `PSH` flag of TCP.

This is most likely because the caddy port has enabled `IP_TRANSPARENT ` sockopt.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full changelogs

- Just accept the skb once `bpf_assign` returns -94 (ESOCKTNOSUPPORT).

### Issue reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #261. Related #154.

### Test Result

<!--- Attach test result here. -->
