### PR TITLE
ci: update ci modules using nodejs to latest

### DIFF
--- a/.github/workflows/kernel-test.yml
+++ b/.github/workflows/kernel-test.yml
@@ -15,11 +15,14 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
+      uses: actions/setup-go@v5
       with:
+        cache-dependency-path: |
+          go.mod
+          go.sum
         go-version: 1.21.0
 
     - name: Generate and build

--- a/.github/workflows/kernel-test.yml
+++ b/.github/workflows/kernel-test.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Retrieve stored executable
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dae
           path: dae

--- a/.github/workflows/kernel-test.yml
+++ b/.github/workflows/kernel-test.yml
@@ -28,7 +28,7 @@ jobs:
         make GOFLAGS="-buildvcs=false" CC=clang
 
     - name: Store executable
-      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+      uses: actions/upload-artifact@v4
       with:
         name: dae
         path: dae

--- a/.github/workflows/kernel-test.yml
+++ b/.github/workflows/kernel-test.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Retrieve stored executable
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.4
         with:
           name: dae
           path: dae

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -145,7 +145,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.4
         with:
           path: release/
 

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -129,13 +129,13 @@ jobs:
 
 #       - name: Upload full source to Artifacts
 #         if: matrix.goarch == 'arm64'
-#         uses: actions/upload-artifact@v3
+#         uses: actions/upload-artifact@v4
 #         with:
 #           name: dae-full-src.zip
 #           path: dae-full-src.zip
 
       - name: Upload files to Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dae-${{ steps.get_filename.outputs.ASSET_NAME }}.zip
           path: ./*.zip*
@@ -145,7 +145,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: release/
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.4
         with:
           path: release/
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,8 +71,11 @@ jobs:
           echo "ASSET_NAME=$_NAME" >> $GITHUB_ENV
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
+          cache-dependency-path: |
+            go.mod
+            go.sum          
           go-version: '^1.21'
 
       - name: Install Dependencies
@@ -128,7 +131,7 @@ jobs:
           echo "$(shasum -a 512 $FILE)""  sha512" >> $FILE.dgst
 
       - name: Upload files to Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dae-${{ steps.get_filename.outputs.ASSET_NAME }}.zip
           path: ./*.zip*
@@ -138,7 +141,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: release/
 

--- a/.github/workflows/seed-build.yml
+++ b/.github/workflows/seed-build.yml
@@ -97,8 +97,11 @@ jobs:
           echo "ASSET_NAME=$_NAME" >> $GITHUB_ENV
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
+          cache-dependency-path: |
+            go.mod
+            go.sum          
           go-version: '^1.21'
 
       - name: Install Dependencies
@@ -132,7 +135,7 @@ jobs:
         run: ./build/dae-$ASSET_NAME --version
 
       - name: Upload files to Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dae-${{ steps.get_filename.outputs.ASSET_NAME }}
           path: build/*

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -66,7 +66,7 @@ jobs:
           ref: master
 
       - name: Copy artifacts from build job to local path
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.4
         with:
           name: pre_flight_artifacts
           path: docs/

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -47,7 +47,7 @@ jobs:
           python3 hack/ci/config-doc-generator.py
 
       - name: Export artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pre_flight_artifacts
           path: |
@@ -66,7 +66,7 @@ jobs:
           ref: master
 
       - name: Copy artifacts from build job to local path
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: pre_flight_artifacts
           path: docs/


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

Node.js 16 is no longer supported by GitHub, we need to update the corresponding modules to a version based on Node.js 20.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
