### PR TITLE
fix: Workaround UDP port conflicts when another local process binds 53

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -268,10 +268,11 @@ loop:
 			break loop
 		}
 	}
+	defer os.Remove(PidFilePath)
+	defer control.GetDaeNetns().Close()
 	if e := c.Close(); e != nil {
 		return fmt.Errorf("close control plane: %w", e)
 	}
-	_ = os.Remove(PidFilePath)
 	return nil
 }
 

--- a/control/anyfrom_pool.go
+++ b/control/anyfrom_pool.go
@@ -190,11 +190,7 @@ func (p *AnyfromPool) GetOrCreate(lAddr string, ttl time.Duration) (conn *Anyfro
 			},
 			KeepAlive: 0,
 		}
-		var pc net.PacketConn
-		err := WithIndieNetns(func() (err error) {
-			pc, err = d.ListenPacket(context.Background(), "udp", lAddr)
-			return err
-		})
+		pc, err := d.ListenPacket(context.Background(), "udp", lAddr)
 		if err != nil {
 			return nil, true, err
 		}

--- a/control/anyfrom_pool.go
+++ b/control/anyfrom_pool.go
@@ -190,7 +190,11 @@ func (p *AnyfromPool) GetOrCreate(lAddr string, ttl time.Duration) (conn *Anyfro
 			},
 			KeepAlive: 0,
 		}
-		pc, err := d.ListenPacket(context.Background(), "udp", lAddr)
+		var pc net.PacketConn
+		err := WithIndieNetns(func() (err error) {
+			pc, err = d.ListenPacket(context.Background(), "udp", lAddr)
+			return err
+		})
 		if err != nil {
 			return nil, true, err
 		}

