### PR TITLE
docs: add reality tcp support to proxy-protocols

### DIFF
--- a/docs/en/proxy-protocols.md
+++ b/docs/en/proxy-protocols.md
@@ -20,6 +20,7 @@
   - [x] TCP
   - [x] WS
   - [x] TLS
+    - [x] Reality (**Experimental, TCP Only**)
   - [x] gRPC
   - [x] Meek
   - [x] HTTPUpgrade

--- a/docs/zh/proxy-protocols.md
+++ b/docs/zh/proxy-protocols.md
@@ -20,6 +20,7 @@
   - [x] TCP
   - [x] WS
   - [x] TLS
+    - [x] Reality (**实验性，目前仅支持 TCP**)
   - [x] gRPC
   - [x] Meek
   - [x] HTTPUpgrade


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

[The reality support for TCP protocol](https://github.com/daeuniverse/dae/pull/573) has been merged. Therefore, the documentation needs to be updated respectively.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- Add reality tcp support in ```proxy-protocols.md```
