### PR TITLE
fix(udp_task_pool): panic: close of closed channel

### DIFF
--- a/control/udp_task_pool.go
+++ b/control/udp_task_pool.go
@@ -10,7 +10,6 @@ const UdpTaskQueueLength = 128
 type UdpTask = func()
 
 type UdpTaskQueue struct {
-	poolFrom  *UdpTaskPool
 	key       string
 	ch        chan UdpTask
 	timer     *time.Timer
@@ -51,7 +50,7 @@ func (p *UdpTaskPool) convoy(q *UdpTaskQueue) {
 				select {
 				case t := <-q.ch:
 					// Emit it back due to closed q.
-					p.poolFrom.EmitTask(p.key, t)
+					p.EmitTask(q.key, t)
 				default:
 					break clearloop
 				}
@@ -70,7 +69,6 @@ func (p *UdpTaskPool) EmitTask(key string, task UdpTask) {
 	if !ok {
 		ch := p.queueChPool.Get().(chan UdpTask)
 		q = &UdpTaskQueue{
-			poolFrom:  p,
 			key:       key,
 			ch:        ch,
 			timer:     nil,

--- a/control/udp_task_pool.go
+++ b/control/udp_task_pool.go
@@ -79,6 +79,7 @@ func (p *UdpTaskPool) EmitTask(key string, task UdpTask) {
 			freed:     make(chan struct{}),
 		}
 		q.timer = time.AfterFunc(q.agingTime, func() {
+			// This func may be invoked twice due to concurrent Reset.
 			select {
 			case <-q.closed:
 				return


### PR DESCRIPTION

<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->


```
panic: close of closed channel

goroutine 358834 [running]:
github.com/daeuniverse/dae/control.(*UdpTaskPool).EmitTask.func1()
  github.com/daeuniverse/dae/control/udp_task_pool.go:81 +0xf4
created by time.goFunc
  time/sleep.go:177 +0x2d
```

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
