### PR TITLE
feat: support reloading progress

### DIFF
--- a/common/consts/reload.go
+++ b/common/consts/reload.go
@@ -1,0 +1,8 @@
+package consts
+
+const (
+	ReloadSend = '0' + iota
+	ReloadProcessing
+	ReloadDone
+	ReloadError
+)


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

In the past, `dae reload` always returned OK. When the reload failed, we had no way of knowing what error occurred and could only obtain the failure information by viewing the dae log.

This PR supports `dae reload` to wait for the reloading progress and print error information when an error occurs.

Specifically, `/var/run/dae.progress` is introduced; dae will write its status to this file during the reloading process, thus `dae reload` can read the current reloading status of dae from this flie.

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->

<img width="541" alt="image" src="https://github.com/daeuniverse/dae/assets/30586220/d6801e6d-d155-4b95-9595-2ff369e20182">

