### PR TITLE
feat: support to auto config firewall (firewalld)

### DIFF
--- a/common/consts/ebpf.go
+++ b/common/consts/ebpf.go
@@ -157,9 +157,10 @@ var (
 )
 
 const (
-	TproxyMark      uint32 = 0x8000000
-	Recognize       uint16 = 0x2017
-	LoopbackIfIndex        = 1
+	TproxyMark       uint32 = 0x08000000
+	TproxyMarkString string = "0x08000000" // Should be aligned with nftables
+	Recognize        uint16 = 0x2017
+	LoopbackIfIndex         = 1
 )
 
 type LanWanFlag uint8

--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,7 @@ type Global struct {
 	DialMode                  string        `mapstructure:"dial_mode" default:"domain"`
 	DisableWaitingNetwork     bool          `mapstructure:"disable_waiting_network" default:"false"`
 	AutoConfigKernelParameter bool          `mapstructure:"auto_config_kernel_parameter" default:"false"`
+	AutoConfigFirewallRule    bool          `mapstructure:"auto_config_firewall_rule" default:"false"`
 	SniffingTimeout           time.Duration `mapstructure:"sniffing_timeout" default:"100ms"`
 	TlsImplementation         string        `mapstructure:"tls_implementation" default:"tls"`
 	UtlsImitate               string        `mapstructure:"utls_imitate" default:"chrome_auto"`

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -198,6 +198,9 @@ func NewControlPlane(
 		if err = core.setupRoutingPolicy(); err != nil {
 			return nil, err
 		}
+		if err = core.addAcceptInputMark(); err == nil {
+			core.deferFuncs = append(core.deferFuncs, core.delAcceptInputMark)
+		}
 	}
 
 	/// Bind to links. Binding should be advance of dialerGroups to avoid un-routable old connection.

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -198,8 +198,10 @@ func NewControlPlane(
 		if err = core.setupRoutingPolicy(); err != nil {
 			return nil, err
 		}
-		if err = core.addAcceptInputMark(); err == nil {
-			core.deferFuncs = append(core.deferFuncs, core.delAcceptInputMark)
+		if global.AutoConfigFirewallRule {
+			if err = core.addAcceptInputMark(); err == nil {
+				core.deferFuncs = append(core.deferFuncs, core.delAcceptInputMark)
+			}
 		}
 	}
 

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -199,11 +199,12 @@ func NewControlPlane(
 			return nil, err
 		}
 		if global.AutoConfigFirewallRule {
-			core.addAcceptInputMark()
-			core.deferFuncs = append(core.deferFuncs, func() error {
-				core.delAcceptInputMark()
-				return nil
-			})
+			if ok := core.addAcceptInputMark(); ok {
+				core.deferFuncs = append(core.deferFuncs, func() error {
+					core.delAcceptInputMark()
+					return nil
+				})
+			}
 		}
 	}
 

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -199,9 +199,11 @@ func NewControlPlane(
 			return nil, err
 		}
 		if global.AutoConfigFirewallRule {
-			if err = core.addAcceptInputMark(); err == nil {
-				core.deferFuncs = append(core.deferFuncs, core.delAcceptInputMark)
-			}
+			core.addAcceptInputMark()
+			core.deferFuncs = append(core.deferFuncs, func() error {
+				core.delAcceptInputMark()
+				return nil
+			})
 		}
 	}
 

