### PR TITLE
fix: rebinding wg/tun not work

### DIFF
--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -8,7 +8,6 @@ package control
 import (
 	"context"
 	"fmt"
-	"github.com/daeuniverse/softwind/transport/meek"
 	"net"
 	"net/netip"
 	"os"
@@ -36,6 +35,7 @@ import (
 	"github.com/daeuniverse/softwind/pool"
 	"github.com/daeuniverse/softwind/protocol/direct"
 	"github.com/daeuniverse/softwind/transport/grpc"
+	"github.com/daeuniverse/softwind/transport/meek"
 	dnsmessage "github.com/miekg/dns"
 	"github.com/mohae/deepcopy"
 	"github.com/sirupsen/logrus"
@@ -193,7 +193,6 @@ func NewControlPlane(
 	// Add clsact qdisc
 	for _, ifname := range common.Deduplicate(append(append([]string{}, global.LanInterface...), global.WanInterface...)) {
 		_ = core.addQdisc(ifname)
-		_ = core.mapLinkType(ifname)
 	}
 	// Bind to LAN
 	if len(global.LanInterface) > 0 {

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -190,10 +190,6 @@ func NewControlPlane(
 	}
 
 	/// Bind to links. Binding should be advance of dialerGroups to avoid un-routable old connection.
-	// Add clsact qdisc
-	for _, ifname := range common.Deduplicate(append(append([]string{}, global.LanInterface...), global.WanInterface...)) {
-		_ = core.addQdisc(ifname)
-	}
 	// Bind to LAN
 	if len(global.LanInterface) > 0 {
 		if err = core.setupRoutingPolicy(); err != nil {

--- a/control/control_plane_core.go
+++ b/control/control_plane_core.go
@@ -425,6 +425,7 @@ func (c *controlPlaneCore) _bindLan(ifname string) error {
 	if err = CheckSendRedirects(ifname); err != nil {
 		return err
 	}
+	_ = c.addQdisc(ifname)
 	_ = c.mapLinkType(ifname)
 	/// Insert an elem into IfindexParamsMap.
 	ifParams, err := getIfParamsFromLink(link)
@@ -565,6 +566,9 @@ func (c *controlPlaneCore) _bindWan(ifname string) error {
 	if link.Attrs().Index == consts.LoopbackIfIndex {
 		return fmt.Errorf("cannot bind to loopback interface")
 	}
+	_ = c.addQdisc(ifname)
+	_ = c.mapLinkType(ifname)
+
 	/// Insert an elem into IfindexParamsMap.
 	ifParams, err := getIfParamsFromLink(link)
 	if err != nil {

--- a/control/control_plane_core.go
+++ b/control/control_plane_core.go
@@ -425,6 +425,7 @@ func (c *controlPlaneCore) _bindLan(ifname string) error {
 	if err = CheckSendRedirects(ifname); err != nil {
 		return err
 	}
+	_ = c.mapLinkType(ifname)
 	/// Insert an elem into IfindexParamsMap.
 	ifParams, err := getIfParamsFromLink(link)
 	if err != nil {


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

<img width="422" alt="image" src="https://github.com/daeuniverse/dae/assets/30586220/f68f374a-fd9b-4517-8924-d2374921d90c">

<img width="265" alt="image" src="https://github.com/daeuniverse/dae/assets/30586220/3a2be6e1-d81c-4e9b-b6b3-fe0dbae6e184">

This is because link type mapping is based on `ifindex`. If the interface re-creates, its index changes, and the mapping will be invalid. This PR fixes it.

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- Move the `mapLinkType` function into `_bindLan`.

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
