### PR TITLE
docs: Replace http to https for `tcp_check_url` in `example.dae` to avoid some pollution I don't know

### DIFF
--- a/example.dae
+++ b/example.dae
@@ -44,8 +44,8 @@ global {
     # Host of URL should have both IPv4 and IPv6 if you have double stack in local.
     # First is URL, others are IP addresses if given.
     # Considering traffic consumption, it is recommended to choose a site with anycast IP and less response.
-    #tcp_check_url: 'http://cp.cloudflare.com'
-    tcp_check_url: 'http://cp.cloudflare.com,1.1.1.1,2606:4700:4700::1111'
+    #tcp_check_url: 'https://cp.cloudflare.com'
+    tcp_check_url: 'https://cp.cloudflare.com,1.1.1.1,2606:4700:4700::1111'
 
     # The HTTP request method to `tcp_check_url`. Use 'HEAD' by default because some server implementations bypass
     # accounting for this kind of traffic.


### PR DESCRIPTION
# Background

There are two node, named A and B, all of them are relay node to HK.

# Problem

Sometimes I find that A can't access the website like Google or Facebook but was selected cause It's latency result is faster.

Then I realized that `tcp_check_url`, which is `http://cp.cloudflare.com` could be polluted to another IP thus dae thought A can connect to `tcp_check_url` but not in fact.

# Solution

So I made this pull request, to make `tcp_check_url` become `https` in `example.dae`, which can avoid the situation I met.