### PR TITLE
ci(generate-changelogs.yml): generate auth token on the fly

### DIFF
--- a/.github/workflows/generate-changelogs.yml
+++ b/.github/workflows/generate-changelogs.yml
@@ -23,6 +23,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Generate GitHub Auth Token
+        # https://github.com/tibdex/github-app-token
+        id: generate_token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.GH_APP_ID }}
+          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
       - name: Generate release changelogs
         uses: daeuniverse/changelogs-generator-action@main
         id: changelog
@@ -30,7 +38,7 @@ jobs:
           # https://github.com/daeuniverse/changelogs-generator-action
           previousRelease: ${{ inputs.previous_release_tag }}
           futureRelease: ${{ inputs.future_release_tag }}
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ steps.generate_token.outputs.token }}
 
       - name: Print outputs
         shell: bash
@@ -41,7 +49,7 @@ jobs:
         if: ${{ inputs.dry_run == 'false' }}
         uses: dacbd/create-issue-action@main
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ steps.generate_token.outputs.token }}
           title: '[Release Changelogs] ${{ inputs.future_release_tag }}'
           labels: automated-issue,release
           assignees: "sumire88,mzz2017,kunish,jschwinger233"


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

As the title suggests. Propose generating auth on the fly with GitHub Application. This solution may also mitigate the risk of hitting GitHub API rate limit.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- ci(generate-changelogs.yml): generate auth token on the fly

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

NA

### Test Result

<!--- Attach test result here. -->

https://github.com/daeuniverse/dae/actions/runs/8521439334/job/23339571820

![image](https://github.com/daeuniverse/dae/assets/151038614/ff88965e-087a-452a-ab59-85f496000261)