### PR TITLE
feat: allow group override global node connectivity check

### DIFF
--- a/component/outbound/dialer/connectivity_check.go
+++ b/component/outbound/dialer/connectivity_check.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unsafe"
 
 	"github.com/daeuniverse/dae/common"
 
@@ -452,6 +453,18 @@ func (d *Dialer) aliveBackground() {
 			}
 		}
 	}()
+	var unused int
+	for _, opt := range CheckOpts {
+		if len(d.mustGetCollection(opt.networkType).AliveDialerSetSet) == 0 {
+			unused++
+		}
+	}
+	if unused == len(CheckOpts) {
+		d.Log.WithField("dialer", d.Property().Name).
+			WithField("p", unsafe.Pointer(d)).
+			Traceln("cleaned up due to unused")
+		return
+	}
 	var wg sync.WaitGroup
 	for range d.checkCh {
 		for _, opt := range CheckOpts {

--- a/component/outbound/dialer/dialer.go
+++ b/component/outbound/dialer/dialer.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/daeuniverse/dae/common"
+	"github.com/daeuniverse/dae/config"
 	D "github.com/daeuniverse/outbound/dialer"
 	"github.com/daeuniverse/outbound/netproxy"
 	"github.com/sirupsen/logrus"
@@ -59,6 +61,21 @@ type Property struct {
 }
 
 type AliveDialerSetSet map[*AliveDialerSet]int
+
+func NewGlobalOption(global *config.Global, log *logrus.Logger) *GlobalOption {
+	return &GlobalOption{
+		ExtraOption: D.ExtraOption{
+			AllowInsecure:     global.AllowInsecure,
+			TlsImplementation: global.TlsImplementation,
+			UtlsImitate:       global.UtlsImitate},
+		Log:               log,
+		TcpCheckOptionRaw: TcpCheckOptionRaw{Raw: global.TcpCheckUrl, Log: log, ResolverNetwork: common.MagicNetwork("udp", global.SoMarkFromDae, global.Mptcp), Method: global.TcpCheckHttpMethod},
+		CheckDnsOptionRaw: CheckDnsOptionRaw{Raw: global.UdpCheckDns, ResolverNetwork: common.MagicNetwork("udp", global.SoMarkFromDae, global.Mptcp), Somark: global.SoMarkFromDae},
+		CheckInterval:     global.CheckInterval,
+		CheckTolerance:    global.CheckTolerance,
+		CheckDnsTcp:       true,
+	}
+}
 
 // NewDialer is for register in general.
 func NewDialer(dialer netproxy.Dialer, option *GlobalOption, iOption InstanceOption, property *Property) *Dialer {

--- a/component/outbound/dialer/dialer.go
+++ b/component/outbound/dialer/dialer.go
@@ -83,6 +83,10 @@ func NewDialer(dialer netproxy.Dialer, option *GlobalOption, iOption InstanceOpt
 	return d
 }
 
+func (d *Dialer) Clone() *Dialer {
+	return NewDialer(d.Dialer, d.GlobalOption, d.InstanceOption, d.property)
+}
+
 func (d *Dialer) Close() error {
 	d.cancel()
 	d.tickerMu.Lock()

--- a/component/outbound/dialer/dialer.go
+++ b/component/outbound/dialer/dialer.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"sync"
 	"time"
+	"unsafe"
 
 	"github.com/daeuniverse/dae/common"
 	"github.com/daeuniverse/dae/config"
@@ -97,6 +98,9 @@ func NewDialer(dialer netproxy.Dialer, option *GlobalOption, iOption InstanceOpt
 		ctx:              ctx,
 		cancel:           cancel,
 	}
+	option.Log.WithField("dialer", d.Property().Name).
+		WithField("p", unsafe.Pointer(d)).
+		Traceln("NewDialer")
 	return d
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -89,6 +89,12 @@ type Group struct {
 	Filter           [][]*config_parser.Function `mapstructure:"filter" repeatable:""`
 	FilterAnnotation [][]*config_parser.Param    `mapstructure:"_"`
 	Policy           FunctionListOrString        `mapstructure:"policy" required:""`
+
+	TcpCheckUrl        []string      `mapstructure:"tcp_check_url"`
+	TcpCheckHttpMethod string        `mapstructure:"tcp_check_http_method"`
+	UdpCheckDns        []string      `mapstructure:"udp_check_dns"`
+	CheckInterval      time.Duration `mapstructure:"check_interval"`
+	CheckTolerance     time.Duration `mapstructure:"check_tolerance"`
 }
 
 type DnsRequestRouting struct {

--- a/config/desc.go
+++ b/config/desc.go
@@ -85,4 +85,9 @@ min: Select node by the latency of last check.
 min_avg10: Select node by the average of latencies of last 10 checks.
 min_moving_avg: Select node by the moving average of latencies of checks, which means more recent latencies have higher weight.
 `,
+	"tcp_check_url":         "Override global config.",
+	"tcp_check_http_method": "Override global config.",
+	"udp_check_dns":         "Override global config.",
+	"check_interval":        "Override global config.",
+	"check_tolerance":       "Override global config.",
 }

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -324,6 +324,7 @@ func NewControlPlane(
 			log.Infoln("\t<Empty>")
 		}
 		groupOption, err := ParseGroupOverrideOption(group, *global, log)
+		finalOption := option
 		if err == nil && groupOption != nil {
 			newDialerSet := make([]*dialer.Dialer, 0)
 			for _, d := range dialers {
@@ -333,9 +334,10 @@ func NewControlPlane(
 			}
 			log.Infof(`Group "%v"'s check option has been override.`, group.Name)
 			dialers = newDialerSet
+			finalOption = groupOption
 		}
 		// Create dialer group and append it to outbounds.
-		dialerGroup := outbound.NewDialerGroup(option, group.Name, dialers, annos, *policy,
+		dialerGroup := outbound.NewDialerGroup(finalOption, group.Name, dialers, annos, *policy,
 			core.outboundAliveChangeCallback(uint8(len(outbounds)), disableKernelAliveCallback))
 		outbounds = append(outbounds, dialerGroup)
 	}

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -33,7 +33,6 @@ import (
 	"github.com/daeuniverse/dae/config"
 	"github.com/daeuniverse/dae/pkg/config_parser"
 	internal "github.com/daeuniverse/dae/pkg/ebpf_internal"
-	D "github.com/daeuniverse/outbound/dialer"
 	"github.com/daeuniverse/outbound/pool"
 	"github.com/daeuniverse/outbound/protocol/direct"
 	"github.com/daeuniverse/outbound/transport/grpc"
@@ -256,18 +255,7 @@ func NewControlPlane(
 	if global.AllowInsecure {
 		log.Warnln("AllowInsecure is enabled, but it is not recommended. Please make sure you have to turn it on.")
 	}
-	option := &dialer.GlobalOption{
-		ExtraOption: D.ExtraOption{
-			AllowInsecure:     global.AllowInsecure,
-			TlsImplementation: global.TlsImplementation,
-			UtlsImitate:       global.UtlsImitate},
-		Log:               log,
-		TcpCheckOptionRaw: dialer.TcpCheckOptionRaw{Raw: global.TcpCheckUrl, Log: log, ResolverNetwork: common.MagicNetwork("udp", global.SoMarkFromDae, global.Mptcp), Method: global.TcpCheckHttpMethod},
-		CheckDnsOptionRaw: dialer.CheckDnsOptionRaw{Raw: global.UdpCheckDns, ResolverNetwork: common.MagicNetwork("udp", global.SoMarkFromDae, global.Mptcp), Somark: global.SoMarkFromDae},
-		CheckInterval:     global.CheckInterval,
-		CheckTolerance:    global.CheckTolerance,
-		CheckDnsTcp:       true,
-	}
+	option := dialer.NewGlobalOption(global, log)
 
 	// Dial mode.
 	dialMode, err := consts.ParseDialMode(global.DialMode)
@@ -552,19 +540,8 @@ func ParseGroupOverrideOption(group config.Group, global config.Global, log *log
 		changed = true
 	}
 	if changed {
-		option := dialer.GlobalOption{
-			ExtraOption: D.ExtraOption{
-				AllowInsecure:     global.AllowInsecure,
-				TlsImplementation: global.TlsImplementation,
-				UtlsImitate:       global.UtlsImitate},
-			Log:               log,
-			TcpCheckOptionRaw: dialer.TcpCheckOptionRaw{Raw: result.TcpCheckUrl, Log: log, ResolverNetwork: common.MagicNetwork("udp", global.SoMarkFromDae, global.Mptcp), Method: result.TcpCheckHttpMethod},
-			CheckDnsOptionRaw: dialer.CheckDnsOptionRaw{Raw: result.UdpCheckDns, ResolverNetwork: common.MagicNetwork("udp", global.SoMarkFromDae, global.Mptcp), Somark: global.SoMarkFromDae},
-			CheckInterval:     result.CheckInterval,
-			CheckTolerance:    result.CheckTolerance,
-			CheckDnsTcp:       true,
-		}
-		return &option, nil
+		option := dialer.NewGlobalOption(&result, log)
+		return option, nil
 	}
 	return nil, nil
 }

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -323,6 +323,17 @@ func NewControlPlane(
 		if len(dialers) == 0 {
 			log.Infoln("\t<Empty>")
 		}
+		groupOption, err := ParseGroupOverrideOption(group, *global, log)
+		if err == nil && groupOption != nil {
+			newDialerSet := make([]*dialer.Dialer, 0)
+			for _, d := range dialers {
+				newDialer := d.Clone()
+				newDialer.GlobalOption = groupOption
+				newDialerSet = append(newDialerSet, newDialer)
+			}
+			log.Infof(`Group "%v"'s check option has been override.`, group.Name)
+			dialers = newDialerSet
+		}
 		// Create dialer group and append it to outbounds.
 		dialerGroup := outbound.NewDialerGroup(option, group.Name, dialers, annos, *policy,
 			core.outboundAliveChangeCallback(uint8(len(outbounds)), disableKernelAliveCallback))
@@ -513,6 +524,47 @@ func ParseFixedDomainTtl(ks []config.KeyableString) (map[string]int, error) {
 		m[strings.TrimSpace(key)] = int(ttl)
 	}
 	return m, nil
+}
+
+func ParseGroupOverrideOption(group config.Group, global config.Global, log *logrus.Logger) (*dialer.GlobalOption, error) {
+	result := global
+	changed := false
+	if group.TcpCheckUrl != nil {
+		result.TcpCheckUrl = group.TcpCheckUrl
+		changed = true
+	}
+	if group.TcpCheckHttpMethod != "" {
+		result.TcpCheckHttpMethod = group.TcpCheckHttpMethod
+		changed = true
+	}
+	if group.UdpCheckDns != nil {
+		result.UdpCheckDns = group.UdpCheckDns
+		changed = true
+	}
+	if group.CheckInterval != 0 {
+		result.CheckInterval = group.CheckInterval
+		changed = true
+	}
+	if group.CheckTolerance != 0 {
+		result.CheckTolerance = group.CheckTolerance
+		changed = true
+	}
+	if changed {
+		option := dialer.GlobalOption{
+			ExtraOption: D.ExtraOption{
+				AllowInsecure:     global.AllowInsecure,
+				TlsImplementation: global.TlsImplementation,
+				UtlsImitate:       global.UtlsImitate},
+			Log:               log,
+			TcpCheckOptionRaw: dialer.TcpCheckOptionRaw{Raw: result.TcpCheckUrl, Log: log, ResolverNetwork: common.MagicNetwork("udp", global.SoMarkFromDae, global.Mptcp), Method: result.TcpCheckHttpMethod},
+			CheckDnsOptionRaw: dialer.CheckDnsOptionRaw{Raw: result.UdpCheckDns, ResolverNetwork: common.MagicNetwork("udp", global.SoMarkFromDae, global.Mptcp), Somark: global.SoMarkFromDae},
+			CheckInterval:     result.CheckInterval,
+			CheckTolerance:    result.CheckTolerance,
+			CheckDnsTcp:       true,
+		}
+		return &option, nil
+	}
+	return nil, nil
 }
 
 // EjectBpf will resect bpf from destroying life-cycle of control plane.

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -314,14 +314,14 @@ func NewControlPlane(
 		groupOption, err := ParseGroupOverrideOption(group, *global, log)
 		finalOption := option
 		if err == nil && groupOption != nil {
-			newDialerSet := make([]*dialer.Dialer, 0)
+			newDialers := make([]*dialer.Dialer, 0)
 			for _, d := range dialers {
 				newDialer := d.Clone()
 				newDialer.GlobalOption = groupOption
-				newDialerSet = append(newDialerSet, newDialer)
+				newDialers = append(newDialers, newDialer)
 			}
 			log.Infof(`Group "%v"'s check option has been override.`, group.Name)
-			dialers = newDialerSet
+			dialers = newDialers
 			finalOption = groupOption
 		}
 		// Create dialer group and append it to outbounds.

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -317,6 +317,7 @@ func NewControlPlane(
 			newDialers := make([]*dialer.Dialer, 0)
 			for _, d := range dialers {
 				newDialer := d.Clone()
+				deferFuncs = append(deferFuncs, newDialer.Close)
 				newDialer.GlobalOption = groupOption
 				newDialers = append(newDialers, newDialer)
 			}

--- a/example.dae
+++ b/example.dae
@@ -213,12 +213,24 @@ group {
 
         # Select the node with min average of the last 10 latencies from the group for every connection.
         policy: min_avg10
+    }
+
+    steam {
+        # Filter nodes from the global node pool defined by the subscription and node section above.
+        filter: subtag(my_sub) && !name(keyword: 'ExpireAt:')
+        # Select the node with min moving average of latencies from the group for every connection.
+        policy: min_moving_avg
 
         # Override tcp_check_url in global.
-        tcp_check_url: https://gstatic.com/generate_204
-
-        # This not override global tcp_check_http_method so it still will be "HEAD"
-        #tcp_check_http_method: GET
+        tcp_check_url: 'http://test.steampowered.com'
+        # Override tcp_check_http_method in global
+        #tcp_check_http_method: HEAD
+        # Override udp_check_dns in global
+        #udp_check_dns: 'dns.google.com:53,8.8.8.8,2001:4860:4860::8888'
+        # Override check_interval in global
+        #check_interval: 30s
+        # Override check_tolerance in global
+        #check_tolerance: 50ms
     }
 }
 
@@ -245,6 +257,7 @@ routing {
     l4proto(udp) && dport(443) -> block
     dip(geoip:cn) -> direct
     domain(geosite:cn) -> direct
+    
 
     fallback: my_group
 }

--- a/example.dae
+++ b/example.dae
@@ -40,6 +40,7 @@ global {
     auto_config_kernel_parameter: true
 
     ##### Node connectivity check.
+    # These options, as defaults, are effective when no definition is given in the group.
 
     # Host of URL should have both IPv4 and IPv6 if you have double stack in local.
     # First is URL, others are IP addresses if given.
@@ -212,6 +213,12 @@ group {
 
         # Select the node with min average of the last 10 latencies from the group for every connection.
         policy: min_avg10
+
+        # Override tcp_check_url in global.
+        tcp_check_url: https://gstatic.com/generate_204
+
+        # This not override global tcp_check_http_method so it still will be "HEAD"
+        #tcp_check_http_method: GET
     }
 }
 


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->
此Pull Request允许group配置覆盖global配置中的节点联通性检查以支持更加灵活的场景

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [x] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- 允许group段中的配置覆盖global的节点联通性检查配置
- 当group中未定义这些新的配置时，行为应当和之前完全一致
- 当group中存在这些新配置时，所有此group的dialer将会被克隆并修改联通性检查配置

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #619 

### Test Result

<!--- Attach test result here. -->
#### 测试环境
Archlinux
```zsh
$ uname -a
Linux secops 6.10.8-zen1-1-zen #1 ZEN SMP PREEMPT_DYNAMIC Wed, 04 Sep 2024 15:18:31 +0000 x86_64 GNU/Linux
```
#### 构建
```zsh
$ make
git submodule update --init --recursive -- trace/kern/headers && \
touch trace/kern/headers
-no-strip
Compiled /home/kagurazakanyaa/src/dae/control/bpf_bpfel.o
Wrote /home/kagurazakanyaa/src/dae/control/bpf_bpfel.go
Compiled /home/kagurazakanyaa/src/dae/control/bpf_bpfeb.o
Wrote /home/kagurazakanyaa/src/dae/control/bpf_bpfeb.go
Compiled /home/kagurazakanyaa/src/dae/trace/bpf_bpfel_x86.o
Wrote /home/kagurazakanyaa/src/dae/trace/bpf_bpfel_x86.go
-DMAX_MATCH_SET_LEN=64 -O2 -Wall -Werror
go build -tags=trace -o dae -trimpath -ldflags "-s -w -X github.com/daeuniverse/dae/cmd.Version=unstable-20240907.r731.b03348d -X github.com/daeuniverse/dae/common/consts.MaxMatchSetLen_=64"  .
$ sudo cp ./dae /usr/bin/dae
```
#### 测试
未更改原有配置的情况下，systemd启动服务正常运行
执行`sudo /usr/bin/dae validate -c /etc/dae/config.dae`返回值0

修改配置后，`systemctl restart dae.service`
主要变更的配置
```
global {
  tcp_check_url: 'https://cp.cloudflare.com'
}
group {
  proxy {
    filter: subtag([redacted]) && name(keyword: '日本', keyword: '新加坡' , keyword: '美国' , keyword: '台湾')
    filter: subtag([redacted]) && name(keyword: '[redacted]')
    filter: subtag([redacted]) && name(keyword: 'AnyPath', keyword: 'PVCC', keyword: '日本', keyword: '新加坡', keyword: 'IPLC' , keyword: 'IEPL') && !name(keyword: '香港', keyword: '印度')
    policy: min_moving_avg
  }
aur {
    filter: subtag([redacted]) && name(keyword: '日本', keyword: '新加坡' , keyword: '美国' , keyword: '台湾')
    filter: subtag([redacted]) && name(keyword: '[redacted]')
	policy: min_moving_avg
    tcp_check_url: 'https://aur.archlinux.org'
  }
}

routing {
  domain(suffix:archlinux.org) -> aur
  fallback: proxy
}
```
检查日志
```
level=info msg="Group "aur"'s check option has been override."
```
且proxy组没有此日志
代理正常运行

内存使用情况
```zsh
$ systemctl status dae
● dae.service - dae Service
     Loaded: loaded (/usr/lib/systemd/system/dae.service; enabled; preset: disabled)
    Drop-In: /etc/systemd/system/dae.service.d
             └─override.conf
     Active: active (running) since Sat 2024-09-07 11:00:20 CST; 6min ago
 Invocation: 086a390b131e41c4932c65be943bf4c8
       Docs: https://github.com/daeuniverse/dae
    Process: 711204 ExecStartPre=/usr/bin/dae validate -c /etc/dae/config.dae (code=exited, status=0/SUCCESS)
   Main PID: 711258 (dae)
      Tasks: 22 (limit: 56940)
     Memory: 234.4M (peak: 248.1M)
        CPU: 5.856s
     CGroup: /system.slice/dae.service
             └─711258 /usr/bin/dae run --disable-timestamp -c /etc/dae/config.dae

9月 07 11:00:11 secops systemd[1]: Starting dae Service...
9月 07 11:00:20 secops systemd[1]: Started dae Service.
```
修改配置添加
```
group {
  steam {
    filter: subtag([redacted]) && name(keyword: '日本', keyword: '新加坡' , keyword: '美国' , keyword: '台湾')
    filter: subtag([redacted]) && name(keyword: '[redacted]')
    policy: min_moving_avg
    tcp_check_url: 'http://test.steampowered.com'
  }
}
routing {
  domain(suffix:steampowered.com) -> steam
  domain(suffix:steamcommunity.com) -> steam
  domain(suffix:steamserver.net) -> steam
  domain(suffix:steam-chat.com) -> steam
}
```
重启后内存使用没有显著增加
```zsh
$ systemctl status dae
● dae.service - dae Service
     Loaded: loaded (/usr/lib/systemd/system/dae.service; enabled; preset: disabled)
    Drop-In: /etc/systemd/system/dae.service.d
             └─override.conf
     Active: active (running) since Sat 2024-09-07 11:12:23 CST; 3min 12s ago
 Invocation: 68cc1e49dcfb42e2a7081b0561fefc99
       Docs: https://github.com/daeuniverse/dae
    Process: 766530 ExecStartPre=/usr/bin/dae validate -c /etc/dae/config.dae (code=exited, status=0/SUCCESS)
   Main PID: 766579 (dae)
      Tasks: 22 (limit: 56940)
     Memory: 240.8M (peak: 242.5M)
        CPU: 4.279s
     CGroup: /system.slice/dae.service
             └─766579 /usr/bin/dae run --disable-timestamp -c /etc/dae/config.dae

9月 07 11:12:15 secops systemd[1]: Starting dae Service...
9月 07 11:12:23 secops systemd[1]: Started dae Service.
```