### PR TITLE
ci/hotfix: demise buildarg=pie

### DIFF
--- a/.github/workflows/seed-build.yml
+++ b/.github/workflows/seed-build.yml
@@ -30,9 +30,12 @@ jobs:
     strategy:
       matrix:
         goos: [ linux ]
-        goarch: [ arm64, 386, riscv64, mips64, mips64le, mipsle, mips ]
+        goarch: [ 386, riscv64, mips64, mips64le, mipsle, mips ]
         include:
-          # BEGIN Linux ARM 5 6 7
+          # BEGIN Linux ARM 5 6 7 64
+          - goos: linux
+            goarch: arm64
+            buildargs: -buildmode=pie
           - goos: linux
             goarch: arm
             goarm: 7
@@ -47,12 +50,15 @@ jobs:
           - goos: linux
             goarch: amd64
             goamd64: v1
+            buildargs: -buildmode=pie
           - goos: linux
             goarch: amd64
             goamd64: v2
+            buildargs: -buildmode=pie
           - goos: linux
             goarch: amd64
             goamd64: v3
+            buildargs: -buildmode=pie
           # END Linux AMD64 v1 v2 v3
       fail-fast: false
 
@@ -63,6 +69,7 @@ jobs:
       GOARM: ${{ matrix.goarm }}
       GOAMD64: ${{ matrix.goamd64 }}
       CGO_ENABLED: 0
+      BUILD_ARGS: ${{ matrix.buildargs }}
 
     steps:
       - name: Checkout codebase

--- a/.github/workflows/seed-build.yml
+++ b/.github/workflows/seed-build.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         goos: [ linux ]
-        goarch: [ 386, riscv64, mips64, mips64le, mipsle, mips ]
+        goarch: [ arm64, riscv64, mips64, mips64le, mipsle, mips ]
         include:
           # BEGIN Linux ARM 5 6 7 64
           - goos: linux
@@ -50,15 +50,12 @@ jobs:
           - goos: linux
             goarch: amd64
             goamd64: v1
-            buildargs: -buildmode=pie
           - goos: linux
             goarch: amd64
             goamd64: v2
-            buildargs: -buildmode=pie
           - goos: linux
             goarch: amd64
             goamd64: v3
-            buildargs: -buildmode=pie
           # END Linux AMD64 v1 v2 v3
       fail-fast: false
 
@@ -69,7 +66,6 @@ jobs:
       GOARM: ${{ matrix.goarm }}
       GOAMD64: ${{ matrix.goamd64 }}
       CGO_ENABLED: 0
-      BUILD_ARGS: ${{ matrix.buildargs }}
 
     steps:
       - name: Checkout codebase

--- a/.github/workflows/seed-build.yml
+++ b/.github/workflows/seed-build.yml
@@ -30,12 +30,9 @@ jobs:
     strategy:
       matrix:
         goos: [ linux ]
-        goarch: [ arm64, riscv64, mips64, mips64le, mipsle, mips ]
+        goarch: [ arm64, 386, riscv64, mips64, mips64le, mipsle, mips ]
         include:
-          # BEGIN Linux ARM 5 6 7 64
-          - goos: linux
-            goarch: arm64
-            buildargs: -buildmode=pie
+          # BEGIN Linux ARM 5 6 7
           - goos: linux
             goarch: arm
             goarm: 7

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ else ifeq ($(wildcard $(STRIP_PATH)),)
 else
 	STRIP_FLAG := -strip=$(STRIP_PATH)
 endif
-GOARCH ?= $(shell go env GOARCH)
 
 # Do NOT remove the line below. This line is for CI.
 #export GOMODCACHE=$(PWD)/go-mod
@@ -37,12 +36,7 @@ else
 	VERSION ?= unstable-$(date).r$(count).$(commit)
 endif
 
-# amd64 and arm64 use PIE build mode by default
-ifeq ($(GOARCH),$(filter $(GOARCH),amd64 arm64))
-    BUILD_MODE ?= -buildmode=pie
-endif
-
-BUILD_ARGS := -trimpath -ldflags "-s -w -X github.com/daeuniverse/dae/cmd.Version=$(VERSION) -X github.com/daeuniverse/dae/common/consts.MaxMatchSetLen_=$(MAX_MATCH_SET_LEN)" $(BUILD_MODE) $(BUILD_ARGS)
+BUILD_ARGS := -trimpath -ldflags "-s -w -X github.com/daeuniverse/dae/cmd.Version=$(VERSION) -X github.com/daeuniverse/dae/common/consts.MaxMatchSetLen_=$(MAX_MATCH_SET_LEN)" $(BUILD_ARGS)
 
 .PHONY: clean-ebpf ebpf dae submodule submodules
 


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Completely demise `buildarg=pie`.

PRs that introduce breaking changes:

- https://github.com/daeuniverse/dae/pull/272
- https://github.com/daeuniverse/dae/pull/273

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- chore(make): revert to #270
- ci(seed-build): revert to 5cb7b4c 

Source: https://github.com/daeuniverse/dae/pull/270/files#diff-5cb7b4c67b5f118757a39679dac9abd4b38fbbf59b77436071adb6255ddfab7c

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
