### PR TITLE
fix: Opt out TCP sockmap bypass by default

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -24,17 +24,18 @@ type Global struct {
 	LogLevel          string `mapstructure:"log_level" default:"info"`
 	// We use DirectTcpCheckUrl to check (tcp)*(ipv4/ipv6) connectivity for direct.
 	//DirectTcpCheckUrl string `mapstructure:"direct_tcp_check_url" default:"http://www.qualcomm.cn/generate_204"`
-	TcpCheckUrl               []string      `mapstructure:"tcp_check_url" default:"http://cp.cloudflare.com,1.1.1.1,2606:4700:4700::1111"`
-	TcpCheckHttpMethod        string        `mapstructure:"tcp_check_http_method" default:"HEAD"` // Use 'HEAD' because some server implementations bypass accounting for this kind of traffic.
-	UdpCheckDns               []string      `mapstructure:"udp_check_dns" default:"dns.google.com:53,8.8.8.8,2001:4860:4860::8888"`
-	CheckInterval             time.Duration `mapstructure:"check_interval" default:"30s"`
-	CheckTolerance            time.Duration `mapstructure:"check_tolerance" default:"0"`
-	LanInterface              []string      `mapstructure:"lan_interface"`
-	WanInterface              []string      `mapstructure:"wan_interface"`
-	AllowInsecure             bool          `mapstructure:"allow_insecure" default:"false"`
-	DialMode                  string        `mapstructure:"dial_mode" default:"domain"`
-	DisableWaitingNetwork     bool          `mapstructure:"disable_waiting_network" default:"false"`
-	AutoConfigKernelParameter bool          `mapstructure:"auto_config_kernel_parameter" default:"false"`
+	TcpCheckUrl                []string      `mapstructure:"tcp_check_url" default:"http://cp.cloudflare.com,1.1.1.1,2606:4700:4700::1111"`
+	TcpCheckHttpMethod         string        `mapstructure:"tcp_check_http_method" default:"HEAD"` // Use 'HEAD' because some server implementations bypass accounting for this kind of traffic.
+	UdpCheckDns                []string      `mapstructure:"udp_check_dns" default:"dns.google.com:53,8.8.8.8,2001:4860:4860::8888"`
+	CheckInterval              time.Duration `mapstructure:"check_interval" default:"30s"`
+	CheckTolerance             time.Duration `mapstructure:"check_tolerance" default:"0"`
+	LanInterface               []string      `mapstructure:"lan_interface"`
+	WanInterface               []string      `mapstructure:"wan_interface"`
+	AllowInsecure              bool          `mapstructure:"allow_insecure" default:"false"`
+	DialMode                   string        `mapstructure:"dial_mode" default:"domain"`
+	DisableWaitingNetwork      bool          `mapstructure:"disable_waiting_network" default:"false"`
+	EnableLocalTcpFastRedirect bool          `mapstructure:"enable_local_tcp_fast_redirect" default:"false"`
+	AutoConfigKernelParameter  bool          `mapstructure:"auto_config_kernel_parameter" default:"false"`
 	// DEPRECATED: not used as of https://github.com/daeuniverse/dae/pull/458
 	AutoConfigFirewallRule bool          `mapstructure:"auto_config_firewall_rule" default:"false"`
 	SniffingTimeout        time.Duration `mapstructure:"sniffing_timeout" default:"100ms"`

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -221,8 +221,10 @@ func NewControlPlane(
 		if err = core.setupSkPidMonitor(); err != nil {
 			log.WithError(err).Warnln("cgroup2 is not enabled; pname routing cannot be used")
 		}
-		if err = core.setupLocalTcpFastRedirect(); err != nil {
-			log.WithError(err).Warnln("failed to setup local tcp fast redirect")
+		if global.EnableLocalTcpFastRedirect {
+			if err = core.setupLocalTcpFastRedirect(); err != nil {
+				log.WithError(err).Warnln("failed to setup local tcp fast redirect")
+			}
 		}
 		for _, ifname := range global.WanInterface {
 			if err = core.bindWan(ifname, global.AutoConfigKernelParameter); err != nil {

--- a/docs/en/configuration/separate-config.md
+++ b/docs/en/configuration/separate-config.md
@@ -44,6 +44,7 @@ global {
 
     dial_mode: domain
     disable_waiting_network: false
+    enable_local_tcp_fast_redirect: false
     auto_config_kernel_parameter: true
     sniffing_timeout: 100ms
 }

--- a/example.dae
+++ b/example.dae
@@ -19,6 +19,8 @@ global {
     # Disable waiting for network before pulling subscriptions.
     disable_waiting_network: false
 
+    # Enable fast redirect for local TCP connections. There is a known kernel issue that breaks certain clients/proxies, such as nadoo/glider. Users may enable this experimental option at their own risks.
+    enable_local_tcp_fast_redirect: false
 
     ##### Interface and kernel options.
 


### PR DESCRIPTION
Once the kernel issue[1] is fixed and backported to TLS, I'll open another pull request as a follow-up to automatically enable this option if kernel has the patches.

[1]: https://github.com/jschwinger233/bpf_msg_redirect_bug_reproducer

### Background

A kernel issue (confirmed by community) breaks TCP clients (e.g. glider) who use splice syscall when enabling bpf sockmap redirect. This PR opts out that performance optimization until kernel bug is fixed.

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
