### PR TITLE
fix: ip rule is not added when binding wan

### DIFF
--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -194,12 +194,15 @@ func NewControlPlane(
 		}
 	}()
 
-	/// Bind to links. Binding should be advance of dialerGroups to avoid un-routable old connection.
-	// Bind to LAN
-	if len(global.LanInterface) > 0 {
+	if len(global.LanInterface) > 0 || len(global.WanInterface) > 0 {
 		if err = core.setupRoutingPolicy(); err != nil {
 			return nil, err
 		}
+	}
+
+	/// Bind to links. Binding should be advance of dialerGroups to avoid un-routable old connection.
+	// Bind to LAN
+	if len(global.LanInterface) > 0 {
 		if global.AutoConfigKernelParameter {
 			_ = SetIpv4forward("1")
 		}

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -195,7 +195,7 @@ group {
 
 # See https://github.com/daeuniverse/dae/blob/main/docs/en/configuration/routing.md for full examples.
 routing {
-  pname(NetworkManager) -> direct
+  pname(NetworkManager, systemd-resolved, dnsmasq) -> must_direct
   dip(224.0.0.0/3, 'ff00::/8') -> direct
 
   ### Write your rules below.

--- a/example.dae
+++ b/example.dae
@@ -202,6 +202,9 @@ routing {
     # WAN.
     pname(NetworkManager) -> direct
 
+    # Bypass DNS stubs. We want to bypass their DNS requests, thus use 'must'.
+    pname(systemd-resolved, dnsmasq) -> must_direct
+
     # Put it in the front to prevent broadcast, multicast and other packets that should be sent to the LAN from being
     # forwarded by the proxy.
     # "dip" means destination IP.


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Since #383 added the mark-based tproxy support on wan interfaces, we should also add ip rule when binding WAN interfaces.

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
