### PR TITLE
Use bpf_sk_assign at tproxy_wan_ingress

### DIFF
--- a/.github/workflows/kernel-test.yml
+++ b/.github/workflows/kernel-test.yml
@@ -144,6 +144,7 @@ jobs:
                 lan_interface: auto
                 wan_interface: auto
                 allow_insecure: false
+                auto_config_kernel_parameter: true
             }
 
             node {
@@ -267,6 +268,7 @@ jobs:
                 lan_interface: dae-veth-peer
                 wan_interface: auto
                 allow_insecure: false
+                auto_config_kernel_parameter: true
             }
 
             node {

--- a/control/control.go
+++ b/control/control.go
@@ -5,4 +5,4 @@
 
 package control
 
-//go:generate go run -mod=mod github.com/cilium/ebpf/cmd/bpf2go -cc "$BPF_CLANG" "$BPF_STRIP_FLAG" -cflags "$BPF_CFLAGS" -target "$BPF_TARGET" bpf kern/tproxy.c -- -I./headers
+//go:generate go run -mod=mod github.com/cilium/ebpf/cmd/bpf2go -cc "$BPF_CLANG" "$BPF_STRIP_FLAG" -cflags "$BPF_CFLAGS" -target "$BPF_TARGET" -type dst_routing_result bpf kern/tproxy.c -- -I./headers

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -216,7 +216,7 @@ func NewControlPlane(
 			return nil, err
 		}
 		for _, ifname := range global.WanInterface {
-			if err = core.bindWan(ifname); err != nil {
+			if err = core.bindWan(ifname, global.AutoConfigKernelParameter); err != nil {
 				return nil, fmt.Errorf("bindWan: %v: %w", ifname, err)
 			}
 		}

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -144,6 +144,7 @@ func NewControlPlane(
 	//var bpf bpfObjects
 	var ProgramOptions = ebpf.ProgramOptions{
 		KernelTypes: nil,
+		LogSize:     ebpf.DefaultVerifierLogSize * 10,
 	}
 	if log.Level == logrus.PanicLevel {
 		ProgramOptions.LogLevel = ebpf.LogLevelBranch | ebpf.LogLevelStats
@@ -736,38 +737,11 @@ func (c *ControlPlane) Serve(readyChan chan<- bool, listener *Listener) (err err
 				pktDst := RetrieveOriginalDest(oob)
 				routingResult, err := c.core.RetrieveRoutingResult(src, pktDst, unix.IPPROTO_UDP)
 				if err != nil {
-					// WAN. Old method.
-					lastErr := err
-					addrHdr, dataOffset, err := ParseAddrHdr(data)
-					if err != nil {
-						if c.tproxyPortProtect {
-							c.log.Warnf("No AddrPort presented: %v, %v", lastErr, err)
-							return
-						} else {
-							routingResult = &bpfRoutingResult{
-								Mark:     0,
-								Must:     0,
-								Mac:      [6]uint8{},
-								Outbound: uint8(consts.OutboundControlPlaneRouting),
-								Pname:    [16]uint8{},
-								Pid:      0,
-								Dscp:     0,
-							}
-							realDst = pktDst
-							goto destRetrieved
-						}
-					}
-					data = data[dataOffset:]
-					routingResult = &addrHdr.RoutingResult
-					__ip := common.Ipv6Uint32ArrayToByteSlice(addrHdr.Ip)
-					_ip, _ := netip.AddrFromSlice(__ip)
-					// Comment it because them SHOULD equal.
-					//src = netip.AddrPortFrom(_ip, src.Port())
-					realDst = netip.AddrPortFrom(_ip, addrHdr.Port)
+					c.log.Warnf("No AddrPort presented: %v", err)
+					return
 				} else {
 					realDst = pktDst
 				}
-			destRetrieved:
 				if e := c.handlePkt(udpConn, data, common.ConvergeAddrPort(src), common.ConvergeAddrPort(pktDst), common.ConvergeAddrPort(realDst), routingResult, false); e != nil {
 					c.log.Warnln("handlePkt:", e)
 				}

--- a/control/control_plane_core.go
+++ b/control/control_plane_core.go
@@ -547,7 +547,10 @@ func (c *controlPlaneCore) setupSkPidMonitor() error {
 	return nil
 }
 
-func (c *controlPlaneCore) bindWan(ifname string) error {
+func (c *controlPlaneCore) bindWan(ifname string, autoConfigKernelParameter bool) error {
+	if autoConfigKernelParameter {
+		SetAcceptLocal(ifname, "1")
+	}
 	return c._bindWan(ifname)
 }
 

--- a/control/udp.go
+++ b/control/udp.go
@@ -13,7 +13,6 @@ import (
 	"net/netip"
 	"syscall"
 	"time"
-	"unsafe"
 
 	"github.com/daeuniverse/dae/common"
 	"github.com/daeuniverse/dae/common/consts"
@@ -49,19 +48,6 @@ func ChooseNatTimeout(data []byte, sniffDns bool) (dmsg *dnsmessage.Msg, timeout
 		}
 	}
 	return nil, DefaultNatTimeout
-}
-
-func ParseAddrHdr(data []byte) (hdr *bpfDstRoutingResult, dataOffset int, err error) {
-	dataOffset = int(unsafe.Sizeof(bpfDstRoutingResult{}))
-	if len(data) < dataOffset {
-		return nil, 0, fmt.Errorf("data is too short to parse AddrHdr")
-	}
-	_hdr := *(*bpfDstRoutingResult)(unsafe.Pointer(&data[0]))
-	if _hdr.Recognize != consts.Recognize {
-		return nil, 0, fmt.Errorf("bad recognize")
-	}
-	_hdr.Port = common.Ntohs(_hdr.Port)
-	return &_hdr, dataOffset, nil
 }
 
 func sendPktWithHdrWithFlag(data []byte, realFrom netip.AddrPort, lConn *net.UDPConn, to netip.AddrPort, lanWanFlag consts.LanWanFlag) error {

--- a/control/utils.go
+++ b/control/utils.go
@@ -128,6 +128,10 @@ func SetForwarding(ifname string, val string) {
 	_ = setForwarding(ifname, consts.IpVersionStr_6, val)
 }
 
+func SetAcceptLocal(ifname, val string) error {
+	return os.WriteFile(fmt.Sprintf("/proc/sys/net/ipv4/conf/%s/accept_local", ifname), []byte(val), 0644)
+}
+
 func checkSendRedirects(ifname string, ipversion consts.IpVersionStr) error {
 	path := fmt.Sprintf("/proc/sys/net/ipv%v/conf/%v/send_redirects", ipversion, ifname)
 	b, err := os.ReadFile(path)


### PR DESCRIPTION
Closes: #375 

废弃 tcp_dst_map，废弃 NAT 模式，全面使用 routing_tuple_map，删除兼容代码。

当前状态:
- 在我 fork 上的测试都通过 CI 了： https://github.com/jschwinger233/dae/actions/runs/7375144887/job/20066383853?pr=5
- IPv6 UDP 还有一点小问题没修，这个 PR 合并后单独修，不然 CI 又红了  - - （因为 #386 对 IPv6 UDP 是 assert failure，如果通过的话反而会挂）
- 请按照 commit review，否则 file diff 非常混乱