### PR TITLE
chore: upgrade quic-go to 0.37.4 to support go1.21

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -52,6 +52,7 @@ jobs:
       GOARM: ${{ matrix.goarm }}
       GOAMD64: ${{ matrix.goamd64 }}
       CGO_ENABLED: 0
+      BUILD_ARGS: ${{ matrix.buildargs }}
 
     steps:
       - name: Checkout codebase

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -13,9 +13,12 @@ jobs:
     strategy:
       matrix:
         goos: [ linux ]
-        goarch: [ arm64, 386, riscv64, mips64, mips64le, mipsle, mips ]
+        goarch: [ 386, riscv64, mips64, mips64le, mipsle, mips ]
         include:
-          # BEGIN Linux ARM 5 6 7
+          # BEGIN Linux ARM 5 6 7 64
+          - goos: linux
+            goarch: arm64
+            buildargs: -buildmode=pie
           - goos: linux
             goarch: arm
             goarm: 7
@@ -30,12 +33,15 @@ jobs:
           - goos: linux
             goarch: amd64
             goamd64: v1
+            buildargs: -buildmode=pie
           - goos: linux
             goarch: amd64
             goamd64: v2
+            buildargs: -buildmode=pie
           - goos: linux
             goarch: amd64
             goamd64: v3
+            buildargs: -buildmode=pie
           # END Linux AMD64 v1 v2 v3
       fail-fast: false
 

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '^1.19'
+          go-version: '^1.21'
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,7 @@ jobs:
       GOARM: ${{ matrix.goarm }}
       GOAMD64: ${{ matrix.goamd64 }}
       CGO_ENABLED: 0
+      BUILD_ARGS: ${{ matrix.buildargs }}
 
     steps:
       - name: Checkout codebase

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,12 @@ jobs:
     strategy:
       matrix:
         goos: [ linux ]
-        goarch: [ arm64, 386, riscv64, mips64, mips64le, mipsle, mips ]
+        goarch: [ 386, riscv64, mips64, mips64le, mipsle, mips ]
         include:
-          # BEGIN Linux ARM 5 6 7
+          # BEGIN Linux ARM 5 6 7 64
+          - goos: linux
+            goarch: arm64
+            buildargs: -buildmode=pie
           - goos: linux
             goarch: arm
             goarm: 7
@@ -30,12 +33,15 @@ jobs:
           - goos: linux
             goarch: amd64
             goamd64: v1
+            buildargs: -buildmode=pie
           - goos: linux
             goarch: amd64
             goamd64: v2
+            buildargs: -buildmode=pie
           - goos: linux
             goarch: amd64
             goamd64: v3
+            buildargs: -buildmode=pie
           # END Linux AMD64 v1 v2 v3
       fail-fast: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '^1.19'
+          go-version: '^1.21'
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/seed-build.yml
+++ b/.github/workflows/seed-build.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         goos: [ linux ]
-        goarch: [386, riscv64, mips64, mips64le, mipsle, mips ]
+        goarch: [ 386, riscv64, mips64, mips64le, mipsle, mips ]
         include:
           # BEGIN Linux ARM 5 6 7 64
           - goos: linux

--- a/.github/workflows/seed-build.yml
+++ b/.github/workflows/seed-build.yml
@@ -30,9 +30,12 @@ jobs:
     strategy:
       matrix:
         goos: [ linux ]
-        goarch: [ arm64, 386, riscv64, mips64, mips64le, mipsle, mips ]
+        goarch: [386, riscv64, mips64, mips64le, mipsle, mips ]
         include:
-          # BEGIN Linux ARM 5 6 7
+          # BEGIN Linux ARM 5 6 7 64
+          - goos: linux
+            goarch: arm64
+            buildargs: -buildmode=pie
           - goos: linux
             goarch: arm
             goarm: 7
@@ -47,12 +50,15 @@ jobs:
           - goos: linux
             goarch: amd64
             goamd64: v1
+            buildargs: -buildmode=pie
           - goos: linux
             goarch: amd64
             goamd64: v2
+            buildargs: -buildmode=pie
           - goos: linux
             goarch: amd64
             goamd64: v3
+            buildargs: -buildmode=pie
           # END Linux AMD64 v1 v2 v3
       fail-fast: false
 
