### PR TITLE
feat: shell completion subcommand

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,59 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2024, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	completionCmd = &cobra.Command{
+		Use:       "completion [bash|zsh|fish]",
+		Short:     "Output shell completion code for the specified shell (bash, zsh or fish)",
+		Long:      "Output shell completion code for the specified shell (bash, zsh or fish).",
+		Args:      cobra.ExactArgs(1),
+		ValidArgs: []string{"bash", "zsh", "fish"},
+		Hidden:    true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			out, err := getCompletion(args[0], cmd.Parent())
+			if err != nil {
+				return err
+			}
+
+			fmt.Print(out)
+			return nil
+		},
+	}
+)
+
+// return the auto completion shell script, if supported
+func getCompletion(sh string, parent *cobra.Command) (string, error) {
+	var err error
+	var buf bytes.Buffer
+
+	switch sh {
+	case "bash":
+		err = parent.GenBashCompletion(&buf)
+	case "zsh":
+		err = parent.GenZshCompletion(&buf)
+	case "fish":
+		err = parent.GenFishCompletion(&buf, true)
+	default:
+		err = errors.New("unsupported shell type (must be bash, zsh or fish): " + sh)
+	}
+
+	if err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+func init() {
+	rootCmd.AddCommand(completionCmd)
+}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -55,7 +55,7 @@ var (
 )
 
 func init() {
-	runCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "Config file of dae.")
+	runCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "Config file of dae.(required)")
 	runCmd.PersistentFlags().StringVar(&logFile, "logfile", "", "Log file to write. Empty means writing to stdout and stderr.")
 	runCmd.PersistentFlags().IntVar(&logFileMaxSize, "logfile-maxsize", 30, "Unit: MB. The maximum size in megabytes of the log file before it gets rotated.")
 	runCmd.PersistentFlags().IntVar(&logFileMaxBackups, "logfile-maxbackups", 3, "The maximum number of old log files to retain.")


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

This PR adds support for auto-generated shell completions subcommand for dae, including Bash, Zsh, and Fish. avoids the need to modify the `install/shell-completions` each time.

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has been fully tested
- [x] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- feat: shell completion subcommand for [bash|fish|zsh]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
