### PR TITLE
fix BPF_PROG_TYPE issue for android

### DIFF
--- a/control/kern/tproxy.c
+++ b/control/kern/tproxy.c
@@ -2232,13 +2232,13 @@ static int __always_inline update_map_elem_by_cookie(const __u64 cookie) {
 }
 
 // Create cookie to pid, pname mapping.
-SEC("cgroup/sock_create")
+SEC("cgroupsock/sock_create")
 int tproxy_wan_cg_sock_create(struct bpf_sock *sk) {
   update_map_elem_by_cookie(bpf_get_socket_cookie(sk));
   return 1;
 }
 // Remove cookie to pid, pname mapping.
-SEC("cgroup/sock_release")
+SEC("cgroupsock/sock_release")
 int tproxy_wan_cg_sock_release(struct bpf_sock *sk) {
   __u64 cookie = bpf_get_socket_cookie(sk);
   if (unlikely(!cookie)) {
@@ -2248,22 +2248,22 @@ int tproxy_wan_cg_sock_release(struct bpf_sock *sk) {
   bpf_map_delete_elem(&cookie_pid_map, &cookie);
   return 1;
 }
-SEC("cgroup/connect4")
+SEC("connect4")
 int tproxy_wan_cg_connect4(struct bpf_sock_addr *ctx) {
   update_map_elem_by_cookie(bpf_get_socket_cookie(ctx));
   return 1;
 }
-SEC("cgroup/connect6")
+SEC("connect6")
 int tproxy_wan_cg_connect6(struct bpf_sock_addr *ctx) {
   update_map_elem_by_cookie(bpf_get_socket_cookie(ctx));
   return 1;
 }
-SEC("cgroup/sendmsg4")
+SEC("sendmsg4")
 int tproxy_wan_cg_sendmsg4(struct bpf_sock_addr *ctx) {
   update_map_elem_by_cookie(bpf_get_socket_cookie(ctx));
   return 1;
 }
-SEC("cgroup/sendmsg6")
+SEC("sendmsg6")
 int tproxy_wan_cg_sendmsg6(struct bpf_sock_addr *ctx) {
   update_map_elem_by_cookie(bpf_get_socket_cookie(ctx));
   return 1;


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background
pname is useful for dae running on android, e.g. pname(netd) -> must_direct. (`netd` is the networkmanager for android)
dae pname not working on android, coz the bpf prog type name is different in libbpf_android.

Error 1
`FATA[0002] Attach(group: (GroupSock(tproxy_wan_cg_sock_create)#27: create link: operation not permitted`

Error 2
`FATA[0002] load eBPF objects: field TproxyWanCgConnect4: cannot load program tproxy_wan_cg_connect4: program type is unspecified`

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- Error 1 solved
- Error 2 upstream AOSP newer version of bpfloader for android needed, coz connect4/6 and sendmsg4/6 are not fully supported until bpfloader v0.36 which is now v0.19 in android13-qpr3-release branch.

### Issue Reference

[AOSP Extending the Kernel with eBPF](https://source.android.com/docs/core/architecture/kernel/bpf)

[Loader.cpp main branch source](https://android.googlesource.com/platform/system/bpf/+/refs/heads/main/libbpf_android/Loader.cpp)

[Loader.cpp android13-qpr3-release branch source](https://android.googlesource.com/platform/system/bpf/+/refs/heads/android13-qpr3-release/libbpf_android/Loader.cpp)

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
