### PR TITLE
feat(cmd): extend --version print info

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1,6 +1,10 @@
 package cmd
 
 import (
+	"fmt"
+	"runtime"
+	"strings"
+
 	"github.com/daeuniverse/dae/config"
 	"github.com/spf13/cobra"
 )
@@ -20,6 +24,12 @@ var (
 
 func init() {
 	config.Version = Version
+	rootCmd.Version = strings.Join([]string{
+		Version,
+		fmt.Sprintf("go runtime %v %v/%v", runtime.Version(), runtime.GOOS, runtime.GOARCH),
+		"Copyright (c) 2023 dae",
+		"License GNU AGPLv3 <https://github.com/daeuniverse/dae/blob/main/LICENSE>",
+	}, "\n")
 }
 
 // Execute executes the root command.


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

As the title suggests. Add extra info such as Go runtime, copy-right, license to `dae --version` cmd.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- feat(cmd): extend --version print info

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

NA

### Test Result

<!--- Attach test result here. -->

```console
◆ dae git:(print-info) ✗ ❯❯❯ make                                                                                                                         23:25:00
-no-strip
Compiled /home/kev/Workspace/dae/control/bpf_bpfel.o
Wrote /home/kev/Workspace/dae/control/bpf_bpfel.go
Compiled /home/kev/Workspace/dae/control/bpf_bpfeb.o
Wrote /home/kev/Workspace/dae/control/bpf_bpfeb.go
-DMAX_MATCH_SET_LEN=64 -O2 -Wall -Werror
go build -o dae -trimpath -ldflags "-s -w -X github.com/daeuniverse/dae/cmd.Version=unstable-20231022.r617.7e57531 -X github.com/daeuniverse/dae/common/consts.Max
MatchSetLen_=64"  .
◆ dae git:(print-info) ✗ ❯❯❯ ./dae --version                                                                                                              23:25:04
dae version unstable-20231022.r617.7e57531
go runtime go1.21.1 linux/amd64
Copyright (c) 2023 dae
License GNU AGPLv3 <https://github.com/daeuniverse/dae/blob/main/LICENSE>
```