### PR TITLE
ci(Makefile): enable trace module by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ else
 	STRIP_FLAG := -strip=$(STRIP_PATH)
 endif
 
+GOARCH ?= $(shell go env GOARCH)
+
 # Do NOT remove the line below. This line is for CI.
 #export GOMODCACHE=$(PWD)/go-mod
 


### PR DESCRIPTION
ci(Makefile): add back `GOARCH ?=$(shell go env GOARCH)` to enable trace module by default

<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- [Implement ...]

### Issue Reference
 https://github.com/daeuniverse/dae/issues/453#issuecomment-1925659736
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
