### PR TITLE
optimize: avoid conflict with potential local dns server

### DIFF
--- a/control/anyfrom_pool.go
+++ b/control/anyfrom_pool.go
@@ -202,8 +202,8 @@ func (p *AnyfromPool) GetOrCreate(lAddr string, ttl time.Duration) (conn *Anyfro
 			gotGSOError:   false,
 			gso:           isGSOSupported(uConn),
 		}
-		// Add port 53 (udp) to whitelist to avoid confliction with the potential local dns server.
-		if uConn.LocalAddr().(*net.UDPAddr).Port != 53 {
+
+		if ttl > 0 {
 			af.deadlineTimer = time.AfterFunc(ttl, func() {
 				p.mu.Lock()
 				defer p.mu.Unlock()

--- a/control/anyfrom_pool.go
+++ b/control/anyfrom_pool.go
@@ -38,7 +38,9 @@ func (a *Anyfrom) afterWrite(err error) {
 	a.RefreshTtl()
 }
 func (a *Anyfrom) RefreshTtl() {
-	a.deadlineTimer.Reset(a.ttl)
+	if a.deadlineTimer != nil {
+		a.deadlineTimer.Reset(a.ttl)
+	}
 }
 func (a *Anyfrom) SupportGso(size int) bool {
 	if size > math.MaxUint16 {

--- a/control/udp.go
+++ b/control/udp.go
@@ -89,7 +89,12 @@ func sendPkt(data []byte, from netip.AddrPort, realTo, to netip.AddrPort, lConn 
 		return sendPktWithHdrWithFlag(data, from, lConn, to, lanWanFlag)
 	}
 
-	uConn, _, err := DefaultAnyfromPool.GetOrCreate(from.String(), AnyfromTimeout)
+	transparentTimeout := AnyfromTimeout
+	if from.Port() == 53 {
+		// Add port 53 (udp) to whitelist to avoid confliction with the potential local dns server.
+		transparentTimeout = 0
+	}
+	uConn, _, err := DefaultAnyfromPool.GetOrCreate(from.String(), transparentTimeout)
 	if err != nil && errors.Is(err, syscall.EADDRINUSE) {
 		logrus.WithField("from", from).
 			WithField("to", to).

--- a/control/udp.go
+++ b/control/udp.go
@@ -91,7 +91,7 @@ func sendPkt(data []byte, from netip.AddrPort, realTo, to netip.AddrPort, lConn 
 
 	transparentTimeout := AnyfromTimeout
 	if from.Port() == 53 {
-		// Add port 53 (udp) to whitelist to avoid confliction with the potential local dns server.
+		// Add port 53 (udp) to whitelist to avoid conflicts with the potential local dns server.
 		transparentTimeout = 0
 	}
 	uConn, _, err := DefaultAnyfromPool.GetOrCreate(from.String(), transparentTimeout)


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

class `Anyfrom` cache udp socket for 5 seconds, which may conflict with local dns server and make them fail in serving and listening.

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- Add port 53 to whitelist and do not cache it.

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #412

### Test Result

<!--- Attach test result here. -->
