### PR TITLE
fix: Create DaeNetns instance strictly once on reload

### DIFF
--- a/control/netns_utils.go
+++ b/control/netns_utils.go
@@ -24,6 +24,7 @@ const (
 
 var (
 	daeNetns *DaeNetns
+	once     sync.Once
 )
 
 type DaeNetns struct {
@@ -37,9 +38,10 @@ type DaeNetns struct {
 }
 
 func InitDaeNetns(log *logrus.Logger) {
-	daeNetns = &DaeNetns{
-		log: log,
-	}
+	once.Do(func() {
+		daeNetns = &DaeNetns{}
+	})
+	daeNetns.log = log
 }
 
 func GetDaeNetns() *DaeNetns {


### PR DESCRIPTION
### Background

Previously DaeNetns instance can be re-created on reload, breaking the singleton pattern. This PR fixes it by introducing sync.Once.

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