--- a/control/control_plane_core.go
+++ b/control/control_plane_core.go
@@ -196,7 +196,7 @@ func (c *controlPlaneCore) delQdisc(ifname string) error {
 
 func (c *controlPlaneCore) addAcceptInputMark() error {
 	// TODO: Support more than firewalld.
-	return exec.Command("sh", "-c", "nft list table inet firewalld && nft 'insert rule inet firewalld filter_INPUT mark "+consts.TproxyMarkString+" accept'").Run()
+	return exec.Command("sh", "-c", "nft list table inet firewalld && nft 'insert rule inet firewalld filter_INPUT mark & "+consts.TproxyMarkString+" == "+consts.TproxyMarkString+" accept'").Run()
 }
 
 func (c *controlPlaneCore) delAcceptInputMark() error {
@@ -205,7 +205,7 @@ func (c *controlPlaneCore) delAcceptInputMark() error {
 		return err
 	}
 	lines := strings.Split(string(output), "\n")
-	regex := regexp.MustCompile("meta mark " + consts.TproxyMarkString + " accept # handle ([0-9]+)")
+	regex := regexp.MustCompile("meta mark & " + consts.TproxyMarkString + " == " + consts.TproxyMarkString + " accept # handle ([0-9]+)")
 	for _, line := range lines {
 		matches := regex.FindStringSubmatch(line)
 		if len(matches) >= 2 {

--- a/control/control_plane_core.go
+++ b/control/control_plane_core.go
@@ -12,7 +12,9 @@ import (
 	"net"
 	"net/netip"
 	"os"
+	"os/exec"
 	"regexp"
+	"strings"
 	"sync"
 
 	"github.com/cilium/ebpf"
@@ -190,6 +192,28 @@ func (c *controlPlaneCore) delQdisc(ifname string) error {
 		}
 	}
 	return nil
+}
+
+func (c *controlPlaneCore) addAcceptInputMark() error {
+	// TODO: Support more than firewalld.
+	return exec.Command("sh", "-c", "nft list table inet firewalld && nft 'insert rule inet firewalld filter_INPUT mark "+consts.TproxyMarkString+" accept'").Run()
+}
+
+func (c *controlPlaneCore) delAcceptInputMark() error {
+	output, err := exec.Command("sh", "-c", "nft --handle --numeric list chain inet firewalld filter_INPUT").Output()
+	if err != nil {
+		// No firewalld.
+		return nil
+	}
+	lines := strings.Split(string(output), "\n")
+	regex := regexp.MustCompile("meta mark " + consts.TproxyMarkString + " accept # handle ([0-9]+)")
+	for _, line := range lines {
+		matches := regex.FindStringSubmatch(line)
+		if len(matches) > 0 {
+			return exec.Command("sh", "-c", "nft 'delete rule inet firewalld filter_INPUT handle "+matches[1]+"'").Run()
+		}
+	}
+	return fmt.Errorf("no such rule")
 }
 
 func (c *controlPlaneCore) setupRoutingPolicy() (err error) {

--- a/control/control_plane_core.go
+++ b/control/control_plane_core.go
@@ -208,8 +208,9 @@ func (c *controlPlaneCore) delAcceptInputMark() error {
 	regex := regexp.MustCompile("meta mark " + consts.TproxyMarkString + " accept # handle ([0-9]+)")
 	for _, line := range lines {
 		matches := regex.FindStringSubmatch(line)
-		if len(matches) > 0 {
-			return exec.Command("sh", "-c", "nft 'delete rule inet firewalld filter_INPUT handle "+matches[1]+"'").Run()
+		if len(matches) >= 2 {
+			handle := matches[1]
+			return exec.Command("sh", "-c", "nft 'delete rule inet firewalld filter_INPUT handle "+handle+"'").Run()
 		}
 	}
 	return fmt.Errorf("no such rule")

--- a/control/control_plane_core.go
+++ b/control/control_plane_core.go
@@ -202,8 +202,7 @@ func (c *controlPlaneCore) addAcceptInputMark() error {
 func (c *controlPlaneCore) delAcceptInputMark() error {
 	output, err := exec.Command("sh", "-c", "nft --handle --numeric list chain inet firewalld filter_INPUT").Output()
 	if err != nil {
-		// No firewalld.
-		return nil
+		return err
 	}
 	lines := strings.Split(string(output), "\n")
 	regex := regexp.MustCompile("meta mark " + consts.TproxyMarkString + " accept # handle ([0-9]+)")

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -162,6 +162,7 @@ global {
   log_level: info
   allow_insecure: false
   auto_config_kernel_parameter: true
+  auto_config_firewall_rule: true
 }
 
 subscription {

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -156,6 +156,7 @@ global {
   log_level: info
   allow_insecure: false
   auto_config_kernel_parameter: true
+  auto_config_firewall_rule: true
 }
 
 subscription {

--- a/example.dae
+++ b/example.dae
@@ -34,6 +34,9 @@ global {
     # https://github.com/daeuniverse/dae/blob/main/docs/en/user-guide/kernel-parameters.md to see what will dae do.
     auto_config_kernel_parameter: true
 
+    # Automatically configure firewall rules like firewalld.
+    # For example: nft list table inet firewalld && nft 'insert rule inet firewalld filter_INPUT mark 0x8000000 accept'
+    auto_config_firewall_rule: true
 
     ##### Node connectivity check.
 

--- a/example.dae
+++ b/example.dae
@@ -34,8 +34,9 @@ global {
     # https://github.com/daeuniverse/dae/blob/main/docs/en/user-guide/kernel-parameters.md to see what will dae do.
     auto_config_kernel_parameter: true
 
-    # Automatically configure firewall rules like firewalld.
-    # For example: nft list table inet firewalld && nft 'insert rule inet firewalld filter_INPUT mark 0x8000000 accept'
+    # Automatically configure firewall rules like firewalld and fw4.
+    # firewalld: nft 'insert rule inet firewalld filter_INPUT mark 0x08000000 accept'
+    # fw4: nft 'insert rule inet fw4 input mark 0x08000000 accept'
     auto_config_firewall_rule: true
 
     ##### Node connectivity check.


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

```
global {
  auto_config_firewall_rule: true
}
```

It performs:

```
nft list table inet firewalld && nft 'insert rule inet firewalld filter_INPUT mark & 0x08000000 == 0x08000000 accept'
```

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #419

### Test Result

<!--- Attach test result here. -->
