### PR TITLE
fix: set accept_ra=2 if necessary to fix missing ipv6 address on WAN interface

### DIFF
--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -208,6 +208,7 @@ func NewControlPlane(
 	if len(global.LanInterface) > 0 {
 		if global.AutoConfigKernelParameter {
 			_ = SetIpv4forward("1")
+			_ = setForwarding("all", consts.IpVersionStr_6, "1")
 		}
 		global.LanInterface = common.Deduplicate(global.LanInterface)
 		for _, ifname := range global.LanInterface {
@@ -225,6 +226,19 @@ func NewControlPlane(
 			log.WithError(err).Warnln("failed to setup local tcp fast redirect")
 		}
 		for _, ifname := range global.WanInterface {
+			if len(global.LanInterface) > 0 {
+				// FIXME: Code is not elegant here.
+				// bindLan setting conf.ipv6.all.forwarding=1 suppresses accept_ra=1,
+				// thus we set it 2 as a workaround.
+				// See https://sysctl-explorer.net/net/ipv6/accept_ra/ for more information.
+				if global.AutoConfigKernelParameter {
+					acceptRaPath := fmt.Sprintf("net.ipv6.conf.%v.accept_ra", ifname)
+					val, _ := sysctl.Get(acceptRaPath)
+					if val == "1" {
+						_ = sysctl.Set(acceptRaPath, "2", false)
+					}
+				}
+			}
 			if err = core.bindWan(ifname, global.AutoConfigKernelParameter); err != nil {
 				return nil, fmt.Errorf("bindWan: %v: %w", ifname, err)
 			}

--- a/control/control_plane_core.go
+++ b/control/control_plane_core.go
@@ -247,7 +247,6 @@ func (c *controlPlaneCore) bindLan(ifname string, autoConfigKernelParameter bool
 	if autoConfigKernelParameter {
 		SetSendRedirects(ifname, "0")
 		SetForwarding(ifname, "1")
-		setForwarding("all", consts.IpVersionStr_6, "1")
 	}
 	if err := c._bindLan(ifname); err != nil {
 		var notFoundErr netlink.LinkNotFoundError

--- a/control/sysctl.go
+++ b/control/sysctl.go
@@ -76,6 +76,15 @@ func (s *SysctlManager) startWatch() {
 	}
 }
 
+func (s *SysctlManager) Get(key string) (value string, err error) {
+	path := SysctlPrefixPath + strings.Replace(key, ".", "/", -1)
+	val, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(val)), nil
+}
+
 func (s *SysctlManager) Set(key string, value string, watch bool) (err error) {
 	path := SysctlPrefixPath + strings.Replace(key, ".", "/", -1)
 	if watch {

--- a/docs/en/user-guide/kernel-parameters.md
+++ b/docs/en/user-guide/kernel-parameters.md
@@ -10,7 +10,7 @@ For every LAN interfaces you want to proxy:
 ```shell
 export lan_ifname=docker0
 
-sudo tee /etc/sysctl.d/60-dae-$lan_ifname.conf << EOF
+sudo tee /etc/sysctl.d/60-dae-lan-$lan_ifname.conf << EOF
 net.ipv4.conf.$lan_ifname.forwarding = 1
 net.ipv6.conf.$lan_ifname.forwarding = 1
 net.ipv4.conf.$lan_ifname.send_redirects = 0
@@ -27,3 +27,19 @@ sudo sysctl --system
 ```
 
 Please modify `docker0` to your LAN interface.
+
+For your WAN interfaces that accept RA:
+
+```shell
+export wan_ifname=eth0
+
+if [ "$(cat /proc/sys/net/ipv6/conf/wlan0/accept_ra)" == "1" ]; then
+    sudo tee /etc/sysctl.d/60-dae-wan-$wan_ifname.conf << EOF
+net.ipv6.conf.$wan_ifname.accept_ra = 2
+EOF
+    sudo sysctl --system
+```
+
+Please modify `eth0` to your WAN interface.
+
+Setting accept_ra to 2 if it is 1 because `net.ipv6.conf.all.forwarding = 1` will suppress it. See <https://sysctl-explorer.net/net/ipv6/accept_ra/> for more information.


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

bindLan setting conf.ipv6.all.forwarding=1 suppresses accept_ra=1, thus we set it 2 as a workaround.
See https://sysctl-explorer.net/net/ipv6/accept_ra/ for more information.

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
