### PR TITLE
ci(docker): remove support for armv6

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,7 +53,7 @@ jobs:
           context: .
           builder: ${{ steps.buildx.outputs.name }}
           file: Dockerfile
-          platforms: linux/arm/v6,linux/arm/v7,linux/arm64,linux/amd64,linux/386
+          platforms: linux/arm/v7,linux/arm64,linux/amd64,linux/386
           push: true
           tags: |
             ${{ steps.prep.outputs.IMAGE }}:${{ steps.prep.outputs.TAG }}


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

<img width="881" alt="image" src="https://github.com/daeuniverse/dae/assets/30586220/84fce97e-f306-482b-816a-a3cbb9ad52c6">
<img width="1234" alt="image" src="https://github.com/daeuniverse/dae/assets/30586220/f47495bb-fb47-4db7-a086-4c9028e4099a">

Golang docker image has stopped the support for armv6, thus we follow it.

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- Remove support for armv6 image.

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
