### PR TITLE
fix: shoot ipv6 icmp redirects

### DIFF
--- a/control/kern/tproxy.c
+++ b/control/kern/tproxy.c
@@ -76,6 +76,8 @@
 
 #define ESOCKTNOSUPPORT 94 /* Socket type not supported */
 
+#define NDP_REDIRECT 137
+
 enum { BPF_F_CURRENT_NETNS = -1 };
 
 enum {
@@ -961,13 +963,12 @@ static __always_inline void prep_redirect_to_control_plane(
 		skb->cb[1] = l4proto;
 }
 
-// SNAT for UDP packet.
 SEC("tc/egress")
 int tproxy_lan_egress(struct __sk_buff *skb)
 {
-	if (skb->ingress_ifindex != NOWHERE_IFINDEX) {
+	if (skb->ingress_ifindex != NOWHERE_IFINDEX)
 		return TC_ACT_PIPE;
-	}
+
 	struct ethhdr ethh;
 	struct iphdr iph;
 	struct ipv6hdr ipv6h;
@@ -977,16 +978,16 @@ int tproxy_lan_egress(struct __sk_buff *skb)
 	__u8 ihl;
 	__u8 l4proto;
 	__u32 link_h_len;
-	if (get_link_h_len(skb->ifindex, &link_h_len)) {
+
+	if (get_link_h_len(skb->ifindex, &link_h_len))
 		return TC_ACT_OK;
-	}
 	int ret = parse_transport(skb, link_h_len, &ethh, &iph, &ipv6h, &icmp6h,
 				  &tcph, &udph, &ihl, &l4proto);
 	if (ret) {
 		bpf_printk("parse_transport: %d", ret);
 		return TC_ACT_OK;
 	}
-	if (l4proto == IPPROTO_ICMPV6 && icmp6h.icmp6_type == 137) {
+	if (l4proto == IPPROTO_ICMPV6 && icmp6h.icmp6_type == NDP_REDIRECT) {
 		// REDIRECT (NDP)
 		return TC_ACT_SHOT;
 	}

--- a/control/kern/tproxy.c
+++ b/control/kern/tproxy.c
@@ -961,6 +961,38 @@ static __always_inline void prep_redirect_to_control_plane(
 		skb->cb[1] = l4proto;
 }
 
+// SNAT for UDP packet.
+SEC("tc/egress")
+int tproxy_lan_egress(struct __sk_buff *skb)
+{
+	if (skb->ingress_ifindex != NOWHERE_IFINDEX) {
+		return TC_ACT_PIPE;
+	}
+	struct ethhdr ethh;
+	struct iphdr iph;
+	struct ipv6hdr ipv6h;
+	struct icmp6hdr icmp6h;
+	struct tcphdr tcph;
+	struct udphdr udph;
+	__u8 ihl;
+	__u8 l4proto;
+	__u32 link_h_len;
+	if (get_link_h_len(skb->ifindex, &link_h_len)) {
+		return TC_ACT_OK;
+	}
+	int ret = parse_transport(skb, link_h_len, &ethh, &iph, &ipv6h, &icmp6h,
+				  &tcph, &udph, &ihl, &l4proto);
+	if (ret) {
+		bpf_printk("parse_transport: %d", ret);
+		return TC_ACT_OK;
+	}
+	if (l4proto == IPPROTO_ICMPV6 && icmp6h.icmp6_type == 137) {
+		// REDIRECT (NDP)
+		return TC_ACT_SHOT;
+	}
+	return TC_ACT_PIPE;
+}
+
 SEC("tc/ingress")
 int tproxy_lan_ingress(struct __sk_buff *skb)
 {


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

In the commits of v0.5-v0.6, lan_egress was removed, resulting in icmpv6 redirect packets not being dropped, which forces some users (旁路由用户) to use MASQUERADE.

This PR fixed it.

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
