### PR TITLE
docs: persistent subscription

### DIFF
--- a/docs/en/user-guide/persistent-subscription.md
+++ b/docs/en/user-guide/persistent-subscription.md
@@ -1,0 +1,112 @@
+# Persistent and automatically update subscriptions
+
+[systemd.timer](https://www.freedesktop.org/software/systemd/man/latest/systemd.timer.html) allows you to run a service periodically.
+
+The current behavior of dae is to pull subscriptions at startup, but this can sometimes result in an empty group if there is a network anomaly or other possible reason when pulling subscriptions.
+
+We'll introduce a way to achieve persistent subscription storage and automatic subscription updates through the systemd service and timer.
+
+## Preparations
+
+### Shell script
+
+We assume that your dae configuration file is stored in `/usr/local/etc/dae/` .
+
+`/usr/local/bin/update-dae-subs.sh`:
+
+```sh
+#!/bin/bash
+
+# Change the path to suit your needs
+cd /usr/local/etc/dae || exit 1
+version="$(dae --version | head -n 1 | sed 's/dae version //')"
+UA="dae/${version} (like v2rayA/1.0 WebRequestHelper) (like v2rayN/1.0 WebRequestHelper)"
+while IFS=':' read -r name url
+do
+    curl -fL -A "$UA" "$url" -o "${name}.sub.new"
+    if [[ $? -eq 0 ]]; then
+        mv "${name}.sub.new" "${name}.sub"
+        chmod 0600 "${name}.sub"
+        echo "Downloaded $name"
+    else
+        rm "${name}.sub.new"
+        echo "Failed to download $name"
+    fi
+done < sublist
+
+dae reload
+```
+
+You need to give it proper permission:
+```sh
+chmod +x /usr/local/bin/update-dae-subs.sh
+```
+
+### `systemd.timer` and `systemd.service`
+
+This timer will automatically update dae subscriptions every 12 hours, or 15 minutes after each boot.
+
+`/etc/systemd/system/update-subs.timer`:
+
+```systemd
+[Unit]
+Description=Auto-update dae subscriptions
+
+[Timer]
+OnBootSec=15min
+OnUnitActiveSec=12h
+
+[Install]
+WantedBy=timers.target
+```
+
+`/etc/systemd/system/update-subs.service`:
+
+```systemd
+[Unit]
+Description=Update dae subscriptions
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/update-dae-subs.sh
+```
+
+## Configurations
+
+Put your subscription links into `/usr/local/etc/dae/sublist`:
+
+```text
+sub1:https://mysub1.com
+sub2:https://mysub2.com
+sub3:https://mysub3.com
+```
+
+Give the file appropriate permissions (for your privacy):
+
+```sh
+chmod 0600 /usr/local/etc/dae/sublist
+```
+
+Edit `config.dae`:
+
+```text
+subscription {
+    # Add your subscription links here.
+    sub1:'file://sub1.sub'
+    sub2:'file://sub2.sub'
+    sub3:'file://sub3.sub'
+}
+```
+
+## Enable timer
+
+Execute the following command:
+
+```sh
+systemctl enable --now update-dae-subs.timer
+
+# If you need to renew your subscription immediately or haven't pulled a subscription before
+systemctl start update-dae-subs.service
+```


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

Some times it may not be possible to pull the subscription when the network is poor, which can lead to users not being able to function properly if they are completely dependent on the subscription.(no node exists in the group)

Add documentation for persistent subscriptions to help users avoid this issue.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [x] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
