### PR TITLE
patch/optimize(bpf): improve lan hijack datapath performance

### DIFF
--- a/.github/workflows/kernel-test.yml
+++ b/.github/workflows/kernel-test.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kernel: [ '5.10-20240201.165956', '5.15-20240201.165956', '6.1-20240201.165956', 'bpf-next-20240204.012837' ]
+        kernel: [ '5.10-20240305.092417', '5.15-20240305.092417', '6.1-20240305.092417', '6.6-20240305.092417' ]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11

--- a/control/kern/tproxy.c
+++ b/control/kern/tproxy.c
@@ -836,24 +836,6 @@ static __always_inline __u32 get_link_h_len(__u32 ifindex,
 }
 
 static __always_inline int
-lookup_and_assign_tcp_established(struct __sk_buff *skb, struct bpf_sock_tuple *tuple, __u32 len)
-{
-	int ret = -1;
-	struct bpf_sock *sk = bpf_skc_lookup_tcp(skb, tuple, len, BPF_F_CURRENT_NETNS, 0);
-	if (!sk)
-		return -1;
-
-	if (sk->state == BPF_TCP_LISTEN || sk->state == BPF_TCP_TIME_WAIT) {
-		goto release;
-	}
-
-	ret = bpf_sk_assign(skb, sk, 0);
-release:
-	bpf_sk_release(sk);
-	return ret;
-}
-
-static __always_inline int
 assign_listener(struct __sk_buff *skb, __u8 l4proto)
 {
 	struct bpf_sock *sk;
@@ -873,7 +855,8 @@ assign_listener(struct __sk_buff *skb, __u8 l4proto)
 static __always_inline int
 redirect_to_control_plane(struct __sk_buff *skb, __u32 link_h_len,
 			  struct tuples *tuples, __u8 l4proto,
-			  struct ethhdr *ethh, __u8 from_wan) {
+			  struct ethhdr *ethh, __u8 from_wan,
+			  struct tcphdr *tcph) {
 
   /* Redirect from L3 dev to L2 dev, e.g. wg0 -> veth */
   if (!link_h_len) {
@@ -903,6 +886,10 @@ redirect_to_control_plane(struct __sk_buff *skb, __u32 link_h_len,
   bpf_map_update_elem(&redirect_track, &redirect_tuple, &redirect_entry, BPF_ANY);
 
   skb->cb[0] = TPROXY_MARK;
+  skb->cb[1] = 0;
+  if ((l4proto == IPPROTO_TCP && tcph->syn) || l4proto == IPPROTO_UDP) {
+    skb->cb[1] = l4proto;
+  }
   return bpf_redirect(PARAM.dae0_ifindex, 0);
 }
 
@@ -1071,7 +1058,7 @@ new_connection:
 
   // Assign to control plane.
 control_plane:
-  return redirect_to_control_plane(skb, link_h_len, &tuples, l4proto, &ethh, 0);
+  return redirect_to_control_plane(skb, link_h_len, &tuples, l4proto, &ethh, 0, &tcph);
 
 direct:
   return TC_ACT_OK;
@@ -1369,72 +1356,31 @@ int tproxy_wan_egress(struct __sk_buff *skb) {
 
   }
 
-  return redirect_to_control_plane(skb, link_h_len, &tuples, l4proto, &ethh, 1);
+  return redirect_to_control_plane(skb, link_h_len, &tuples, l4proto, &ethh, 1, &tcph);
 }
 
 SEC("tc/dae0peer_ingress")
 int tproxy_dae0peer_ingress(struct __sk_buff *skb) {
-  struct ethhdr ethh;
-  struct iphdr iph;
-  struct ipv6hdr ipv6h;
-  struct icmp6hdr icmp6h;
-  struct tcphdr tcph;
-  struct udphdr udph;
-  __u8 ihl;
-  __u8 l4proto;
-  __u32 link_h_len = 14;
-
+  /* Only packets redirected from wan_egress or lan_ingress have this cb mark. */
   if (skb->cb[0] != TPROXY_MARK) {
     return TC_ACT_SHOT;
   }
 
-  int ret = parse_transport(skb, link_h_len, &ethh, &iph, &ipv6h, &icmp6h,
-                            &tcph, &udph, &ihl, &l4proto);
-  if (ret) {
-    return TC_ACT_OK;
-  }
-  if (l4proto == IPPROTO_ICMPV6) {
-    return TC_ACT_OK;
-  }
-
-  struct tuples tuples;
-  get_tuples(skb, &tuples, &iph, &ipv6h, &tcph, &udph, l4proto);
-
+  /* ip rule add fwmark 0x8000000/0x8000000 table 2023
+   * ip route add local default dev lo table 2023
+   */
   skb->mark = TPROXY_MARK;
   bpf_skb_change_type(skb, PACKET_HOST);
 
-  /* First look for established socket.
-   * This is done for TCP only, otherwise bpf_sk_lookup_udp would find
-   * previously created transparent socket for UDP, which is not what we want.
-   * */
-  if (l4proto == IPPROTO_TCP) {
-    __u32 tuple_size;
-    struct bpf_sock_tuple tuple = {};
-
-    if (skb->protocol == bpf_htons(ETH_P_IP)) {
-      tuple.ipv4.saddr = tuples.five.sip.u6_addr32[3];
-      tuple.ipv4.daddr = tuples.five.dip.u6_addr32[3];
-      tuple.ipv4.sport = tuples.five.sport;
-      tuple.ipv4.dport = tuples.five.dport;
-      tuple_size = sizeof(tuple.ipv4);
-    } else {
-      __builtin_memcpy(tuple.ipv6.saddr, &tuples.five.sip, IPV6_BYTE_LENGTH);
-      __builtin_memcpy(tuple.ipv6.daddr, &tuples.five.dip, IPV6_BYTE_LENGTH);
-      tuple.ipv6.sport = tuples.five.sport;
-      tuple.ipv6.dport = tuples.five.dport;
-      tuple_size = sizeof(tuple.ipv6);
-    }
-    if (lookup_and_assign_tcp_established(skb, &tuple, tuple_size) == 0) {
-      return TC_ACT_OK;
-    }
+  /* l4proto is stored in skb->cb[1] only for UDP and new TCP. As for
+   * established TCP, kernel can take care of socket lookup, so just
+   * return them to stack without calling bpf_sk_assign.
+   */
+  __u8 l4proto = skb->cb[1];
+  if (l4proto != 0) {
+    assign_listener(skb, l4proto);
   }
-
-  /* Then look for tproxy listening socket */
-  if (assign_listener(skb, l4proto) == 0) {
-    return TC_ACT_OK;
-  }
-
-  return TC_ACT_SHOT;
+  return TC_ACT_OK;
 }
 
 SEC("tc/dae0_ingress")

--- a/control/netns_utils.go
+++ b/control/netns_utils.go
@@ -290,6 +290,14 @@ func (ns *DaeNetns) setupSysctl() (err error) {
 	}
 	// sysctl net.ipv6.conf.all.forwarding=1
 	SetForwarding("all", "1")
+
+	// *_early_demux is not mandatory, but it's recommended to enable it for better performance
+	if err = netns.Set(ns.daeNs); err != nil {
+		return fmt.Errorf("failed to switch to daens: %v", err)
+	}
+	defer netns.Set(ns.hostNs)
+	sysctl.Set("net.ipv4.tcp_early_demux", "1", false)
+	sysctl.Set("net.ipv4.ip_early_demux", "1", false)
 	return
 }
 


### PR DESCRIPTION
### Background

这个 PR 引入了三项针对 lan 的性能优化。先回顾 datapath：

```                              
                ┌──────────────────┐ 
  1             │ 2                │ 
┌────┐     ┌────┼────┐      ┌───┐  │ 
│    ├─────►    │    ├──────►   │  │ 
│lan0│     │dae0│peer│      │dae│  │ 
│    ◄─────┤    │    ◄──────┤   │  │ 
└────┘     └────┼────┘      └───┘  │ 
             3  │     dae netns    │ 
                └──────────────────┘ 

a. bpf_lan_ingress: 做分流决策：直连流量放行进入网络栈，分流流量调用 bpf_redirect 重定向给 dae0
b. bpf_peer_ingress: 只有分流流量才可能到达这里，调用 bpf_skc_lookup 和 bpf_sk_assign 把流量指定给 dae socket
c. bpf_dae0_ingress: 只有分流流量的 **回复** 才可能到达这里，调用 bpf_redirect 把它重定向回 wan0
```

优化 1：a 和 b 处的 bpf 程序都解析了一遍二三四层的包头，其实没有必要解析两次，在 a 出解析完了之后可以通过 skb->cb 把 b 处需要知道的信息夹带过去。
优化 2：b 处的 peer_ingress bpf 没有必要对 established tcp 调用 bpf_skc_lookup 查询 socket，因为内核本身就可以完成 socket lookup。在开启 tcp_early_demux 的情况下还可以避免路由决策直接做 local delivery。
优化 3：a 处的 lan_ingress 可以调用 bpf_redirect_peer 直接重定向给 netns 内部的 peer，避免 enqueue_to_backlog 造成的性能影响。

---

### Background

This PR introduces 3 performance optimizations. First, let's review the datapath:

```
                ┌──────────────────┐ 
  1             │ 2                │ 
┌────┐     ┌────┼────┐      ┌───┐  │ 
│    ├─────►    │    ├──────►   │  │ 
│lan0│     │dae0│peer│      │dae│  │ 
│    ◄─────┤    │    ◄──────┤   │  │ 
└────┘     └────┼────┘      └───┘  │ 
             3  │     dae netns    │ 
                └──────────────────┘ 

a. bpf_lan_ingress: Make split routing decisions: Direct traffic enters the network stack, and split traffic is redirected to dae0 using bpf_redirect.
b. bpf_peer_ingress: Only split traffic can reach this point, using bpf_skc_lookup and bpf_sk_assign to assign traffic to the dae socket.
c. bpf_dae0_ingress: Only split traffic **replies** can reach this point, using bpf_redirect to redirect it back to wan0.
```

Optimization 1: Both the BPF programs at points a and b have parsed the packet headers up to layers two, three, and four. It's unnecessary to parse them twice. After parsing at point a, the information needed at point b can be passed using skb->cb.

Optimization 2: The peer_ingress BPF at point b doesn't need to perform socket lookup for established TCP connections using bpf_skc_lookup because the kernel itself can handle socket lookup. With tcp_early_demux enabled, it can also avoid routing decisions and perform local delivery directly.

Optimization 3: The lan_ingerss at point a redirects the skb from wan0 to dae0, which then goes through netns to reach the peer. This step can be simplified using bpf_redirect_peer: redirect the skb directly from lan0 to the peer inside the netns, avoiding performance impact from enqueue_to_backlog.

Recommendation: Review by commit.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
