### PR TITLE
chore: amd64 and arm64 use PIE build mode by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ else ifeq ($(wildcard $(STRIP_PATH)),)
 else
 	STRIP_FLAG := -strip=$(STRIP_PATH)
 endif
+GOARCH ?= $(shell go env GOARCH)
 
 # Do NOT remove the line below. This line is for CI.
 #export GOMODCACHE=$(PWD)/go-mod

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,12 @@ else
 	VERSION ?= unstable-$(date).r$(count).$(commit)
 endif
 
-BUILD_ARGS := -trimpath -ldflags "-s -w -X github.com/daeuniverse/dae/cmd.Version=$(VERSION) -X github.com/daeuniverse/dae/common/consts.MaxMatchSetLen_=$(MAX_MATCH_SET_LEN)" $(BUILD_ARGS)
+# amd64 and arm64 use PIE build mode by default
+ifeq ($(GOARCH),$(filter $(GOARCH),amd64 arm64))
+    BUILD_MODE ?= -buildmode=pie
+endif
+
+BUILD_ARGS := -trimpath -ldflags "-s -w -X github.com/daeuniverse/dae/cmd.Version=$(VERSION) -X github.com/daeuniverse/dae/common/consts.MaxMatchSetLen_=$(MAX_MATCH_SET_LEN)" $(BUILD_MODE) $(BUILD_ARGS)
 
 .PHONY: clean-ebpf ebpf dae submodule submodules
 


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Usage:
``````shell
make BUILD_MODE='-buildmode=(build mode)'
# or
BUILD_MODE='-buildmode=(build mode)' make
``````

### Added the feature of setting BUILD_MODE according to GOARCH in Makefile

I added some code in Makefile to set different BUILD_MODE values  according to different GOARCH values, so as to achieve cross-platform  compilation and position-independent executable files. This allows the  program to run on different operating systems and computing  architectures, and also improves the security of the program. This PR is to enhance the compatibility and stability of the project.

I specifically specified that only when GOARCH is amd64 or arm64,  -buildmode=pie will be used to set BUILD_MODE. This is because pie may  not be supported on other computing architectures. Therefore, I used an  ifeq statement to judge the value of GOARCH and set BUILD_MODE according to different situations.

I also added a feature that allows users to manually specify the  build mode using make BUILD_MODE=-buildmode=*, overriding the default  settings. This allows users to choose the appropriate build mode  according to their needs, such as , pie, c-shared, c-archive,  shared, plugin, etc. If the user does not manually specify the build  mode, then if GOARCH is amd64 or arm64, -buildmode=pie will be used.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Fix #_[issue number]_

### Test Result

I used different GOARCH and BUILD_MODE values to compile the project  and run tests on amd64 and arm64 platforms. The test results show that  my modification can correctly set BUILD_MODE and does not affect the  normal operation of other parameters and functions. 

**test code:**

``````shell
#!/bin/bash

make
echo ""
echo ""

for arch in 386 amd64 arm arm64 mips mips64 mips64le mipsle; do
        echo "===================$arch=========================="
        make GOARCH=$arch
        echo ""
        echo "============$arch Test Set BUILD_MODE============="
        make VERSION=$arch BUILD_MODE=-buildmode=exe
        echo ""


done
``````

**result:**

``````shell
-no-strip
Compiled /home/kvm/github/dae/control/bpf_bpfel.o
Wrote /home/kvm/github/dae/control/bpf_bpfel.go
Compiled /home/kvm/github/dae/control/bpf_bpfeb.o
Wrote /home/kvm/github/dae/control/bpf_bpfeb.go
-DMAX_MATCH_SET_LEN=64 -O2 -Wall -Werror
go build -o dae -trimpath -ldflags "-s -w -X github.com/daeuniverse/dae/cmd.Version=unstable-20230811.r594.caa23ea -X github.com/daeuniverse/dae/common/consts.MaxMatchSetLen_=64" -buildmode=pie  .


===================386==========================
-no-strip
Compiled /home/kvm/github/dae/control/bpf_bpfel.o
Wrote /home/kvm/github/dae/control/bpf_bpfel.go
Compiled /home/kvm/github/dae/control/bpf_bpfeb.o
Wrote /home/kvm/github/dae/control/bpf_bpfeb.go
-DMAX_MATCH_SET_LEN=64 -O2 -Wall -Werror
go build -o dae -trimpath -ldflags "-s -w -X github.com/daeuniverse/dae/cmd.Version=unstable-20230811.r594.caa23ea -X github.com/daeuniverse/dae/common/consts.MaxMatchSetLen_=64"   .

