### PR TITLE
docs: refine DNS example

### DIFF
--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -180,7 +180,7 @@ dns {
     }
     response {
       upstream(googledns) -> accept
-      !qname(geosite:cn) && ip(geoip:private) -> googledns
+      ip(geoip:private) && !qname(geosite:cn) -> googledns
       fallback: accept
     }
   }

--- a/docs/en/configuration/dns.md
+++ b/docs/en/configuration/dns.md
@@ -62,7 +62,7 @@ dns {
             upstream(googledns) -> accept
             # If DNS request name is not in CN and response answers include private IP, which is most likely polluted
             # in China mainland. Therefore, resend DNS request to 'googledns' to get correct result.
-            !qname(geosite:cn) && ip(geoip:private) -> googledns
+            ip(geoip:private) && !qname(geosite:cn) -> googledns
             fallback: accept
         }
     }
@@ -112,7 +112,7 @@ dns {
       # Trusted upstream. Always accept its result.
       upstream(googledns) -> accept
       # Possibly polluted, re-lookup using googledns.
-      !qname(geosite:cn) && ip(geoip:private) -> googledns
+      ip(geoip:private) && !qname(geosite:cn) -> googledns
       # fallback is also called default.
       fallback: accept
     }

--- a/docs/en/tutorials/run-on-macos.md
+++ b/docs/en/tutorials/run-on-macos.md
@@ -127,7 +127,7 @@ dns {
     }
     response {
       upstream(googledns) -> accept
-      !qname(geosite:cn) && ip(geoip:private) -> googledns
+      ip(geoip:private) && !qname(geosite:cn) -> googledns
       fallback: accept
     }
   }

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -174,7 +174,7 @@ dns {
     }
     response {
       upstream(googledns) -> accept
-      !qname(geosite:cn) && ip(geoip:private) -> googledns
+      ip(geoip:private) && !qname(geosite:cn) -> googledns
       fallback: accept
     }
   }

--- a/docs/zh/configuration/dns.md
+++ b/docs/zh/configuration/dns.md
@@ -61,7 +61,7 @@ dns {
             # 接受upstream 'googledns' 回复的 DNS 响应。 有助于避免回环。
             upstream(googledns) -> accept
             # 若 DNS 请求的域名不属于 CN 且回复包含私有 IP， 大抵是被污染了，向 'googledns' 重查。
-            !qname(geosite:cn) && ip(geoip:private) -> googledns
+            ip(geoip:private) && !qname(geosite:cn) -> googledns
             fallback: accept
         }
     }
@@ -111,7 +111,7 @@ dns {
       # 可信的 upstream。总是接受它的回复。
       upstream(googledns) -> accept
       # 疑似被污染结果，向 'googledns' 重查。
-      !qname(geosite:cn) && ip(geoip:private) -> googledns
+      ip(geoip:private) && !qname(geosite:cn) -> googledns
       # fallback 意为 default。
       fallback: accept
     }

--- a/example.dae
+++ b/example.dae
@@ -152,7 +152,7 @@ dns {
             # Trusted upstream. Always accept its result.
             upstream(googledns) -> accept
             # Possibly polluted, re-lookup using googledns.
-            !qname(geosite:cn) && ip(geoip:private) -> googledns
+            ip(geoip:private) && !qname(geosite:cn) -> googledns
             # fallback is also called default.
             fallback: accept
         }


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

Since `qname` condition is more slow than `ip` condition, so the DNS example should move the `ip` condition to the start, for most DNS request, it will only need check if IP is private.

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [x] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- Refine DNS example, better performance

### Issue Reference

no


### Test Result

no
