### PR TITLE
chore: Add a global config to enable pprof

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -41,6 +41,7 @@ type Global struct {
 	SniffingTimeout        time.Duration `mapstructure:"sniffing_timeout" default:"100ms"`
 	TlsImplementation      string        `mapstructure:"tls_implementation" default:"tls"`
 	UtlsImitate            string        `mapstructure:"utls_imitate" default:"chrome_auto"`
+	PprofPort              uint16        `mapstructure:"pprof_port" default:"0"`
 }
 
 type Utls struct {

--- a/example.dae
+++ b/example.dae
@@ -9,6 +9,9 @@ global {
     # iptables tproxy rules.
     tproxy_port_protect: true
 
+    # Set non-zero value to enable pprof.
+    pprof_port: 0
+
     # If not zero, traffic sent from dae will be set SO_MARK. It is useful to avoid traffic loop with iptables tproxy
     # rules.
     so_mark_from_dae: 0


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

This PR adds a new global config `pprof_port` to specify (and enable/disable) pprof server. Users can also enable or disable pprof on the fly using `dae reload`.

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
