### PR TITLE
feat: preformat dns qname to compatible with DNS type 65

### DIFF
--- a/component/dns/dns.go
+++ b/component/dns/dns.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/netip"
 	"net/url"
+	"strings"
 	"sync"
 
 	"github.com/daeuniverse/dae/common"
@@ -151,8 +152,20 @@ func (s *Dns) InitUpstreams() {
 	wg.Wait()
 }
 
+func formatDNSName(rawURL string) string {
+	if strings.HasPrefix(rawURL, "https://") {
+		parsedURL, err := url.Parse(rawURL)
+		if err != nil {
+			return rawURL
+		}
+		return parsedURL.Hostname()
+	}
+	return rawURL
+}
+
 func (s *Dns) RequestSelect(qname string, qtype uint16) (upstreamIndex consts.DnsRequestOutboundIndex, upstream *Upstream, err error) {
 	// Route.
+	qname = formatDNSName(qname)
 	upstreamIndex, err = s.reqMatcher.Match(qname, qtype)
 	if err != nil {
 		return 0, nil, err


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

Preformat the name in DNS requests routing to be compatible with DNS type 65

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

Before:
![image](https://github.com/user-attachments/assets/c370c1de-b176-42e5-856f-caa2a78d4216)
After:
![image](https://github.com/user-attachments/assets/575880dc-4e55-4760-9d63-d5e6d9161067)