============386 Test Set BUILD_MODE=============
-no-strip
Compiled /home/kvm/github/dae/control/bpf_bpfel.o
Wrote /home/kvm/github/dae/control/bpf_bpfel.go
Compiled /home/kvm/github/dae/control/bpf_bpfeb.o
Wrote /home/kvm/github/dae/control/bpf_bpfeb.go
-DMAX_MATCH_SET_LEN=64 -O2 -Wall -Werror
go build -o dae -trimpath -ldflags "-s -w -X github.com/daeuniverse/dae/cmd.Version=386 -X github.com/daeuniverse/dae/common/consts.MaxMatchSetLen_=64" -buildmode=exe  .

===================amd64==========================
-no-strip
Compiled /home/kvm/github/dae/control/bpf_bpfeb.o
Wrote /home/kvm/github/dae/control/bpf_bpfeb.go
Compiled /home/kvm/github/dae/control/bpf_bpfel.o
Wrote /home/kvm/github/dae/control/bpf_bpfel.go
-DMAX_MATCH_SET_LEN=64 -O2 -Wall -Werror
go build -o dae -trimpath -ldflags "-s -w -X github.com/daeuniverse/dae/cmd.Version=unstable-20230811.r594.caa23ea -X github.com/daeuniverse/dae/common/consts.MaxMatchSetLen_=64" -buildmode=pie  .

============amd64 Test Set BUILD_MODE=============
-no-strip
Compiled /home/kvm/github/dae/control/bpf_bpfel.o
Wrote /home/kvm/github/dae/control/bpf_bpfel.go
Compiled /home/kvm/github/dae/control/bpf_bpfeb.o
Wrote /home/kvm/github/dae/control/bpf_bpfeb.go
-DMAX_MATCH_SET_LEN=64 -O2 -Wall -Werror
go build -o dae -trimpath -ldflags "-s -w -X github.com/daeuniverse/dae/cmd.Version=amd64 -X github.com/daeuniverse/dae/common/consts.MaxMatchSetLen_=64" -buildmode=exe  .

===================arm==========================
-no-strip
Compiled /home/kvm/github/dae/control/bpf_bpfel.o
Wrote /home/kvm/github/dae/control/bpf_bpfel.go
Compiled /home/kvm/github/dae/control/bpf_bpfeb.o
Wrote /home/kvm/github/dae/control/bpf_bpfeb.go
-DMAX_MATCH_SET_LEN=64 -O2 -Wall -Werror
go build -o dae -trimpath -ldflags "-s -w -X github.com/daeuniverse/dae/cmd.Version=unstable-20230811.r594.caa23ea -X github.com/daeuniverse/dae/common/consts.MaxMatchSetLen_=64"   .

============arm Test Set BUILD_MODE=============
-no-strip
Compiled /home/kvm/github/dae/control/bpf_bpfel.o
Wrote /home/kvm/github/dae/control/bpf_bpfel.go
Compiled /home/kvm/github/dae/control/bpf_bpfeb.o
Wrote /home/kvm/github/dae/control/bpf_bpfeb.go
-DMAX_MATCH_SET_LEN=64 -O2 -Wall -Werror
go build -o dae -trimpath -ldflags "-s -w -X github.com/daeuniverse/dae/cmd.Version=arm -X github.com/daeuniverse/dae/common/consts.MaxMatchSetLen_=64" -buildmode=exe  .

===================arm64==========================
-no-strip
Compiled /home/kvm/github/dae/control/bpf_bpfel.o
Wrote /home/kvm/github/dae/control/bpf_bpfel.go
Compiled /home/kvm/github/dae/control/bpf_bpfeb.o
Wrote /home/kvm/github/dae/control/bpf_bpfeb.go
-DMAX_MATCH_SET_LEN=64 -O2 -Wall -Werror
go build -o dae -trimpath -ldflags "-s -w -X github.com/daeuniverse/dae/cmd.Version=unstable-20230811.r594.caa23ea -X github.com/daeuniverse/dae/common/consts.MaxMatchSetLen_=64" -buildmode=pie  .

============arm64 Test Set BUILD_MODE=============
-no-strip
Compiled /home/kvm/github/dae/control/bpf_bpfel.o
Wrote /home/kvm/github/dae/control/bpf_bpfel.go
Compiled /home/kvm/github/dae/control/bpf_bpfeb.o
Wrote /home/kvm/github/dae/control/bpf_bpfeb.go
-DMAX_MATCH_SET_LEN=64 -O2 -Wall -Werror
go build -o dae -trimpath -ldflags "-s -w -X github.com/daeuniverse/dae/cmd.Version=arm64 -X github.com/daeuniverse/dae/common/consts.MaxMatchSetLen_=64" -buildmode=exe  .

===================mips==========================
-no-strip
Compiled /home/kvm/github/dae/control/bpf_bpfel.o
Wrote /home/kvm/github/dae/control/bpf_bpfel.go
Compiled /home/kvm/github/dae/control/bpf_bpfeb.o
Wrote /home/kvm/github/dae/control/bpf_bpfeb.go
-DMAX_MATCH_SET_LEN=64 -O2 -Wall -Werror
go build -o dae -trimpath -ldflags "-s -w -X github.com/daeuniverse/dae/cmd.Version=unstable-20230811.r594.caa23ea -X github.com/daeuniverse/dae/common/consts.MaxMatchSetLen_=64"   .

