### PR TITLE
docs(troubleshooting.md): add firewalld related docs

### DIFF
--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -27,7 +27,7 @@ ufw
 firewalld
 ```
 
-**ufw**
+#### ufw
 
 UFW users may need some extra steps to make sure `Binding to LAN` working.
 
@@ -41,7 +41,7 @@ Such as adding as follows to `/etc/ufw/before*.rules`:
 -A ufw6-before-input -m mark --mark 0x8000000 -j ACCEPT
 ```
 
-**firewalld**
+#### firewalld
 
 If you use firewalld, it is hard to add mark support. You have to execute following commands every time machine boot and firewall rule changes:
 

--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -27,6 +27,8 @@ ufw
 firewalld
 ```
 
+**ufw**
+
 UFW users may need some extra steps to make sure `Binding to LAN` working.
 
 Such as adding as follows to `/etc/ufw/before*.rules`:
@@ -37,6 +39,14 @@ Such as adding as follows to `/etc/ufw/before*.rules`:
 
 # before6.rules
 -A ufw6-before-input -m mark --mark 0x8000000 -j ACCEPT
+```
+
+**firewalld**
+
+If you use firewalld, it is hard to add mark support. You have to execute following commands every time machine boot and firewall rule changes:
+
+```bash
+sudo nft 'insert rule inet firewalld filter_INPUT mark 0x8000000 accept'
 ```
 
 ### Troubleshoot PPPoE

--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -18,7 +18,7 @@ If you use `adguardhome`, `mosdns` in `dns` section, refer to [external-dns](con
 
 ### Troubleshoot firewall
 
-If you bind to wan, make sure firewall is stopped or `12345` is allowed by firewall. Don't worry about the security of this port because this port has its own firewall rule.
+If you bind to wan, make sure firewall is stopped or mark `0x8000000` is allowed by firewall. Don't worry about the security of this port because this port has its own firewall rule.
 
 Usual firewalls on Linux:
 


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

由于新版本（v0.5.0+）不再使用两次 NAT 方案，所以放行 port 12345 的方案无法使得防火墙放行 dae 流量。

firewalld 会拦截 reroute packets，firewalld 无法支持匹配 mark，因此只能使用 nft 来加入放行规则。

The new version (v0.5.0+) no longer uses the double NAT scheme, so the solution to allow port 12345 cannot make the firewall allow dae traffic.

Firewalld will block reroute packets. Firewalld does not support matching marks, so only NFT (nftables) can be used to add allow rules.

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [x] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
