### PR TITLE
fix: Don't enable net.ipv6.conf.all.forwarding

### DIFF
--- a/control/netns_utils.go
+++ b/control/netns_utils.go
@@ -288,8 +288,6 @@ func (ns *DaeNetns) setupSysctl() (err error) {
 	if err = sysctl.Set(fmt.Sprintf("net.ipv6.conf.%s.forwarding", HostVethName), "1", true); err != nil {
 		return fmt.Errorf("failed to set forwarding for dae0: %v", err)
 	}
-	// sysctl net.ipv6.conf.all.forwarding=1
-	SetForwarding("all", "1")
 
 	// *_early_demux is not mandatory, but it's recommended to enable it for better performance
 	if err = netns.Set(ns.daeNs); err != nil {


### PR DESCRIPTION
### Background

After #458 dae doesn't rely on the majority of stack network settings. This PR removes `sysctl net.ipv6.conf.all.forwarding=1`.

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
