### PR TITLE
ci: add trigger-downstream-flake-sync workflow

### DIFF
--- a/.github/workflows/trigger-downstream-flake-sync.yml
+++ b/.github/workflows/trigger-downstream-flake-sync.yml
@@ -20,7 +20,7 @@ on:
 
 env:
   DOWNSTREAM_REPO: flake.nix
-  WORKFLOW_BRANCH: main
+  WORKFLOW_BRANCH: unstable
   WORKFLOW_FILE: sync-upstream.yml
 
 jobs:
@@ -43,7 +43,7 @@ jobs:
           github_token: ${{ steps.generate_token.outputs.token }}
           workflow_file_name: ${{ env.WORKFLOW_FILE }}
           ref: ${{ env.WORKFLOW_BRANCH }}
-          client_payload: '{"project":"${{ env.DOWNSTREAM_REPO }}"}'
+          client_payload: '{"project":"${{ env.DOWNSTREAM_REPO }}","branch":"${{ env.WORKFLOW_BRANCH }}"}'
           trigger_workflow: true
           propagate_failure: false
           wait_workflow: false


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

As requested in https://github.com/daeuniverse/flake.nix/issues/13, add new workflow to trigger downstream flake sync workflow.

Accompany with PR https://github.com/daeuniverse/flake.nix/pull/78

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- ci: add trigger-downstream-flake-sync workflow

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

NA

### Test Result

<!--- Attach test result here. -->

https://github.com/daeuniverse/flake.nix/actions/runs/10550266073