@@ -62,6 +68,7 @@ jobs:
       GOARCH: ${{ matrix.goarch }}
       GOARM: ${{ matrix.goarm }}
       GOAMD64: ${{ matrix.goamd64 }}
+      BUILD_ARGS: ${{ matrix.buildargs }}
       CGO_ENABLED: 0
 
     steps:
@@ -116,7 +123,6 @@ jobs:
       - name: Build dae
         run: |
           mkdir -p ./build/
-          export CGO_ENABLED=0
           export GOFLAGS="-trimpath -modcacherw"
           export OUTPUT=build/dae-$ASSET_NAME
           export VERSION=${{ steps.get_version.outputs.VERSION }}

--- a/.github/workflows/seed-build.yml
+++ b/.github/workflows/seed-build.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '^1.19'
+          go-version: '^1.21'
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/seed-build.yml
+++ b/.github/workflows/seed-build.yml
@@ -68,8 +68,8 @@ jobs:
       GOARCH: ${{ matrix.goarch }}
       GOARM: ${{ matrix.goarm }}
       GOAMD64: ${{ matrix.goamd64 }}
-      BUILD_ARGS: ${{ matrix.buildargs }}
       CGO_ENABLED: 0
+      BUILD_ARGS: ${{ matrix.buildargs }}
 
     steps:
       - name: Checkout codebase

--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,7 @@ BUILD_ARGS := -trimpath -ldflags "-s -w -X github.com/daeuniverse/dae/cmd.Versio
 
 ## Begin Dae Build
 dae: export GOOS=linux
-# dae: ebpf
-dae:
+dae: ebpf
 	@echo $(CFLAGS)
 	go build -o $(OUTPUT) $(BUILD_ARGS) .
 ## End Dae Build

--- a/Makefile
+++ b/Makefile
@@ -36,12 +36,16 @@ else
 	VERSION ?= unstable-$(date).r$(count).$(commit)
 endif
 
+BUILD_ARGS := -trimpath -ldflags "-s -w -X github.com/daeuniverse/dae/cmd.Version=$(VERSION) -X github.com/daeuniverse/dae/common/consts.MaxMatchSetLen_=$(MAX_MATCH_SET_LEN)" $(BUILD_ARGS)
+
 .PHONY: clean-ebpf ebpf dae submodule submodules
 
 ## Begin Dae Build
 dae: export GOOS=linux
