### PR TITLE
feat: support assist connectivity check (udp-dns) by dns module

### DIFF
--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -444,8 +444,15 @@ func NewControlPlane(
 			}, nil
 		},
 		BestDialerChooser: plane.chooseBestDnsDialer,
-		IpVersionPrefer:   dnsConfig.IpVersionPrefer,
-		FixedDomainTtl:    fixedDomainTtl,
+		TimeoutExceedCallback: func(dialArgument *dialArgument, err error) {
+			dialArgument.bestDialer.ReportUnavailable(&dialer.NetworkType{
+				L4Proto:   dialArgument.l4proto,
+				IpVersion: dialArgument.ipversion,
+				IsDns:     true,
+			}, err)
+		},
+		IpVersionPrefer: dnsConfig.IpVersionPrefer,
+		FixedDomainTtl:  fixedDomainTtl,
 	}); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

There were sporadic user reports in the past that `tcp+udp` did not work properly. I cannot reproduce this problem. One possibility is that the DNS server used for check connectivity is different from the actual DNS, and the dialer server has different connectivity quality (good/poor) to the two DNS servers.

To solve this problem, this PR supports the DNS module to feedback query failures to the connectivity module, thereby assisting in connectivity checks and reducing node priority.

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