============mips Test Set BUILD_MODE=============
-no-strip
Compiled /home/kvm/github/dae/control/bpf_bpfeb.o
Wrote /home/kvm/github/dae/control/bpf_bpfeb.go
Compiled /home/kvm/github/dae/control/bpf_bpfel.o
Wrote /home/kvm/github/dae/control/bpf_bpfel.go
-DMAX_MATCH_SET_LEN=64 -O2 -Wall -Werror
go build -o dae -trimpath -ldflags "-s -w -X github.com/daeuniverse/dae/cmd.Version=mips -X github.com/daeuniverse/dae/common/consts.MaxMatchSetLen_=64" -buildmode=exe  .

===================mips64==========================
-no-strip
Compiled /home/kvm/github/dae/control/bpf_bpfel.o
Wrote /home/kvm/github/dae/control/bpf_bpfel.go
Compiled /home/kvm/github/dae/control/bpf_bpfeb.o
Wrote /home/kvm/github/dae/control/bpf_bpfeb.go
-DMAX_MATCH_SET_LEN=64 -O2 -Wall -Werror
go build -o dae -trimpath -ldflags "-s -w -X github.com/daeuniverse/dae/cmd.Version=unstable-20230811.r594.caa23ea -X github.com/daeuniverse/dae/common/consts.MaxMatchSetLen_=64"   .

============mips64 Test Set BUILD_MODE=============
-no-strip
Compiled /home/kvm/github/dae/control/bpf_bpfel.o
Wrote /home/kvm/github/dae/control/bpf_bpfel.go
Compiled /home/kvm/github/dae/control/bpf_bpfeb.o
Wrote /home/kvm/github/dae/control/bpf_bpfeb.go
-DMAX_MATCH_SET_LEN=64 -O2 -Wall -Werror
go build -o dae -trimpath -ldflags "-s -w -X github.com/daeuniverse/dae/cmd.Version=mips64 -X github.com/daeuniverse/dae/common/consts.MaxMatchSetLen_=64" -buildmode=exe  .

===================mips64le==========================
-no-strip
Compiled /home/kvm/github/dae/control/bpf_bpfel.o
Wrote /home/kvm/github/dae/control/bpf_bpfel.go
Compiled /home/kvm/github/dae/control/bpf_bpfeb.o
Wrote /home/kvm/github/dae/control/bpf_bpfeb.go
-DMAX_MATCH_SET_LEN=64 -O2 -Wall -Werror
go build -o dae -trimpath -ldflags "-s -w -X github.com/daeuniverse/dae/cmd.Version=unstable-20230811.r594.caa23ea -X github.com/daeuniverse/dae/common/consts.MaxMatchSetLen_=64"   .

============mips64le Test Set BUILD_MODE=============
-no-strip
Compiled /home/kvm/github/dae/control/bpf_bpfel.o
Wrote /home/kvm/github/dae/control/bpf_bpfel.go
Compiled /home/kvm/github/dae/control/bpf_bpfeb.o
Wrote /home/kvm/github/dae/control/bpf_bpfeb.go
-DMAX_MATCH_SET_LEN=64 -O2 -Wall -Werror
go build -o dae -trimpath -ldflags "-s -w -X github.com/daeuniverse/dae/cmd.Version=mips64le -X github.com/daeuniverse/dae/common/consts.MaxMatchSetLen_=64" -buildmode=exe  .

===================mipsle==========================
-no-strip
Compiled /home/kvm/github/dae/control/bpf_bpfel.o
Wrote /home/kvm/github/dae/control/bpf_bpfel.go
Compiled /home/kvm/github/dae/control/bpf_bpfeb.o
Wrote /home/kvm/github/dae/control/bpf_bpfeb.go
-DMAX_MATCH_SET_LEN=64 -O2 -Wall -Werror
go build -o dae -trimpath -ldflags "-s -w -X github.com/daeuniverse/dae/cmd.Version=unstable-20230811.r594.caa23ea -X github.com/daeuniverse/dae/common/consts.MaxMatchSetLen_=64"   .

============mipsle Test Set BUILD_MODE=============
-no-strip
Compiled /home/kvm/github/dae/control/bpf_bpfel.o
Wrote /home/kvm/github/dae/control/bpf_bpfel.go
Compiled /home/kvm/github/dae/control/bpf_bpfeb.o
Wrote /home/kvm/github/dae/control/bpf_bpfeb.go
-DMAX_MATCH_SET_LEN=64 -O2 -Wall -Werror
go build -o dae -trimpath -ldflags "-s -w -X github.com/daeuniverse/dae/cmd.Version=mipsle -X github.com/daeuniverse/dae/common/consts.MaxMatchSetLen_=64" -buildmode=exe  .

``````

<!--- Attach test result here. -->