### PR TITLE
fix/docs: fix the first check failure and possible dns leaking

### DIFF
--- a/component/outbound/dialer/connectivity_check.go
+++ b/component/outbound/dialer/connectivity_check.go
@@ -272,10 +272,10 @@ type CheckOption struct {
 func (d *Dialer) ActivateCheck() {
 	d.tickerMu.Lock()
 	defer d.tickerMu.Unlock()
-	if d.InstanceOption.CheckEnabled {
+	if d.InstanceOption.DisableCheck || d.checkActivated {
 		return
 	}
-	d.InstanceOption.CheckEnabled = true
+	d.checkActivated = true
 	go d.aliveBackground()
 }
 

--- a/component/outbound/dialer/dialer.go
+++ b/component/outbound/dialer/dialer.go
@@ -35,6 +35,8 @@ type Dialer struct {
 	checkCh  chan time.Time
 	ctx      context.Context
 	cancel   context.CancelFunc
+
+	checkActivated bool
 }
 
 type GlobalOption struct {
@@ -48,7 +50,7 @@ type GlobalOption struct {
 }
 
 type InstanceOption struct {
-	CheckEnabled bool
+	DisableCheck bool
 }
 
 type Property struct {
@@ -77,9 +79,6 @@ func NewDialer(dialer netproxy.Dialer, option *GlobalOption, iOption InstanceOpt
 		checkCh:          make(chan time.Time, 1),
 		ctx:              ctx,
 		cancel:           cancel,
-	}
-	if iOption.CheckEnabled {
-		go d.aliveBackground()
 	}
 	return d
 }

--- a/component/outbound/dialer_group_test.go
+++ b/component/outbound/dialer_group_test.go
@@ -30,7 +30,7 @@ var log = logger.NewLogger("trace", false, nil)
 
 func newDirectDialer(option *dialer.GlobalOption, fullcone bool) *dialer.Dialer {
 	_d, p := dialer.NewDirectDialer(option, true)
-	d := dialer.NewDialer(_d, option, dialer.InstanceOption{CheckEnabled: false}, p)
+	d := dialer.NewDialer(_d, option, dialer.InstanceOption{DisableCheck: false}, p)
 	return d
 }
 

--- a/component/outbound/filter.go
+++ b/component/outbound/filter.go
@@ -39,7 +39,7 @@ func NewDialerSetFromLinks(option *dialer.GlobalOption, tagToNodeList map[string
 	}
 	for subscriptionTag, nodes := range tagToNodeList {
 		for _, node := range nodes {
-			d, err := dialer.NewFromLink(option, dialer.InstanceOption{CheckEnabled: false}, node, subscriptionTag)
+			d, err := dialer.NewFromLink(option, dialer.InstanceOption{DisableCheck: false}, node, subscriptionTag)
 			if err != nil {
 				option.Log.Infof("failed to parse node: %v", err)
 				continue

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -253,9 +253,9 @@ func NewControlPlane(
 	}
 	disableKernelAliveCallback := dialMode != consts.DialMode_Ip
 	_direct, directProperty := dialer.NewDirectDialer(option, true)
-	direct := dialer.NewDialer(_direct, option, dialer.InstanceOption{CheckEnabled: false}, directProperty)
+	direct := dialer.NewDialer(_direct, option, dialer.InstanceOption{DisableCheck: true}, directProperty)
 	_block, blockProperty := dialer.NewBlockDialer(option, func() { /*Dialer Outbound*/ })
-	block := dialer.NewDialer(_block, option, dialer.InstanceOption{CheckEnabled: false}, blockProperty)
+	block := dialer.NewDialer(_block, option, dialer.InstanceOption{DisableCheck: true}, blockProperty)
 	outbounds := []*outbound.DialerGroup{
 		outbound.NewDialerGroup(option, consts.OutboundDirect.String(),
 			[]*dialer.Dialer{direct}, []*dialer.Annotation{{}},

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -195,7 +195,7 @@ group {
 
 # See https://github.com/daeuniverse/dae/blob/main/docs/en/configuration/routing.md for full examples.
 routing {
-  pname(NetworkManager, systemd-resolved, dnsmasq) -> must_direct
+  pname(NetworkManager) -> direct
   dip(224.0.0.0/3, 'ff00::/8') -> direct
 
   ### Write your rules below.

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -189,7 +189,7 @@ group {
 
 # 更多的 Routing 样例见 https://github.com/daeuniverse/dae/blob/main/docs/en/configuration/routing.md
 routing {
-  pname(NetworkManager, systemd-resolved, dnsmasq) -> must_direct
+  pname(NetworkManager) -> direct
   dip(224.0.0.0/3, 'ff00::/8') -> direct
 
   ### 以下为自定义规则

--- a/example.dae
+++ b/example.dae
@@ -143,20 +143,30 @@ dns {
         # According to the request of dns query, decide to use which DNS upstream.
         # Match rules from top to bottom.
         request {
+            # Lookup China mainland domains using alidns, otherwise googledns.
+            qname(geosite:cn) -> alidns
             # fallback is also called default.
-            fallback: alidns
-        }
-        # According to the response of dns query, decide to accept or re-lookup using another DNS upstream.
-        # Match rules from top to bottom.
-        response {
-            # Trusted upstream. Always accept its result.
-            upstream(googledns) -> accept
-            # Possibly polluted, re-lookup using googledns.
-            ip(geoip:private) && !qname(geosite:cn) -> googledns
-            # fallback is also called default.
-            fallback: accept
+            fallback: googledns
         }
     }
+#    routing {
+#        # According to the request of dns query, decide to use which DNS upstream.
+#        # Match rules from top to bottom.
+#        request {
+#            # fallback is also called default.
+#            fallback: alidns
+#        }
+#        # According to the response of dns query, decide to accept or re-lookup using another DNS upstream.
+#        # Match rules from top to bottom.
+#        response {
+#            # Trusted upstream. Always accept its result.
+#            upstream(googledns) -> accept
+#            # Possibly polluted, re-lookup using googledns.
+#            ip(geoip:private) && !qname(geosite:cn) -> googledns
+#            # fallback is also called default.
+#            fallback: accept
+#        }
+#    }
 }
 
 # Node group (outbound).
@@ -201,9 +211,6 @@ routing {
     # Network managers in localhost should be direct to avoid false negative network connectivity check when binding to
     # WAN.
     pname(NetworkManager) -> direct
-
-    # Bypass DNS stubs. We want to bypass their DNS requests, thus use 'must'.
-    pname(systemd-resolved, dnsmasq) -> must_direct
 
     # Put it in the front to prevent broadcast, multicast and other packets that should be sent to the LAN from being
     # forwarded by the proxy.


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

When local dns server is listening at :53 and resolv.conf points to it, the first connectivity check will fail. This is because when we use the local dns server to resolve the domain name of the node, the dae is not yet listening, but the ebpf program has been installed and dns request is redirected to dae, so the first dns request will fail.

If we add local dns servers to must_direct list, dns leaking possibly occurs.

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- Activate connectivity check after listening to avoid the first failure.
- Update docs and don't add these dns servers to must_direct list.

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
<img width="930" alt="image" src="https://github.com/daeuniverse/dae/assets/30586220/f5a2cc2f-9832-4d84-a39b-abd82965660d">