--- a/control/netns_utils.go
+++ b/control/netns_utils.go
@@ -1,6 +1,7 @@
 package control
 
 import (
+	"fmt"
 	"net"
 	"os"
 	"path"
@@ -55,7 +56,7 @@ func setupIndieNetns() (err error) {
 
 	hostNetns, err := netns.Get()
 	if err != nil {
-		return
+		return fmt.Errorf("Failed to get host netns: %v", err)
 	}
 	defer netns.Set(hostNetns)
 
@@ -63,10 +64,10 @@ func setupIndieNetns() (err error) {
 	DeleteNamedNetns("daens")
 	indieNetns, err = netns.NewNamed("daens")
 	if err != nil {
-		return
+		return fmt.Errorf("Failed to create netns: %v", err)
 	}
 	if err = netns.Set(hostNetns); err != nil {
-		return
+		return fmt.Errorf("Failed to switch to host netns: %v", err)
 	}
 	// ip l a dae0 type veth peer name dae0peer
 	DeleteLink("dae0")
@@ -76,47 +77,47 @@ func setupIndieNetns() (err error) {
 		},
 		PeerName: "dae0peer",
 	}); err != nil {
-		return
+		return fmt.Errorf("Failed to add veth pair: %v", err)
 	}
 	dae0, err := netlink.LinkByName("dae0")
 	if err != nil {
-		return
+		return fmt.Errorf("Failed to get link dae0: %v", err)
 	}
 	dae0peer, err := netlink.LinkByName("dae0peer")
 	if err != nil {
-		return
+		return fmt.Errorf("Failed to get link dae0peer: %v", err)
 	}
 	// ip l s dae0 up
 	if err = netlink.LinkSetUp(dae0); err != nil {
-		return
+		return fmt.Errorf("Failed to set link dae0 up: %v", err)
 	}
 	// sysctl net.ipv4.conf.{dae0,all}.rp_filter=0
 	if err = SetRpFilter("dae0", "0"); err != nil {
-		return
+		return fmt.Errorf("Failed to set rp_filter for dae0: %v", err)
 	}
 	if err = SetRpFilter("all", "0"); err != nil {
-		return
+		return fmt.Errorf("Failed to set rp_filter for all: %v", err)
 	}
 	// ip l s dae0peer netns daens
 	if err = netlink.LinkSetNsFd(dae0peer, int(indieNetns)); err != nil {
-		return
+		return fmt.Errorf("Failed to move dae0peer to daens: %v", err)
 	}
 	// ip net e daens
 	if err = netns.Set(indieNetns); err != nil {
-		return
+		return fmt.Errorf("Failed to switch to daens: %v", err)
 	}
 	// (ip net e daens) ip l s dae0peer up
 	if err = netlink.LinkSetUp(dae0peer); err != nil {
-		return
+		return fmt.Errorf("Failed to set link dae0peer up: %v", err)
 	}
 	// (ip net e daens) ip a a 169.254.0.1 dev dae0peer
 	ip, ipNet, err := net.ParseCIDR("169.254.0.1/24")
 	ipNet.IP = ip
 	if err != nil {
-		return
+		return fmt.Errorf("Failed to parse ip: %v", err)
 	}
 	if err = netlink.AddrAdd(dae0peer, &netlink.Addr{IPNet: ipNet}); err != nil {
-		return
+		return fmt.Errorf("Failed to add addr to dae0peer: %v", err)
 	}
 	// (ip net e daens) ip r a default dev dae0peer
 	if err = netlink.RouteAdd(&netlink.Route{
@@ -124,14 +125,14 @@ func setupIndieNetns() (err error) {
 		Dst:       &net.IPNet{IP: net.IPv4(0, 0, 0, 0), Mask: net.CIDRMask(0, 32)},
 		Gw:        nil,
 	}); err != nil {
-		return
+		return fmt.Errorf("Failed to add route to dae0peer: %v", err)
 	}
 	return
 }
 
 func DeleteNamedNetns(name string) error {
 	namedPath := path.Join("/run/netns", name)
-	unix.Unmount(namedPath, unix.MNT_DETACH)
+	unix.Unmount(namedPath, unix.MNT_DETACH|unix.MNT_FORCE)
 	return os.Remove(namedPath)
 }
 

--- a/control/netns_utils.go
+++ b/control/netns_utils.go
@@ -38,6 +38,10 @@ func init() {
 	daeNetns = &DaeNetns{}
 }
 
+func GetDaeNetns() *DaeNetns {
+	return daeNetns
+}
+
 func (ns *DaeNetns) Setup() (err error) {
 	if ns.setupDone.Load() {
 		return
@@ -53,6 +57,12 @@ func (ns *DaeNetns) Setup() (err error) {
 	}
 	ns.setupDone.Store(true)
 	return nil
+}
+
+func (ns *DaeNetns) Close() (err error) {
+	DeleteNamedNetns(NsName)
+	DeleteLink(HostVethName)
+	return
 }
 
 func (ns *DaeNetns) With(f func() error) (err error) {

--- a/control/netns_utils.go
+++ b/control/netns_utils.go
@@ -57,31 +57,31 @@ func (ns *DaeNetns) Setup() (err error) {
 
 func (ns *DaeNetns) With(f func() error) (err error) {
 	if err = daeNetns.Setup(); err != nil {
-		return fmt.Errorf("Failed to setup dae netns: %v", err)
+		return fmt.Errorf("failed to setup dae netns: %v", err)
 	}
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
 	if err = netns.Set(ns.daeNs); err != nil {
-		return fmt.Errorf("Failed to switch to daens: %v", err)
+		return fmt.Errorf("failed to switch to daens: %v", err)
 	}
 	defer netns.Set(ns.hostNs)
 
 	if err = f(); err != nil {
-		return fmt.Errorf("Failed to run func in dae netns: %v", err)
+		return fmt.Errorf("failed to run func in dae netns: %v", err)
 	}
 	return
 }
 
 func (ns *DaeNetns) setup() (err error) {
-	logrus.Trace("Setting up dae netns")
+	logrus.Trace("setting up dae netns")
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
 	if ns.hostNs, err = netns.Get(); err != nil {
-		return fmt.Errorf("Failed to get host netns: %v", err)
+		return fmt.Errorf("failed to get host netns: %v", err)
 	}
 	defer netns.Set(ns.hostNs)
 
@@ -113,17 +113,17 @@ func (ns *DaeNetns) setupVeth() (err error) {
 		},
 		PeerName: NsVethName,
 	}); err != nil {
-		return fmt.Errorf("Failed to add veth pair: %v", err)
+		return fmt.Errorf("failed to add veth pair: %v", err)
 	}
 	if ns.dae0, err = netlink.LinkByName(HostVethName); err != nil {
-		return fmt.Errorf("Failed to get link dae0: %v", err)
+		return fmt.Errorf("failed to get link dae0: %v", err)
 	}
 	if ns.dae0peer, err = netlink.LinkByName(NsVethName); err != nil {
-		return fmt.Errorf("Failed to get link dae0peer: %v", err)
+		return fmt.Errorf("failed to get link dae0peer: %v", err)
 	}
 	// ip l s dae0 up
 	if err = netlink.LinkSetUp(ns.dae0); err != nil {
-		return fmt.Errorf("Failed to set link dae0 up: %v", err)
+		return fmt.Errorf("failed to set link dae0 up: %v", err)
 	}
 	return
 }
@@ -131,27 +131,27 @@ func (ns *DaeNetns) setupVeth() (err error) {
 func (ns *DaeNetns) setupSysctl() (err error) {
 	// sysctl net.ipv4.conf.dae0.rp_filter=0
 	if err = SetRpFilter(HostVethName, "0"); err != nil {
-		return fmt.Errorf("Failed to set rp_filter for dae0: %v", err)
+		return fmt.Errorf("failed to set rp_filter for dae0: %v", err)
 	}
 	// sysctl net.ipv4.conf.all.rp_filter=0
 	if err = SetRpFilter("all", "0"); err != nil {
-		return fmt.Errorf("Failed to set rp_filter for all: %v", err)
+		return fmt.Errorf("failed to set rp_filter for all: %v", err)
 	}
 	// sysctl net.ipv4.conf.dae0.arp_filter=0
 	if err = SetArpFilter(HostVethName, "0"); err != nil {
-		return fmt.Errorf("Failed to set arp_filter for dae0: %v", err)
+		return fmt.Errorf("failed to set arp_filter for dae0: %v", err)
 	}
 	// sysctl net.ipv4.conf.all.arp_filter=0
 	if err = SetArpFilter("all", "0"); err != nil {
-		return fmt.Errorf("Failed to set arp_filter for all: %v", err)
+		return fmt.Errorf("failed to set arp_filter for all: %v", err)
 	}
 	// sysctl net.ipv4.conf.dae0.accept_local=1
 	if err = SetAcceptLocal(HostVethName, "1"); err != nil {
-		return fmt.Errorf("Failed to set accept_local for dae0: %v", err)
+		return fmt.Errorf("failed to set accept_local for dae0: %v", err)
 	}
 	// sysctl net.ipv6.conf.dae0.disable_ipv6=0
 	if err = SetDisableIpv6(HostVethName, "0"); err != nil {
-		return fmt.Errorf("Failed to set disable_ipv6 for dae0: %v", err)
+		return fmt.Errorf("failed to set disable_ipv6 for dae0: %v", err)
 	}
 	// sysctl net.ipv6.conf.dae0.forwarding=1
 	SetForwarding(HostVethName, "1")
@@ -165,38 +165,38 @@ func (ns *DaeNetns) setupNetns() (err error) {
 	DeleteNamedNetns(NsName)
 	ns.daeNs, err = netns.NewNamed(NsName)
 	if err != nil {
-		return fmt.Errorf("Failed to create netns: %v", err)
+		return fmt.Errorf("failed to create netns: %v", err)
 	}
 	// NewNamed() will switch to the new netns, switch back to host netns
 	if err = netns.Set(ns.hostNs); err != nil {
-		return fmt.Errorf("Failed to switch to host netns: %v", err)
+		return fmt.Errorf("failed to switch to host netns: %v", err)
 	}
 	// ip l s dae0peer netns daens
 	if err = netlink.LinkSetNsFd(ns.dae0peer, int(ns.daeNs)); err != nil {
-		return fmt.Errorf("Failed to move dae0peer to daens: %v", err)
+		return fmt.Errorf("failed to move dae0peer to daens: %v", err)
 	}
 	return
 }
 
 func (ns *DaeNetns) setupIPv4Datapath() (err error) {
 	if err = netns.Set(ns.daeNs); err != nil {
-		return fmt.Errorf("Failed to switch to daens: %v", err)
+		return fmt.Errorf("failed to switch to daens: %v", err)
 	}
 	defer netns.Set(ns.hostNs)
 
 	// (ip net e daens) ip l s dae0peer up
 	if err = netlink.LinkSetUp(ns.dae0peer); err != nil {
-		return fmt.Errorf("Failed to set link dae0peer up: %v", err)
+		return fmt.Errorf("failed to set link dae0peer up: %v", err)
 	}
 	// (ip net e daens) ip a a 169.254.0.11 dev dae0peer
 	// Although transparent UDP socket doesn't use this IP, it's still needed to make proper L3 header
 	ip, ipNet, err := net.ParseCIDR("169.254.0.11/32")
 	ipNet.IP = ip
 	if err != nil {
-		return fmt.Errorf("Failed to parse ip 169.254.0.11: %v", err)
+		return fmt.Errorf("failed to parse ip 169.254.0.11: %v", err)
 	}
 	if err = netlink.AddrAdd(ns.dae0peer, &netlink.Addr{IPNet: ipNet}); err != nil {
-		return fmt.Errorf("Failed to add v4 addr to dae0peer: %v", err)
+		return fmt.Errorf("failed to add v4 addr to dae0peer: %v", err)
 	}
 	// (ip net e daens) ip r a 169.254.0.1 dev dae0peer
 	// 169.254.0.1 is the link-local address used for ARP caching
@@ -206,7 +206,7 @@ func (ns *DaeNetns) setupIPv4Datapath() (err error) {
 		Gw:        nil,
 		Scope:     netlink.SCOPE_LINK,
 	}); err != nil {
-		return fmt.Errorf("Failed to add v4 route1 to dae0peer: %v", err)
+		return fmt.Errorf("failed to add v4 route1 to dae0peer: %v", err)
 	}
 	// (ip net e daens) ip r a default via 169.254.0.1 dev dae0peer
 	if err = netlink.RouteAdd(&netlink.Route{
@@ -214,7 +214,7 @@ func (ns *DaeNetns) setupIPv4Datapath() (err error) {
 		Dst:       &net.IPNet{IP: net.IPv4(0, 0, 0, 0), Mask: net.CIDRMask(0, 32)},
 		Gw:        net.ParseIP("169.254.0.1"),
 	}); err != nil {
-		return fmt.Errorf("Failed to add v4 route2 to dae0peer: %v", err)
+		return fmt.Errorf("failed to add v4 route2 to dae0peer: %v", err)
 	}
 	// (ip net e daens) ip n r 169.254.0.1 dev dae0peer lladdr $mac_dae0 nud permanent
 	return
@@ -229,11 +229,11 @@ func (ns *DaeNetns) setupIPv6Datapath() (err error) {
 			Mask: net.CIDRMask(128, 128),
 		},
 	}); err != nil {
-		return fmt.Errorf("Failed to add v6 addr to dae0: %v", err)
+		return fmt.Errorf("failed to add v6 addr to dae0: %v", err)
 	}
 
 	if err = netns.Set(ns.daeNs); err != nil {
-		return fmt.Errorf("Failed to switch to daens: %v", err)
+		return fmt.Errorf("failed to switch to daens: %v", err)
 	}
 	defer netns.Set(ns.hostNs)
 
@@ -243,7 +243,7 @@ func (ns *DaeNetns) setupIPv6Datapath() (err error) {
 		Dst:       &net.IPNet{IP: net.IPv6zero, Mask: net.CIDRMask(0, 128)},
 		Gw:        net.ParseIP("fe80::ecee:eeff:feee:eeee"),
 	}); err != nil {
-		return fmt.Errorf("Failed to add v6 route to dae0peer: %v", err)
+		return fmt.Errorf("failed to add v6 route to dae0peer: %v", err)
 	}
 	return
 }
@@ -254,7 +254,7 @@ func (ns *DaeNetns) updateNeigh() (err error) {
 	defer runtime.UnlockOSThread()
 
 	if err = netns.Set(ns.daeNs); err != nil {
-		return fmt.Errorf("Failed to switch to daens: %v", err)
+		return fmt.Errorf("failed to switch to daens: %v", err)
 	}
 	defer netns.Set(ns.hostNs)
 
@@ -264,7 +264,7 @@ func (ns *DaeNetns) updateNeigh() (err error) {
 		LinkIndex:    ns.dae0peer.Attrs().Index,
 		State:        netlink.NUD_PERMANENT,
 	}); err != nil {
-		return fmt.Errorf("Failed to add neigh to dae0peer: %v", err)
+		return fmt.Errorf("failed to add neigh to dae0peer: %v", err)
 	}
 	return
 }
