### PR TITLE
optimize: latencyString shows realLatency(+offset)

### DIFF
--- a/component/outbound/dialer/utils.go
+++ b/component/outbound/dialer/utils.go
@@ -2,9 +2,16 @@ package dialer
 
 import "time"
 
-func latencyString(latencyAfterOffset, latencyBeforeOffset time.Duration) string {
-	if latencyBeforeOffset == latencyAfterOffset {
-		return latencyAfterOffset.Truncate(time.Millisecond).String()
-	}
-	return latencyAfterOffset.Truncate(time.Millisecond).String() + "(" + latencyBeforeOffset.Truncate(time.Millisecond).String() + ")"
+func latencyString(realLatency, latencyOffset time.Duration) string {
+	offsetPart := func() string {
+		if latencyOffset > 0 {
+			return "(+" + latencyOffset.Truncate(time.Millisecond).String() + ")"
+		} else if latencyOffset < 0 {
+			return "(" + latencyOffset.Truncate(time.Millisecond).String() + ")"
+		} else { // latencyOffset == 0
+			return ""
+		}
+	}()
+
+	return realLatency.Truncate(time.Millisecond).String() + offsetPart
 }

--- a/component/outbound/dialer/utils.go
+++ b/component/outbound/dialer/utils.go
@@ -2,6 +2,10 @@ package dialer
 
 import "time"
 
+func showDuration(d time.Duration) string {
+	return d.Truncate(time.Millisecond).String()
+}
+
 func latencyString(realLatency, latencyOffset time.Duration) string {
 	var offsetSign string = "+"
 	if latencyOffset < 0 {
@@ -10,8 +14,8 @@ func latencyString(realLatency, latencyOffset time.Duration) string {
 
 	var offsetPart string = ""
 	if latencyOffset != 0 {
-		offsetPart = "(" + offsetSign + latencyOffset.Truncate(time.Millisecond).Abs().String() + ")"
+		offsetPart = "(" + offsetSign + showDuration(latencyOffset.Abs()) + "=" + showDuration(realLatency+latencyOffset) + ")"
 	}
 
-	return realLatency.Truncate(time.Millisecond).String() + offsetPart
+	return showDuration(realLatency) + offsetPart
 }

--- a/component/outbound/dialer/utils.go
+++ b/component/outbound/dialer/utils.go
@@ -3,15 +3,19 @@ package dialer
 import "time"
 
 func latencyString(realLatency, latencyOffset time.Duration) string {
-	offsetPart := func() string {
-		if latencyOffset > 0 {
-			return "(+" + latencyOffset.Truncate(time.Millisecond).String() + ")"
-		} else if latencyOffset < 0 {
-			return "(" + latencyOffset.Truncate(time.Millisecond).String() + ")"
-		} else { // latencyOffset == 0
-			return ""
-		}
-	}()
+	var offsetSign string
+	if latencyOffset > 0 {
+		offsetSign = "+"
+	} else {
+		offsetSign = "-"
+	}
+
+	var offsetPart string
+	if latencyOffset != 0 {
+		offsetPart = "(" + offsetSign + latencyOffset.Truncate(time.Millisecond).Abs().String() + ")"
+	} else { // latencyOffset == 0
+		offsetPart = ""
+	}
 
 	return realLatency.Truncate(time.Millisecond).String() + offsetPart
 }

--- a/component/outbound/dialer/utils.go
+++ b/component/outbound/dialer/utils.go
@@ -3,18 +3,14 @@ package dialer
 import "time"
 
 func latencyString(realLatency, latencyOffset time.Duration) string {
-	var offsetSign string
-	if latencyOffset > 0 {
-		offsetSign = "+"
-	} else {
+	var offsetSign string = "+"
+	if latencyOffset < 0 {
 		offsetSign = "-"
 	}
 
-	var offsetPart string
+	var offsetPart string = ""
 	if latencyOffset != 0 {
 		offsetPart = "(" + offsetSign + latencyOffset.Truncate(time.Millisecond).Abs().String() + ")"
-	} else { // latencyOffset == 0
-		offsetPart = ""
 	}
 
 	return realLatency.Truncate(time.Millisecond).String() + offsetPart


### PR DESCRIPTION

<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

this PR make latencyString() shows latency like  `realLatency(+offset)` instead of `latencyAfterOffset(latencyBeforeOffset)`

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
