### PR TITLE
chore: expose netproxy dialer creator

### DIFF
--- a/component/outbound/dialer/register.go
+++ b/component/outbound/dialer/register.go
@@ -23,11 +23,10 @@ func FromLinkRegister(name string, creator FromLinkCreator) {
 	fromLinkCreators[name] = creator
 }
 
-func NewNetproxyDialerFromLink(gOption *GlobalOption, link string) (netproxy.Dialer, *Property, error) {
+func NewNetproxyDialerFromLink(d netproxy.Dialer, gOption *GlobalOption, link string) (netproxy.Dialer, *Property, error) {
 	/// Get overwritten name.
 	overwrittenName, linklike := common.GetTagFromLinkLikePlaintext(link)
 	links := strings.Split(linklike, "->")
-	d := direct.SymmetricDirect
 	p := &Property{
 		Name:     "",
 		Address:  "",
@@ -72,7 +71,7 @@ func NewNetproxyDialerFromLink(gOption *GlobalOption, link string) (netproxy.Dia
 }
 
 func NewFromLink(gOption *GlobalOption, iOption InstanceOption, link string) (*Dialer, error) {
-	d, p, err := NewNetproxyDialerFromLink(gOption, link)
+	d, p, err := NewNetproxyDialerFromLink(direct.SymmetricDirect, gOption, link)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

This ability is exposed for juicity to utilize. See <https://github.com/juicity/juicity/issues/72>. We can support not only socks5, but also ss, ssr, trojan, vmess, vless, tuic, and even chain proxy.

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