@@ -276,10 +276,10 @@ func (ns *DaeNetns) monitorDae0LinkAddr() {
 
 	err := netlink.LinkSubscribe(ch, done)
 	if err != nil {
-		logrus.Errorf("Failed to subscribe link updates: %v", err)
+		logrus.Errorf("failed to subscribe link updates: %v", err)
 	}
 	if err = ns.updateNeigh(); err != nil {
-		logrus.Errorf("Failed to update neigh: %v", err)
+		logrus.Errorf("failed to update neigh: %v", err)
 	}
 	for msg := range ch {
 		if msg.Link.Attrs().Name == HostVethName && !bytes.Equal(msg.Link.Attrs().HardwareAddr, ns.dae0.Attrs().HardwareAddr) {

--- a/control/netns_utils.go
+++ b/control/netns_utils.go
@@ -288,6 +288,9 @@ func (ns *DaeNetns) monitorDae0LinkAddr() {
 	if err != nil {
 		logrus.Errorf("failed to subscribe link updates: %v", err)
 	}
+	if ns.dae0, err = netlink.LinkByName(HostVethName); err != nil {
+		logrus.Errorf("failed to get link dae0: %v", err)
+	}
 	if err = ns.updateNeigh(); err != nil {
 		logrus.Errorf("failed to update neigh: %v", err)
 	}

--- a/control/netns_utils.go
+++ b/control/netns_utils.go
@@ -107,6 +107,10 @@ func setupIndieNetns() (err error) {
 	if err = SetArpFilter("all", "0"); err != nil {
 		return fmt.Errorf("Failed to set arp_filter for all: %v", err)
 	}
+	// sysctl net.ipv4.conf.dae0.accept_local=1
+	if err = SetAcceptLocal("dae0", "1"); err != nil {
+		return fmt.Errorf("Failed to set accept_local for dae0: %v", err)
+	}
 	// sysctl net.ipv6.conf.dae0.disable_ipv6=0
 	if err = SetDisableIpv6("dae0", "0"); err != nil {
 		return fmt.Errorf("Failed to set disable_ipv6 for dae0: %v", err)

--- a/control/netns_utils.go
+++ b/control/netns_utils.go
@@ -1,0 +1,134 @@
+package control
+
+import (
+	"net"
+	"os"
+	"path"
+	"runtime"
+
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
+	"golang.org/x/sys/unix"
+)
+
+var indieNetns netns.NsHandle
+
+func WithIndieNetns(f func() error) (err error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	hostNetns, err := netns.Get()
+	if err != nil {
+		return
+	}
+	defer netns.Set(hostNetns)
+
+	ns, err := GetIndieNetns()
+	if err != nil {
+		return
+	}
+	if err = netns.Set(ns); err != nil {
+		return
+	}
+
+	return f()
+}
+
+func GetIndieNetns() (_ netns.NsHandle, err error) {
+	if indieNetns != 0 {
+		return indieNetns, nil
+	}
+
+	// Setup a new netns
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	hostNetns, err := netns.Get()
+	if err != nil {
+		return
+	}
+	defer netns.Set(hostNetns)
+
+	// ip netns a daens
+	DeleteNamedNetns("daens")
+	indieNetns, err = netns.NewNamed("daens")
+	if err != nil {
+		return
+	}
+	if err = netns.Set(hostNetns); err != nil {
+		return
+	}
+	// ip l a dae0 type veth peer name dae0peer
+	DeleteLink("dae0")
+	if err = netlink.LinkAdd(&netlink.Veth{
+		LinkAttrs: netlink.LinkAttrs{
+			Name: "dae0",
+		},
+		PeerName: "dae0peer",
+	}); err != nil {
+		return
+	}
+	dae0, err := netlink.LinkByName("dae0")
+	if err != nil {
+		return
+	}
+	dae0peer, err := netlink.LinkByName("dae0peer")
+	if err != nil {
+		return
+	}
+	// ip l s dae0 up
+	if err = netlink.LinkSetUp(dae0); err != nil {
+		return
+	}
+	// sysctl net.ipv4.conf.{dae0,all}.rp_filter=0
+	if err = SetRpFilter("dae0", "0"); err != nil {
+		return
+	}
+	if err = SetRpFilter("all", "0"); err != nil {
+		return
+	}
+	// ip l s dae0peer netns daens
+	if err = netlink.LinkSetNsFd(dae0peer, int(indieNetns)); err != nil {
+		return
+	}
+	// ip net e daens
+	if err = netns.Set(indieNetns); err != nil {
+		return
+	}
+	// (ip net e daens) ip l s dae0peer up
+	if err = netlink.LinkSetUp(dae0peer); err != nil {
+		return
+	}
+	// (ip net e daens) ip a a 169.254.0.1 dev dae0peer
+	ip, ipNet, err := net.ParseCIDR("169.254.0.1/24")
+	ipNet.IP = ip
+	if err != nil {
+		return
+	}
+	if err = netlink.AddrAdd(dae0peer, &netlink.Addr{IPNet: ipNet}); err != nil {
+		return
+	}
+	// (ip net e daens) ip r a default dev dae0peer
+	if err = netlink.RouteAdd(&netlink.Route{
+		LinkIndex: dae0peer.Attrs().Index,
+		Dst:       &net.IPNet{IP: net.IPv4(0, 0, 0, 0), Mask: net.CIDRMask(0, 32)},
+		Gw:        nil,
+	}); err != nil {
+		return
+	}
+	return indieNetns, err
+}
+
+func DeleteNamedNetns(name string) error {
+	namedPath := path.Join("/run/netns", name)
+	unix.Unmount(namedPath, unix.MNT_DETACH)
+	return os.Remove(namedPath)
+}
+
+func DeleteLink(name string) error {
+	link, err := netlink.LinkByName(name)
+	if err == nil {
+		return netlink.LinkDel(link)
+	}
+	return err
+}

--- a/control/netns_utils.go
+++ b/control/netns_utils.go
@@ -1,6 +1,7 @@
 package control
 
 import (
+	"bytes"
 	"fmt"
 	"net"
 	"os"
@@ -14,183 +15,273 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-var (
-	daeNetns netns.NsHandle
-	once     sync.Once
+const (
+	NsName       = "daens"
+	HostVethName = "dae0"
+	NsVethName   = "dae0peer"
 )
 
-func WithDaeNetns(f func() error) (err error) {
+var (
+	daeNetns *DaeNetns
+)
+
+type DaeNetns struct {
+	once sync.Once
+
+	dae0, dae0peer netlink.Link
+	hostNs, daeNs  netns.NsHandle
+}
+
+func init() {
+	daeNetns = &DaeNetns{}
+}
+
+func (ns *DaeNetns) Setup() (err error) {
+	if ns.daeNs != 0 && ns.hostNs != 0 {
+		return nil
+	}
+
+	ns.once.Do(func() {
+		if err = ns.setup(); err != nil {
+			logrus.Fatal("Failed to setup dae netns: %v", err)
+		}
+	})
+	return err
+}
+
+func (ns *DaeNetns) With(f func() error) (err error) {
+	if err = daeNetns.Setup(); err != nil {
+		return fmt.Errorf("Failed to setup dae netns: %v", err)
+	}
+
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	hostNetns, err := netns.Get()
-	if err != nil {
-		return fmt.Errorf("Failed to get host netns: %v", err)
-	}
-	defer netns.Set(hostNetns)
-
-	ns, err := GetDaeNetns()
-	if err != nil {
-		return
-	}
-	if err = netns.Set(ns); err != nil {
+	if err = netns.Set(ns.daeNs); err != nil {
 		return fmt.Errorf("Failed to switch to daens: %v", err)
 	}
+	defer netns.Set(ns.hostNs)
 
-	return f()
-}
-
-func GetDaeNetns() (_ netns.NsHandle, err error) {
-	if daeNetns != 0 {
-		return daeNetns, nil
+	if err = f(); err != nil {
+		return fmt.Errorf("Failed to run func in dae netns: %v", err)
 	}
-
-	once.Do(func() {
-		daeNetns, err = setupDaeNetns()
-		if err != nil {
-			once = sync.Once{}
-		}
-	})
-	return daeNetns, err
+	return
 }
 
-func setupDaeNetns() (ns netns.NsHandle, err error) {
+func (ns *DaeNetns) setup() (err error) {
 	logrus.Trace("Setting up dae netns")
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	hostNetns, err := netns.Get()
-	if err != nil {
-		return 0, fmt.Errorf("Failed to get host netns: %v", err)
+	if ns.hostNs, err = netns.Get(); err != nil {
+		return fmt.Errorf("Failed to get host netns: %v", err)
 	}
-	defer netns.Set(hostNetns)
+	defer netns.Set(ns.hostNs)
 
-	// ip netns a daens
-	DeleteNamedNetns("daens")
-	ns, err = netns.NewNamed("daens")
-	if err != nil {
-		return 0, fmt.Errorf("Failed to create netns: %v", err)
+	if err = ns.setupVeth(); err != nil {
+		return
 	}
-	if err = netns.Set(hostNetns); err != nil {
-		return 0, fmt.Errorf("Failed to switch to host netns: %v", err)
+	if err = ns.setupSysctl(); err != nil {
+		return
 	}
+	if err = ns.setupNetns(); err != nil {
+		return
+	}
+	if err = ns.setupIPv4Datapath(); err != nil {
+		return
+	}
+	if err = ns.setupIPv6Datapath(); err != nil {
+		return
+	}
+	go ns.monitorDae0LinkAddr()
+	return
+}
+
+func (ns *DaeNetns) setupVeth() (err error) {
 	// ip l a dae0 type veth peer name dae0peer
-	DeleteLink("dae0")
+	DeleteLink(HostVethName)
 	if err = netlink.LinkAdd(&netlink.Veth{
 		LinkAttrs: netlink.LinkAttrs{
-			Name: "dae0",
+			Name: HostVethName,
 		},
-		PeerName: "dae0peer",
+		PeerName: NsVethName,
 	}); err != nil {
-		return 0, fmt.Errorf("Failed to add veth pair: %v", err)
+		return fmt.Errorf("Failed to add veth pair: %v", err)
 	}
-	dae0, err := netlink.LinkByName("dae0")
-	if err != nil {
-		return 0, fmt.Errorf("Failed to get link dae0: %v", err)
+	if ns.dae0, err = netlink.LinkByName(HostVethName); err != nil {
+		return fmt.Errorf("Failed to get link dae0: %v", err)
 	}
-	dae0peer, err := netlink.LinkByName("dae0peer")
-	if err != nil {
-		return 0, fmt.Errorf("Failed to get link dae0peer: %v", err)
+	if ns.dae0peer, err = netlink.LinkByName(NsVethName); err != nil {
+		return fmt.Errorf("Failed to get link dae0peer: %v", err)
 	}
 	// ip l s dae0 up
-	if err = netlink.LinkSetUp(dae0); err != nil {
-		return 0, fmt.Errorf("Failed to set link dae0 up: %v", err)
+	if err = netlink.LinkSetUp(ns.dae0); err != nil {
+		return fmt.Errorf("Failed to set link dae0 up: %v", err)
 	}
+	return
+}
+
+func (ns *DaeNetns) setupSysctl() (err error) {
 	// sysctl net.ipv4.conf.dae0.rp_filter=0
-	if err = SetRpFilter("dae0", "0"); err != nil {
-		return 0, fmt.Errorf("Failed to set rp_filter for dae0: %v", err)
+	if err = SetRpFilter(HostVethName, "0"); err != nil {
+		return fmt.Errorf("Failed to set rp_filter for dae0: %v", err)
 	}
 	// sysctl net.ipv4.conf.all.rp_filter=0
 	if err = SetRpFilter("all", "0"); err != nil {
-		return 0, fmt.Errorf("Failed to set rp_filter for all: %v", err)
+		return fmt.Errorf("Failed to set rp_filter for all: %v", err)
 	}
 	// sysctl net.ipv4.conf.dae0.arp_filter=0
-	if err = SetArpFilter("dae0", "0"); err != nil {
-		return 0, fmt.Errorf("Failed to set arp_filter for dae0: %v", err)
+	if err = SetArpFilter(HostVethName, "0"); err != nil {
+		return fmt.Errorf("Failed to set arp_filter for dae0: %v", err)
 	}
 	// sysctl net.ipv4.conf.all.arp_filter=0
 	if err = SetArpFilter("all", "0"); err != nil {
-		return 0, fmt.Errorf("Failed to set arp_filter for all: %v", err)
+		return fmt.Errorf("Failed to set arp_filter for all: %v", err)
 	}
 	// sysctl net.ipv4.conf.dae0.accept_local=1
-	if err = SetAcceptLocal("dae0", "1"); err != nil {
-		return 0, fmt.Errorf("Failed to set accept_local for dae0: %v", err)
+	if err = SetAcceptLocal(HostVethName, "1"); err != nil {
+		return fmt.Errorf("Failed to set accept_local for dae0: %v", err)
 	}
 	// sysctl net.ipv6.conf.dae0.disable_ipv6=0
-	if err = SetDisableIpv6("dae0", "0"); err != nil {
-		return 0, fmt.Errorf("Failed to set disable_ipv6 for dae0: %v", err)
+	if err = SetDisableIpv6(HostVethName, "0"); err != nil {
+		return fmt.Errorf("Failed to set disable_ipv6 for dae0: %v", err)
 	}
 	// sysctl net.ipv6.conf.dae0.forwarding=1
-	SetForwarding("dae0", "1")
+	SetForwarding(HostVethName, "1")
 	// sysctl net.ipv6.conf.all.forwarding=1
 	SetForwarding("all", "1")
-	// ip -6 a a fe80::ecee:eeff:feee:eeee dev dae0 scope link
-	if err = netlink.AddrAdd(dae0, &netlink.Addr{
+	return
+}
+
+func (ns *DaeNetns) setupNetns() (err error) {
+	// ip netns a daens
+	DeleteNamedNetns(NsName)
+	ns.daeNs, err = netns.NewNamed(NsName)
+	if err != nil {
+		return fmt.Errorf("Failed to create netns: %v", err)
+	}
+	// NewNamed() will switch to the new netns, switch back to host netns
+	if err = netns.Set(ns.hostNs); err != nil {
+		return fmt.Errorf("Failed to switch to host netns: %v", err)
+	}
+	// ip l s dae0peer netns daens
+	if err = netlink.LinkSetNsFd(ns.dae0peer, int(ns.daeNs)); err != nil {
+		return fmt.Errorf("Failed to move dae0peer to daens: %v", err)
+	}
+	return
+}
+
+func (ns *DaeNetns) setupIPv4Datapath() (err error) {
+	if err = netns.Set(ns.daeNs); err != nil {
+		return fmt.Errorf("Failed to switch to daens: %v", err)
+	}
+	defer netns.Set(ns.hostNs)
+
+	// (ip net e daens) ip l s dae0peer up
+	if err = netlink.LinkSetUp(ns.dae0peer); err != nil {
+		return fmt.Errorf("Failed to set link dae0peer up: %v", err)
+	}
+	// (ip net e daens) ip a a 169.254.0.11 dev dae0peer
+	// Although transparent UDP socket doesn't use this IP, it's still needed to make proper L3 header
+	ip, ipNet, err := net.ParseCIDR("169.254.0.11/32")
+	ipNet.IP = ip
+	if err != nil {
+		return fmt.Errorf("Failed to parse ip 169.254.0.11: %v", err)
+	}
+	if err = netlink.AddrAdd(ns.dae0peer, &netlink.Addr{IPNet: ipNet}); err != nil {
+		return fmt.Errorf("Failed to add v4 addr to dae0peer: %v", err)
+	}
+	// (ip net e daens) ip r a 169.254.0.1 dev dae0peer
+	// 169.254.0.1 is the link-local address used for ARP caching
+	if err = netlink.RouteAdd(&netlink.Route{
+		LinkIndex: ns.dae0peer.Attrs().Index,
+		Dst:       &net.IPNet{IP: net.ParseIP("169.254.0.1"), Mask: net.CIDRMask(32, 32)},
+		Gw:        nil,
+		Scope:     netlink.SCOPE_LINK,
+	}); err != nil {
+		return fmt.Errorf("Failed to add v4 route1 to dae0peer: %v", err)
+	}
+	// (ip net e daens) ip r a default via 169.254.0.1 dev dae0peer
+	if err = netlink.RouteAdd(&netlink.Route{
+		LinkIndex: ns.dae0peer.Attrs().Index,
+		Dst:       &net.IPNet{IP: net.IPv4(0, 0, 0, 0), Mask: net.CIDRMask(0, 32)},
+		Gw:        net.ParseIP("169.254.0.1"),
+	}); err != nil {
+		return fmt.Errorf("Failed to add v4 route2 to dae0peer: %v", err)
+	}
+	// (ip net e daens) ip n r 169.254.0.1 dev dae0peer lladdr $mac_dae0 nud permanent
+	return
+}
+
+func (ns *DaeNetns) setupIPv6Datapath() (err error) {
+	// ip -6 a a fe80::ecee:eeff:feee:eeee/128 dev dae0 scope link
+	// fe80::ecee:eeff:feee:eeee/128 is the link-local address used for L2 NDP addressing
+	if err = netlink.AddrAdd(ns.dae0, &netlink.Addr{
 		IPNet: &net.IPNet{
 			IP:   net.ParseIP("fe80::ecee:eeff:feee:eeee"),
 			Mask: net.CIDRMask(128, 128),
 		},
 	}); err != nil {
-		return 0, fmt.Errorf("Failed to add v6 addr to dae0: %v", err)
+		return fmt.Errorf("Failed to add v6 addr to dae0: %v", err)
 	}
-	// ip l s dae0peer netns daens
-	if err = netlink.LinkSetNsFd(dae0peer, int(ns)); err != nil {
-		return 0, fmt.Errorf("Failed to move dae0peer to daens: %v", err)
+
+	if err = netns.Set(ns.daeNs); err != nil {
+		return fmt.Errorf("Failed to switch to daens: %v", err)
 	}
-	// ip net e daens
-	if err = netns.Set(ns); err != nil {
-		return 0, fmt.Errorf("Failed to switch to daens: %v", err)
-	}
-	// (ip net e daens) ip l s dae0peer up
-	if err = netlink.LinkSetUp(dae0peer); err != nil {
-		return 0, fmt.Errorf("Failed to set link dae0peer up: %v", err)
-	}
-	// (ip net e daens) ip a a 169.254.0.11 dev dae0peer
-	ip, ipNet, err := net.ParseCIDR("169.254.0.11/32")
-	ipNet.IP = ip
-	if err != nil {
-		return 0, fmt.Errorf("Failed to parse ip: %v", err)
-	}
-	if err = netlink.AddrAdd(dae0peer, &netlink.Addr{IPNet: ipNet}); err != nil {
-		return 0, fmt.Errorf("Failed to add v4 addr to dae0peer: %v", err)
-	}
-	// (ip net e daens) ip r a 169.254.0.1 dev dae0peer
-	if err = netlink.RouteAdd(&netlink.Route{
-		LinkIndex: dae0peer.Attrs().Index,
-		Dst:       &net.IPNet{IP: net.ParseIP("169.254.0.1"), Mask: net.CIDRMask(32, 32)},
-		Gw:        nil,
-		Scope:     netlink.SCOPE_LINK,
-	}); err != nil {
-		return 0, fmt.Errorf("Failed to add v4 route1 to dae0peer: %v", err)
-	}
-	// (ip net e daens) ip r a default via 169.254.0.1 dev dae0peer
-	if err = netlink.RouteAdd(&netlink.Route{
-		LinkIndex: dae0peer.Attrs().Index,
-		Dst:       &net.IPNet{IP: net.IPv4(0, 0, 0, 0), Mask: net.CIDRMask(0, 32)},
-		Gw:        net.ParseIP("169.254.0.1"),
-	}); err != nil {
-		return 0, fmt.Errorf("Failed to add v4 route2 to dae0peer: %v", err)
-	}
-	// (ip net e daens) ip n r 169.254.0.1 dev dae0peer lladdr $mac_dae0 nud permanent
-	if err = netlink.NeighAdd(&netlink.Neigh{
-		IP:           net.ParseIP("169.254.0.1"),
-		HardwareAddr: dae0.Attrs().HardwareAddr,
-		LinkIndex:    dae0peer.Attrs().Index,
-		State:        netlink.NUD_PERMANENT,
-	}); err != nil {
-		return 0, fmt.Errorf("Failed to add neigh to dae0peer: %v", err)
-	}
+	defer netns.Set(ns.hostNs)
+
 	// (ip net e daens) ip -6 r a default via fe80::ecee:eeff:feee:eeee dev dae0peer
 	if err = netlink.RouteAdd(&netlink.Route{
-		LinkIndex: dae0peer.Attrs().Index,
+		LinkIndex: ns.dae0peer.Attrs().Index,
 		Dst:       &net.IPNet{IP: net.IPv6zero, Mask: net.CIDRMask(0, 128)},
 		Gw:        net.ParseIP("fe80::ecee:eeff:feee:eeee"),
 	}); err != nil {
-		return 0, fmt.Errorf("Failed to add v6 route to dae0peer: %v", err)
+		return fmt.Errorf("Failed to add v6 route to dae0peer: %v", err)
 	}
-
 	return
+}
+
+// updateNeigh() isn't named as setupNeigh() because it requires runtime.LockOSThread()
+func (ns *DaeNetns) updateNeigh() (err error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	if err = netns.Set(ns.daeNs); err != nil {
+		return fmt.Errorf("Failed to switch to daens: %v", err)
+	}
+	defer netns.Set(ns.hostNs)
+
+	if err = netlink.NeighSet(&netlink.Neigh{
+		IP:           net.ParseIP("169.254.0.1"),
+		HardwareAddr: ns.dae0.Attrs().HardwareAddr,
+		LinkIndex:    ns.dae0peer.Attrs().Index,
+		State:        netlink.NUD_PERMANENT,
+	}); err != nil {
+		return fmt.Errorf("Failed to add neigh to dae0peer: %v", err)
+	}
+	return
+}
+
+func (ns *DaeNetns) monitorDae0LinkAddr() {
+	ch := make(chan netlink.LinkUpdate)
+	done := make(chan struct{})
+	defer close(done)
+
+	err := netlink.LinkSubscribe(ch, done)
+	if err != nil {
+		logrus.Errorf("Failed to subscribe link updates: %v", err)
+	}
+	if err = ns.updateNeigh(); err != nil {
+		logrus.Errorf("Failed to update neigh: %v", err)
+	}
+	for msg := range ch {
+		if msg.Link.Attrs().Name == HostVethName && !bytes.Equal(msg.Link.Attrs().HardwareAddr, ns.dae0.Attrs().HardwareAddr) {
+			logrus.WithField("old addr", ns.dae0.Attrs().HardwareAddr).WithField("new addr", msg.Link.Attrs().HardwareAddr).Info("dae0 link addr changed")
+			ns.dae0 = msg.Link
+			ns.updateNeigh()
+		}
+	}
 }
 
 func DeleteNamedNetns(name string) error {

--- a/control/netns_utils.go
+++ b/control/netns_utils.go
@@ -8,17 +8,18 @@ import (
 	"runtime"
 	"sync"
 
+	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
 	"golang.org/x/sys/unix"
 )
 
 var (
-	indieNetns netns.NsHandle
-	once       sync.Once
+	daeNetns netns.NsHandle
+	once     sync.Once
 )
 
-func WithIndieNetns(f func() error) (err error) {
+func WithDaeNetns(f func() error) (err error) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
@@ -28,7 +29,7 @@ func WithIndieNetns(f func() error) (err error) {
 	}
 	defer netns.Set(hostNetns)
 
-	ns, err := GetIndieNetns()
+	ns, err := GetDaeNetns()
 	if err != nil {
 		return
 	}
@@ -39,35 +40,40 @@ func WithIndieNetns(f func() error) (err error) {
 	return f()
 }
 
-func GetIndieNetns() (_ netns.NsHandle, err error) {
-	if indieNetns != 0 {
-		return indieNetns, nil
+func GetDaeNetns() (_ netns.NsHandle, err error) {
+	if daeNetns != 0 {
+		return daeNetns, nil
 	}
 
 	once.Do(func() {
-		err = setupIndieNetns()
+		daeNetns, err = setupDaeNetns()
+		if err != nil {
+			once = sync.Once{}
+		}
 	})
-	return indieNetns, err
+	return daeNetns, err
 }
 
-func setupIndieNetns() (err error) {
+func setupDaeNetns() (ns netns.NsHandle, err error) {
+	logrus.Trace("Setting up dae netns")
+
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
 	hostNetns, err := netns.Get()
 	if err != nil {
-		return fmt.Errorf("Failed to get host netns: %v", err)
+		return 0, fmt.Errorf("Failed to get host netns: %v", err)
 	}
 	defer netns.Set(hostNetns)
 
 	// ip netns a daens
 	DeleteNamedNetns("daens")
-	indieNetns, err = netns.NewNamed("daens")
+	ns, err = netns.NewNamed("daens")
 	if err != nil {
-		return fmt.Errorf("Failed to create netns: %v", err)
+		return 0, fmt.Errorf("Failed to create netns: %v", err)
 	}
 	if err = netns.Set(hostNetns); err != nil {
-		return fmt.Errorf("Failed to switch to host netns: %v", err)
+		return 0, fmt.Errorf("Failed to switch to host netns: %v", err)
 	}
 	// ip l a dae0 type veth peer name dae0peer
 	DeleteLink("dae0")
@@ -77,43 +83,43 @@ func setupIndieNetns() (err error) {
 		},
 		PeerName: "dae0peer",
 	}); err != nil {
-		return fmt.Errorf("Failed to add veth pair: %v", err)
+		return 0, fmt.Errorf("Failed to add veth pair: %v", err)
 	}
 	dae0, err := netlink.LinkByName("dae0")
 	if err != nil {
-		return fmt.Errorf("Failed to get link dae0: %v", err)
+		return 0, fmt.Errorf("Failed to get link dae0: %v", err)
 	}
 	dae0peer, err := netlink.LinkByName("dae0peer")
 	if err != nil {
-		return fmt.Errorf("Failed to get link dae0peer: %v", err)
+		return 0, fmt.Errorf("Failed to get link dae0peer: %v", err)
 	}
 	// ip l s dae0 up
 	if err = netlink.LinkSetUp(dae0); err != nil {
-		return fmt.Errorf("Failed to set link dae0 up: %v", err)
+		return 0, fmt.Errorf("Failed to set link dae0 up: %v", err)
 	}
 	// sysctl net.ipv4.conf.dae0.rp_filter=0
 	if err = SetRpFilter("dae0", "0"); err != nil {
-		return fmt.Errorf("Failed to set rp_filter for dae0: %v", err)
+		return 0, fmt.Errorf("Failed to set rp_filter for dae0: %v", err)
 	}
 	// sysctl net.ipv4.conf.all.rp_filter=0
 	if err = SetRpFilter("all", "0"); err != nil {
-		return fmt.Errorf("Failed to set rp_filter for all: %v", err)
+		return 0, fmt.Errorf("Failed to set rp_filter for all: %v", err)
 	}
 	// sysctl net.ipv4.conf.dae0.arp_filter=0
 	if err = SetArpFilter("dae0", "0"); err != nil {
-		return fmt.Errorf("Failed to set arp_filter for dae0: %v", err)
+		return 0, fmt.Errorf("Failed to set arp_filter for dae0: %v", err)
 	}
 	// sysctl net.ipv4.conf.all.arp_filter=0
 	if err = SetArpFilter("all", "0"); err != nil {
-		return fmt.Errorf("Failed to set arp_filter for all: %v", err)
+		return 0, fmt.Errorf("Failed to set arp_filter for all: %v", err)
 	}
 	// sysctl net.ipv4.conf.dae0.accept_local=1
 	if err = SetAcceptLocal("dae0", "1"); err != nil {
-		return fmt.Errorf("Failed to set accept_local for dae0: %v", err)
+		return 0, fmt.Errorf("Failed to set accept_local for dae0: %v", err)
 	}
 	// sysctl net.ipv6.conf.dae0.disable_ipv6=0
 	if err = SetDisableIpv6("dae0", "0"); err != nil {
-		return fmt.Errorf("Failed to set disable_ipv6 for dae0: %v", err)
+		return 0, fmt.Errorf("Failed to set disable_ipv6 for dae0: %v", err)
 	}
 	// sysctl net.ipv6.conf.dae0.forwarding=1
 	SetForwarding("dae0", "1")
@@ -126,28 +132,28 @@ func setupIndieNetns() (err error) {
 			Mask: net.CIDRMask(128, 128),
 		},
 	}); err != nil {
-		return fmt.Errorf("Failed to add v6 addr to dae0: %v", err)
+		return 0, fmt.Errorf("Failed to add v6 addr to dae0: %v", err)
 	}
 	// ip l s dae0peer netns daens
-	if err = netlink.LinkSetNsFd(dae0peer, int(indieNetns)); err != nil {
-		return fmt.Errorf("Failed to move dae0peer to daens: %v", err)
+	if err = netlink.LinkSetNsFd(dae0peer, int(ns)); err != nil {
+		return 0, fmt.Errorf("Failed to move dae0peer to daens: %v", err)
 	}
 	// ip net e daens
-	if err = netns.Set(indieNetns); err != nil {
-		return fmt.Errorf("Failed to switch to daens: %v", err)
+	if err = netns.Set(ns); err != nil {
+		return 0, fmt.Errorf("Failed to switch to daens: %v", err)
 	}
 	// (ip net e daens) ip l s dae0peer up
 	if err = netlink.LinkSetUp(dae0peer); err != nil {
-		return fmt.Errorf("Failed to set link dae0peer up: %v", err)
+		return 0, fmt.Errorf("Failed to set link dae0peer up: %v", err)
 	}
 	// (ip net e daens) ip a a 169.254.0.11 dev dae0peer
 	ip, ipNet, err := net.ParseCIDR("169.254.0.11/32")
 	ipNet.IP = ip
 	if err != nil {
-		return fmt.Errorf("Failed to parse ip: %v", err)
+		return 0, fmt.Errorf("Failed to parse ip: %v", err)
 	}
 	if err = netlink.AddrAdd(dae0peer, &netlink.Addr{IPNet: ipNet}); err != nil {
-		return fmt.Errorf("Failed to add v4 addr to dae0peer: %v", err)
+		return 0, fmt.Errorf("Failed to add v4 addr to dae0peer: %v", err)
 	}
 	// (ip net e daens) ip r a 169.254.0.1 dev dae0peer
 	if err = netlink.RouteAdd(&netlink.Route{
@@ -156,7 +162,7 @@ func setupIndieNetns() (err error) {
 		Gw:        nil,
 		Scope:     netlink.SCOPE_LINK,
 	}); err != nil {
-		return fmt.Errorf("Failed to add v4 route1 to dae0peer: %v", err)
+		return 0, fmt.Errorf("Failed to add v4 route1 to dae0peer: %v", err)
 	}
 	// (ip net e daens) ip r a default via 169.254.0.1 dev dae0peer
 	if err = netlink.RouteAdd(&netlink.Route{
@@ -164,7 +170,7 @@ func setupIndieNetns() (err error) {
 		Dst:       &net.IPNet{IP: net.IPv4(0, 0, 0, 0), Mask: net.CIDRMask(0, 32)},
 		Gw:        net.ParseIP("169.254.0.1"),
 	}); err != nil {
-		return fmt.Errorf("Failed to add v4 route2 to dae0peer: %v", err)
+		return 0, fmt.Errorf("Failed to add v4 route2 to dae0peer: %v", err)
 	}
 	// (ip net e daens) ip n r 169.254.0.1 dev dae0peer lladdr $mac_dae0 nud permanent
 	if err = netlink.NeighAdd(&netlink.Neigh{
@@ -173,7 +179,7 @@ func setupIndieNetns() (err error) {
 		LinkIndex:    dae0peer.Attrs().Index,
 		State:        netlink.NUD_PERMANENT,
 	}); err != nil {
-		return fmt.Errorf("Failed to add neigh to dae0peer: %v", err)
+		return 0, fmt.Errorf("Failed to add neigh to dae0peer: %v", err)
 	}
 	// (ip net e daens) ip -6 r a default via fe80::ecee:eeff:feee:eeee dev dae0peer
 	if err = netlink.RouteAdd(&netlink.Route{
@@ -181,7 +187,7 @@ func setupIndieNetns() (err error) {
 		Dst:       &net.IPNet{IP: net.IPv6zero, Mask: net.CIDRMask(0, 128)},
 		Gw:        net.ParseIP("fe80::ecee:eeff:feee:eeee"),
 	}); err != nil {
-		return fmt.Errorf("Failed to add v6 route to dae0peer: %v", err)
+		return 0, fmt.Errorf("Failed to add v6 route to dae0peer: %v", err)
 	}
 
 	return

--- a/control/udp.go
+++ b/control/udp.go
@@ -95,7 +95,7 @@ func sendPkt(data []byte, from netip.AddrPort, realTo, to netip.AddrPort, lConn 
 			WithField("to", to).
 			WithField("realTo", realTo).
 			Trace("Port in use, fallback to use netns.")
-		err = daeNetns.With(func() (err error) {
+		err = GetDaeNetns().With(func() (err error) {
 			uConn, _, err = DefaultAnyfromPool.GetOrCreate(from.String(), AnyfromTimeout)
 			return err
 		})

--- a/control/udp.go
+++ b/control/udp.go
@@ -95,7 +95,7 @@ func sendPkt(data []byte, from netip.AddrPort, realTo, to netip.AddrPort, lConn 
 			WithField("to", to).
 			WithField("realTo", realTo).
 			Trace("Port in use, fallback to use netns.")
-		err = WithIndieNetns(func() (err error) {
+		err = WithDaeNetns(func() (err error) {
 			uConn, _, err = DefaultAnyfromPool.GetOrCreate(from.String(), AnyfromTimeout)
 			return err
 		})

--- a/control/udp.go
+++ b/control/udp.go
@@ -95,7 +95,7 @@ func sendPkt(data []byte, from netip.AddrPort, realTo, to netip.AddrPort, lConn 
 			WithField("to", to).
 			WithField("realTo", realTo).
 			Trace("Port in use, fallback to use netns.")
-		err = WithDaeNetns(func() (err error) {
+		err = daeNetns.With(func() (err error) {
 			uConn, _, err = DefaultAnyfromPool.GetOrCreate(from.String(), AnyfromTimeout)
 			return err
 		})

--- a/control/udp.go
+++ b/control/udp.go
@@ -91,6 +91,10 @@ func sendPkt(data []byte, from netip.AddrPort, realTo, to netip.AddrPort, lConn 
 
 	uConn, _, err := DefaultAnyfromPool.GetOrCreate(from.String(), AnyfromTimeout)
 	if err != nil && errors.Is(err, syscall.EADDRINUSE) {
+		logrus.WithField("from", from).
+			WithField("to", to).
+			WithField("realTo", realTo).
+			Trace("Port in use, fallback to use netns.")
 		err = WithIndieNetns(func() (err error) {
 			uConn, _, err = DefaultAnyfromPool.GetOrCreate(from.String(), AnyfromTimeout)
 			return err

--- a/control/udp.go
+++ b/control/udp.go
@@ -97,7 +97,10 @@ func sendPkt(data []byte, from netip.AddrPort, realTo, to netip.AddrPort, lConn 
 		}
 		return err
 	}
-	_, err = uConn.WriteToUDPAddrPort(data, realTo)
+	err = WithIndieNetns(func() (err error) {
+		_, err = uConn.WriteToUDPAddrPort(data, realTo)
+		return
+	})
 	return err
 }
 

--- a/control/utils.go
+++ b/control/utils.go
@@ -132,6 +132,10 @@ func SetAcceptLocal(ifname, val string) error {
 	return os.WriteFile(fmt.Sprintf("/proc/sys/net/ipv4/conf/%s/accept_local", ifname), []byte(val), 0644)
 }
 
+func SetRpFilter(ifname, val string) error {
+	return os.WriteFile(fmt.Sprintf("/proc/sys/net/ipv4/conf/%s/rp_filter", ifname), []byte(val), 0644)
+}
+
 func checkSendRedirects(ifname string, ipversion consts.IpVersionStr) error {
 	path := fmt.Sprintf("/proc/sys/net/ipv%v/conf/%v/send_redirects", ipversion, ifname)
 	b, err := os.ReadFile(path)

--- a/control/utils.go
+++ b/control/utils.go
@@ -136,6 +136,14 @@ func SetRpFilter(ifname, val string) error {
 	return os.WriteFile(fmt.Sprintf("/proc/sys/net/ipv4/conf/%s/rp_filter", ifname), []byte(val), 0644)
 }
 
+func SetArpFilter(ifname, val string) error {
+	return os.WriteFile(fmt.Sprintf("/proc/sys/net/ipv4/conf/%s/arp_filter", ifname), []byte(val), 0644)
+}
+
+func SetDisableIpv6(ifname, val string) error {
+	return os.WriteFile(fmt.Sprintf("/proc/sys/net/ipv6/conf/%s/disable_ipv6", ifname), []byte(val), 0644)
+}
+
 func checkSendRedirects(ifname string, ipversion consts.IpVersionStr) error {
 	path := fmt.Sprintf("/proc/sys/net/ipv%v/conf/%v/send_redirects", ipversion, ifname)
 	b, err := os.ReadFile(path)


### PR DESCRIPTION
### Background

Setup an independent netns for transparent UDP socket if necessary (EADDRINUSE occurred).

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->


### Test Result

<!--- Attach test result here. -->
