### PR TITLE
patch(pkg/logger): use local system timezone

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -6,10 +6,21 @@
 package logger
 
 import (
+	"time"
+
 	"github.com/sirupsen/logrus"
 	prefixed "github.com/x-cray/logrus-prefixed-formatter"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
+
+type TZFormatter struct {
+	logrus.Formatter
+}
+
+func (u TZFormatter) Format(e *logrus.Entry) ([]byte, error) {
+	e.Time = time.Now()
+	return u.Formatter.Format(e)
+}
 
 func NewLogger(logLevel string, disableTimestamp bool, logFileOpt *lumberjack.Logger) *logrus.Logger {
 	log := logrus.New()
@@ -20,11 +31,11 @@ func NewLogger(logLevel string, disableTimestamp bool, logFileOpt *lumberjack.Lo
 	}
 
 	log.SetLevel(level)
-	log.SetFormatter(&prefixed.TextFormatter{
+	log.SetFormatter(TZFormatter{&prefixed.TextFormatter{
 		DisableTimestamp: disableTimestamp,
 		FullTimestamp:    true,
 		TimestampFormat:  "Jan 02 15:04:05",
-	})
+	}})
 	if logFileOpt != nil {
 		log.SetOutput(logFileOpt)
 	}

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -1,0 +1,13 @@
+package logger
+
+import (
+	"testing"
+
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+func TestLogger(t *testing.T) {
+	var logOpts *lumberjack.Logger
+	log := NewLogger("debug", false, logOpts)
+	log.Info("Hi there!")
+}


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Use the host's system timezone instead of UTC.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- patch(pkg/logger): use local system timezone
- fixture(pkg/logger): add unit test

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #326 

### Test Result

```console
◆ dae git:(timezone_based_logger) ✗ ❯❯❯ go test -v ./pkg/logger/ -run TestLogger            01:21:01
=== RUN   TestLogger
time="Sep 11 01:21:02" level=info msg="Hi there!"
--- PASS: TestLogger (0.00s)
PASS
ok      github.com/daeuniverse/dae/pkg/logger   0.002s
```

<!--- Attach test result here. -->

#### Unit Test

<img width="1128" alt="CleanShot 2023-09-11 at 01 22 12@2x" src="https://github.com/daeuniverse/dae/assets/31861128/d723a1a1-6bea-4349-9732-99171d6f642d">

---

#### Actual behavior test

![image](https://github.com/daeuniverse/dae/assets/31861128/19d024b8-79a3-4a9f-b5a6-d90d49b166d7)