-dae: ebpf
-	go build -o $(OUTPUT) -trimpath -buildmode=pie -ldflags "-s -w -X github.com/daeuniverse/dae/cmd.Version=$(VERSION) -X github.com/daeuniverse/dae/common/consts.MaxMatchSetLen_=$(MAX_MATCH_SET_LEN)" .
+# dae: ebpf
+dae:
+	@echo $(CFLAGS)
+	go build -o $(OUTPUT) $(BUILD_ARGS) .
 ## End Dae Build
 
 ## Begin Git Submodules

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -277,7 +277,7 @@ func newControlPlane(log *logrus.Logger, bpf interface{}, dnsCache map[string]*c
 		client := http.Client{
 			Transport: &http.Transport{
 				DialContext: func(ctx context.Context, network, addr string) (c net.Conn, err error) {
-					cd := netproxy.ContextDialer{Dialer: direct.SymmetricDirect}
+					cd := netproxy.ContextDialerConverter{Dialer: direct.SymmetricDirect}
 					conn, err := cd.DialContext(ctx, common.MagicNetwork("tcp", conf.Global.SoMarkFromDae), addr)
 					if err != nil {
 						return nil, err
@@ -319,7 +319,7 @@ func newControlPlane(log *logrus.Logger, bpf interface{}, dnsCache map[string]*c
 	client := http.Client{
 		Transport: &http.Transport{
 			DialContext: func(ctx context.Context, network, addr string) (c net.Conn, err error) {
-				cd := netproxy.ContextDialer{Dialer: direct.SymmetricDirect}
+				cd := netproxy.ContextDialerConverter{Dialer: direct.SymmetricDirect}
 				conn, err := cd.DialContext(ctx, common.MagicNetwork("tcp", conf.Global.SoMarkFromDae), addr)
 				if err != nil {
 					return nil, err

--- a/common/netutils/dns.go
+++ b/common/netutils/dns.go
@@ -211,7 +211,7 @@ func resolve(ctx context.Context, d netproxy.Dialer, dns netip.AddrPort, host st
 	}
 
 	// Dial and write.
-	cd := &netproxy.ContextDialer{Dialer: d}
+	cd := &netproxy.ContextDialerConverter{Dialer: d}
 	c, err := cd.DialContext(ctx, network, dns.String())
 	if err != nil {
 		return nil, err

--- a/component/outbound/dialer/connectivity_check.go
+++ b/component/outbound/dialer/connectivity_check.go
@@ -570,7 +570,7 @@ func (d *Dialer) HttpCheck(ctx context.Context, u *netutils.URL, ip netip.Addr, 
 	if method == "" {
 		method = http.MethodGet
 	}
-	cd := &netproxy.ContextDialer{Dialer: d.Dialer}
+	cd := &netproxy.ContextDialerConverter{Dialer: d.Dialer}
 	cli := http.Client{
 		Transport: &http.Transport{
 			DialContext: func(ctx context.Context, network, addr string) (c net.Conn, err error) {

--- a/component/outbound/dialer/trojan/trojan.go
+++ b/component/outbound/dialer/trojan/trojan.go
@@ -83,7 +83,7 @@ func (s *Trojan) Dialer(option *dialer.GlobalOption, nextDialer netproxy.Dialer)
 			serviceName = "GunService"
 		}
 		d = &grpc.Dialer{
-			NextDialer:    &netproxy.ContextDialer{Dialer: d},
+			NextDialer:    &netproxy.ContextDialerConverter{Dialer: d},
 			ServiceName:   serviceName,
 			ServerName:    s.Sni,
 			AllowInsecure: s.AllowInsecure || option.AllowInsecure,

--- a/component/outbound/dialer/v2ray/v2ray.go
+++ b/component/outbound/dialer/v2ray/v2ray.go
@@ -135,7 +135,7 @@ func (s *V2Ray) Dialer(option *dialer.GlobalOption, nextDialer netproxy.Dialer) 
 			serviceName = "GunService"
 		}
 		d = &grpc.Dialer{
-			NextDialer:    &netproxy.ContextDialer{Dialer: d},
+			NextDialer:    &netproxy.ContextDialerConverter{Dialer: d},
 			ServiceName:   serviceName,
 			ServerName:    sni,
 			AllowInsecure: s.AllowInsecure || option.AllowInsecure,

--- a/control/dns_control.go
+++ b/control/dns_control.go
@@ -556,7 +556,7 @@ func (c *DnsController) dialSend(invokingDepth int, req *udpRequest, data []byte
 
 	ctxDial, cancel := context.WithTimeout(context.TODO(), consts.DefaultDialTimeout)
 	defer cancel()
-	bestContextDialer := netproxy.ContextDialer{
+	bestContextDialer := netproxy.ContextDialerConverter{
 		Dialer: dialArgument.bestDialer,
 	}
 

--- a/control/tcp.go
+++ b/control/tcp.go
@@ -188,7 +188,7 @@ func (c *ControlPlane) RouteDialTcp(p *RouteDialParam) (conn netproxy.Conn, err 
 	}
 	ctx, cancel := context.WithTimeout(context.TODO(), consts.DefaultDialTimeout)
 	defer cancel()
-	cd := netproxy.ContextDialer{
+	cd := netproxy.ContextDialerConverter{
 		Dialer: d,
 	}
 	return cd.DialContext(ctx, common.MagicNetwork("tcp", routingResult.Mark), dialTarget)

--- a/control/udp_endpoint.go
+++ b/control/udp_endpoint.go
@@ -121,7 +121,7 @@ begin:
 		if err != nil {
 			return nil, false, err
 		}
-		cd := netproxy.ContextDialer{
+		cd := netproxy.ContextDialerConverter{
 			Dialer: dialOption.Dialer,
 		}
 		ctx, cancel := context.WithTimeout(context.TODO(), consts.DefaultDialTimeout)

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/bits-and-blooms/bloom/v3 v3.5.0
 	github.com/cilium/ebpf v0.11.0
 	github.com/daeuniverse/dae-config-dist/go/dae_config v0.0.0-20230604120805-1c27619b592d
-	github.com/daeuniverse/softwind v0.0.0-20230806140139-8dd211d63c60
+	github.com/daeuniverse/softwind v0.0.0-20230809141237-cbe650b0e27c
 	github.com/gorilla/websocket v1.5.0
 	github.com/json-iterator/go v1.1.12
 	github.com/miekg/dns v1.1.55
@@ -34,7 +34,7 @@ require (
 	github.com/golang/mock v1.6.0 // indirect
 	github.com/google/pprof v0.0.0-20230705174524-200ffdc848b8 // indirect
 	github.com/klauspost/compress v1.16.7 // indirect
-	github.com/mzz2017/quic-go v0.0.0-20230806040851-f9ecab3bb42a // indirect
+	github.com/mzz2017/quic-go v0.0.0-20230809140948-2ea096492e36 // indirect
 	github.com/onsi/ginkgo/v2 v2.11.0 // indirect
 	github.com/quic-go/qtls-go1-20 v0.3.1 // indirect
 	golang.org/x/mod v0.12.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/cilium/ebpf v0.11.0/go.mod h1:WE7CZAnqOL2RouJ4f1uyNhqr2P4CCvXFIqdRDUg
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/daeuniverse/dae-config-dist/go/dae_config v0.0.0-20230604120805-1c27619b592d h1:hnC39MjR7xt5kZjrKlef7DXKFDkiX8MIcDXYC/6Jf9Q=
 github.com/daeuniverse/dae-config-dist/go/dae_config v0.0.0-20230604120805-1c27619b592d/go.mod h1:VGWGgv7pCP5WGyHGUyb9+nq/gW0yBm+i/GfCNATOJ1M=
-github.com/daeuniverse/softwind v0.0.0-20230806140139-8dd211d63c60 h1:3h6gBNiPvaEINMKJWwjAz6TojZ4MpSj+fLWj/uvqrRs=
-github.com/daeuniverse/softwind v0.0.0-20230806140139-8dd211d63c60/go.mod h1:SXBNF3LXl1cfYKxoRJO/aK5ycoTNdou280mM9cGZYr4=
+github.com/daeuniverse/softwind v0.0.0-20230809141237-cbe650b0e27c h1:CWSa7Jnmuz8pWjMi31wxbSC+cPDzk9eZ5UClZMC2uIc=
+github.com/daeuniverse/softwind v0.0.0-20230809141237-cbe650b0e27c/go.mod h1:fL1IT5Qi5oZsrZwq38b4HYQH5AFe8XofpuukHQByTbM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -91,8 +91,8 @@ github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/mzz2017/disk-bloom v1.0.1 h1:rEF9MiXd9qMW3ibRpqcerLXULoTgRlM21yqqJl1B90M=
 github.com/mzz2017/disk-bloom v1.0.1/go.mod h1:JLHETtUu44Z6iBmsqzkOtFlRvXSlKnxjwiBRDapizDI=
-github.com/mzz2017/quic-go v0.0.0-20230806040851-f9ecab3bb42a h1:clBJMmZdRtli4Tko2ZdQ+3n1cA4Es/0ao3tB5vXvctY=
-github.com/mzz2017/quic-go v0.0.0-20230806040851-f9ecab3bb42a/go.mod h1:DBA25b2LoPhrfSzOPE8KcDOicysx00qvvnqe0BpA8DQ=
+github.com/mzz2017/quic-go v0.0.0-20230809140948-2ea096492e36 h1:ikWpUK6uyLmECHFDL/ZU3KA86l7eqIpDf3L46GA42jI=
+github.com/mzz2017/quic-go v0.0.0-20230809140948-2ea096492e36/go.mod h1:DBA25b2LoPhrfSzOPE8KcDOicysx00qvvnqe0BpA8DQ=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

<img width="460" alt="image" src="https://github.com/daeuniverse/dae/assets/30586220/fc5369e0-dc02-4274-aabe-13233891b93f">


### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- Bump quic-go to v0.37.4.
- Bump go to v1.21.

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

N/A

### Test Result

<!--- Attach test result here. -->
