### PR TITLE
chore(dae.service): set TimeoutStartSec=120 instead of 10

### DIFF
--- a/install/dae.service
+++ b/install/dae.service
@@ -13,6 +13,7 @@ ExecStartPre=/usr/bin/dae validate -c /etc/dae/config.dae
 ExecStart=/usr/bin/dae run --disable-timestamp -c /etc/dae/config.dae
 ExecReload=/usr/bin/dae reload $MAINPID
 Restart=on-abnormal
+TimeoutStartSec=600
 
 [Install]
 WantedBy=multi-user.target

--- a/install/dae.service
+++ b/install/dae.service
@@ -13,7 +13,7 @@ ExecStartPre=/usr/bin/dae validate -c /etc/dae/config.dae
 ExecStart=/usr/bin/dae run --disable-timestamp -c /etc/dae/config.dae
 ExecReload=/usr/bin/dae reload $MAINPID
 Restart=on-abnormal
-TimeoutStartSec=600
+TimeoutStartSec=120
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
修改服务启动的超时时间，避免造成在低性能开发板上启动失败。