### PR TITLE
fix: Fix bpf CO-RE issue on 6.9

### DIFF
--- a/control/kern/tproxy.c
+++ b/control/kern/tproxy.c
@@ -601,10 +601,13 @@ route(const __u32 flag[8], const void *l4hdr, const __be32 saddr[4],
 #define _dscp flag[6]
 
 	int ret;
-	struct lpm_key lpm_key_instance, *lpm_key;
+	struct lpm_key *lpm_key;
 	__u32 key = MatchType_L4Proto;
 	__u16 h_dport;
 	__u16 h_sport;
+	struct lpm_key lpm_key_instance = {
+		.trie_key = { IPV6_BYTE_LENGTH * 8, {} },
+	};
 
 	/// TODO: BPF_MAP_UPDATE_BATCH ?
 	ret = bpf_map_update_elem(&l4proto_ipversion_map, &key, &_l4proto_type, BPF_ANY);
@@ -631,7 +634,6 @@ route(const __u32 flag[8], const void *l4hdr, const __be32 saddr[4],
 	if (unlikely((ret = bpf_map_update_elem(&h_port_map, &key, &h_dport, BPF_ANY))))
 		return ret;
 
-	lpm_key_instance.trie_key.prefixlen = IPV6_BYTE_LENGTH * 8;
 	__builtin_memcpy(lpm_key_instance.data, daddr, IPV6_BYTE_LENGTH);
 	key = MatchType_IpSet;
 	ret = bpf_map_update_elem(&lpm_key_map, &key, &lpm_key_instance, BPF_ANY);


### PR DESCRIPTION
### Background

6.9 introduces https://lore.kernel.org/bpf/202402221046.020C94D@keescook/T/ which renamed bpf_lpm_trie_key to bpf_lpm_trie_key_u8, breaking CO-RE because vmlinux no longer has the definition.

This patch fixes the CO-RE issue by relying on a special cornor case that doesn't emit CO-RE relocation.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #482 

### Test Result

<!--- Attach test result here. -->
