### PR TITLE
ci/chore: remove the buildmode specified in CI

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -13,12 +13,9 @@ jobs:
     strategy:
       matrix:
         goos: [ linux ]
-        goarch: [ 386, riscv64, mips64, mips64le, mipsle, mips ]
+        goarch: [ arm64, 386, riscv64, mips64, mips64le, mipsle, mips ]
         include:
-          # BEGIN Linux ARM 5 6 7 64
-          - goos: linux
-            goarch: arm64
-            buildargs: -buildmode=pie
+          # BEGIN Linux ARM 5 6 7
           - goos: linux
             goarch: arm
             goarm: 7
@@ -33,15 +30,12 @@ jobs:
           - goos: linux
             goarch: amd64
             goamd64: v1
-            buildargs: -buildmode=pie
           - goos: linux
             goarch: amd64
             goamd64: v2
-            buildargs: -buildmode=pie
           - goos: linux
             goarch: amd64
             goamd64: v3
-            buildargs: -buildmode=pie
           # END Linux AMD64 v1 v2 v3
       fail-fast: false
 
@@ -52,7 +46,6 @@ jobs:
       GOARM: ${{ matrix.goarm }}
       GOAMD64: ${{ matrix.goamd64 }}
       CGO_ENABLED: 0
-      BUILD_ARGS: ${{ matrix.buildargs }}
 
     steps:
       - name: Checkout codebase

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,9 @@ jobs:
     strategy:
       matrix:
         goos: [ linux ]
-        goarch: [ 386, riscv64, mips64, mips64le, mipsle, mips ]
+        goarch: [ arm64, 386, riscv64, mips64, mips64le, mipsle, mips ]
         include:
-          # BEGIN Linux ARM 5 6 7 64
-          - goos: linux
-            goarch: arm64
-            buildargs: -buildmode=pie
+          # BEGIN Linux ARM 5 6 7
           - goos: linux
             goarch: arm
             goarm: 7
@@ -33,15 +30,12 @@ jobs:
           - goos: linux
             goarch: amd64
             goamd64: v1
-            buildargs: -buildmode=pie
           - goos: linux
             goarch: amd64
             goamd64: v2
-            buildargs: -buildmode=pie
           - goos: linux
             goarch: amd64
             goamd64: v3
-            buildargs: -buildmode=pie
           # END Linux AMD64 v1 v2 v3
       fail-fast: false
 
@@ -52,7 +46,6 @@ jobs:
       GOARM: ${{ matrix.goarm }}
       GOAMD64: ${{ matrix.goamd64 }}
       CGO_ENABLED: 0
-      BUILD_ARGS: ${{ matrix.buildargs }}
 
     steps:
       - name: Checkout codebase

--- a/.github/workflows/seed-build.yml
+++ b/.github/workflows/seed-build.yml
@@ -30,12 +30,9 @@ jobs:
     strategy:
       matrix:
         goos: [ linux ]
-        goarch: [ 386, riscv64, mips64, mips64le, mipsle, mips ]
+        goarch: [ arm64, 386, riscv64, mips64, mips64le, mipsle, mips ]
         include:
-          # BEGIN Linux ARM 5 6 7 64
-          - goos: linux
-            goarch: arm64
-            buildargs: -buildmode=pie
+          # BEGIN Linux ARM 5 6 7
           - goos: linux
             goarch: arm
             goarm: 7
@@ -50,15 +47,12 @@ jobs:
           - goos: linux
             goarch: amd64
             goamd64: v1
-            buildargs: -buildmode=pie
           - goos: linux
             goarch: amd64
             goamd64: v2
-            buildargs: -buildmode=pie
           - goos: linux
             goarch: amd64
             goamd64: v3
-            buildargs: -buildmode=pie
           # END Linux AMD64 v1 v2 v3
       fail-fast: false
 
@@ -69,7 +63,6 @@ jobs:
       GOARM: ${{ matrix.goarm }}
       GOAMD64: ${{ matrix.goamd64 }}
       CGO_ENABLED: 0
-      BUILD_ARGS: ${{ matrix.buildargs }}
 
     steps:
       - name: Checkout codebase


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

This PR is because [#272](https://translate.google.com/) has already selected whether to enable `-buildmode=pie` in Makefile according to GOARCH, so there is no need to specify `-buildmode=pie` in CI.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
