### PR TITLE
fix: cannot route for sniffed domain with port

### DIFF
--- a/component/routing/domain_matcher/ahocorasick_slimtrie.go
+++ b/component/routing/domain_matcher/ahocorasick_slimtrie.go
@@ -100,11 +100,12 @@ func (n *AhocorasickSlimtrie) MatchDomainBitmap(domain string) (bitmap []uint32)
 	bitmap = make([]uint32, N)
 	domain = strings.ToLower(strings.TrimSuffix(domain, "."))
 	// Domain should consist of 'a'-'z' and '.' and '-'
-	for _, b := range []byte(domain) {
-		if !ahocorasick.IsValidChar(b) {
-			return bitmap
-		}
-	}
+	// NOTE: DO NOT VERIFY THE DOMAIN TO MATCH: https://github.com/daeuniverse/dae/issues/528
+	// for _, b := range []byte(domain) {
+	// 	if !ahocorasick.IsValidChar(b) {
+	// 		return bitmap
+	// 	}
+	// }
 	// Suffix matching.
 	suffixTrieDomain := ToSuffixTrieString("^" + domain)
 	for _, i := range n.validTrieIndexes {

--- a/component/routing/domain_matcher/ahocorasick_slimtrie_test.go
+++ b/component/routing/domain_matcher/ahocorasick_slimtrie_test.go
@@ -6,11 +6,12 @@
 package domain_matcher
 
 import (
+	"math/rand"
+	"testing"
+
 	"github.com/daeuniverse/dae/common/consts"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/exp/slices"
-	"math/rand"
-	"testing"
 )
 
 func TestAhocorasickSlimtrie(t *testing.T) {


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

In some cases, especially for non-typical ports, http sniffer will return the sniffing results carrying the port. At this time, due to some valid character restrictions, the domain routing will lose its function.

This PR fixes it.

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #528

### Test Result

<!--- Attach test result here. -->
