### PR TITLE
chore: Build statically linked binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ BUILD_ARGS := -trimpath -ldflags "-s -w -X github.com/daeuniverse/dae/cmd.Versio
 
 ## Begin Dae Build
 dae: export GOOS=linux
+ifndef CGO_ENABLED
+dae: export CGO_ENABLED=0
+endif
 dae: ebpf
 	@echo $(CFLAGS)
 	go build -o $(OUTPUT) $(BUILD_ARGS) .


### PR DESCRIPTION
### Background

This PR makes dae binary statically linked:

```shell
dae $ CGO_ENABLED=1 make
-strip=/usr/bin/llvm-strip
Compiled /home/gray/src/github.com/daeuniverse/dae/control/bpf_bpfel.o
Stripped /home/gray/src/github.com/daeuniverse/dae/control/bpf_bpfel.o
Wrote /home/gray/src/github.com/daeuniverse/dae/control/bpf_bpfel.go
Compiled /home/gray/src/github.com/daeuniverse/dae/control/bpf_bpfeb.o
Stripped /home/gray/src/github.com/daeuniverse/dae/control/bpf_bpfeb.o
Wrote /home/gray/src/github.com/daeuniverse/dae/control/bpf_bpfeb.go
-DMAX_MATCH_SET_LEN=64 -O2 -Wall -Werror
go build -o dae -trimpath -ldflags "-s -w -X github.com/daeuniverse/dae/cmd.Version=unstable-20240102.r642.d69b023 -X github.com/daeuniverse/dae/common/consts.MaxMatchSetLen_=64"  .

dae $ file dae
dae: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, Go BuildID=h8QVSMkpKNNUwfTNG4Lv/7b4sUbYhT9lAsDAn0CHn/cA_9FtALnDheLIJ1We-9/z5nghMosW3BTGulv8Or6
, stripped

dae $ make
-strip=/usr/bin/llvm-strip
Compiled /home/gray/src/github.com/daeuniverse/dae/control/bpf_bpfel.o
Stripped /home/gray/src/github.com/daeuniverse/dae/control/bpf_bpfel.o
Wrote /home/gray/src/github.com/daeuniverse/dae/control/bpf_bpfel.go
Compiled /home/gray/src/github.com/daeuniverse/dae/control/bpf_bpfeb.o
Stripped /home/gray/src/github.com/daeuniverse/dae/control/bpf_bpfeb.o
Wrote /home/gray/src/github.com/daeuniverse/dae/control/bpf_bpfeb.go
-DMAX_MATCH_SET_LEN=64 -O2 -Wall -Werror
go build -o dae -trimpath -ldflags "-s -w -X github.com/daeuniverse/dae/cmd.Version=unstable-20240102.r642.d69b023 -X github.com/daeuniverse/dae/common/consts.MaxMatchSetLen_=64"  .

dae $ file dae
dae: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=81YyLKLSJzIgTeh6Pmcp/e31GkTgqxlRv9sm0mNUr/kKVRNUzqQWnqUh8qC5VH/FnhXPMkOVptxxIbjmCF-, stripped

```

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
