### PR TITLE
feat(trace): add drop-only option

### DIFF
--- a/cmd/trace.go
+++ b/cmd/trace.go
@@ -67,7 +67,7 @@ func init() {
 	traceCmd.PersistentFlags().BoolVarP(&IPv6, "ipv6", "6", false, "Capture IPv6 traffic")
 	traceCmd.PersistentFlags().StringVarP(&L4Proto, "l4-proto", "p", "tcp", "Layer 4 protocol")
 	traceCmd.PersistentFlags().IntVarP(&Port, "port", "P", 80, "Port")
-	traceCmd.PersistentFlags().BoolVarP(&DropOnly, "drop-only", "", true, "only trace the dropped package")
+	traceCmd.PersistentFlags().BoolVarP(&DropOnly, "drop-only", "", false, "only trace the dropped package")
 	traceCmd.PersistentFlags().StringVarP(&OutputFile, "output", "o", "/dev/stdout", "Output file")
 
 	rootCmd.AddCommand(traceCmd)

--- a/cmd/trace.go
+++ b/cmd/trace.go
@@ -24,6 +24,7 @@ var (
 	L4Proto    string
 	Port       int
 	OutputFile string
+	DropOnly   bool
 )
 
 func init() {
@@ -56,7 +57,7 @@ func init() {
 
 			ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 			defer cancel()
-			if err := trace.StartTrace(ctx, IPVersion, L4ProtoNo, Port, OutputFile); err != nil {
+			if err := trace.StartTrace(ctx, IPVersion, L4ProtoNo, Port, DropOnly, OutputFile); err != nil {
 				logrus.Fatalln(err)
 			}
 		},
@@ -66,6 +67,7 @@ func init() {
 	traceCmd.PersistentFlags().BoolVarP(&IPv6, "ipv6", "6", false, "Capture IPv6 traffic")
 	traceCmd.PersistentFlags().StringVarP(&L4Proto, "l4-proto", "p", "tcp", "Layer 4 protocol")
 	traceCmd.PersistentFlags().IntVarP(&Port, "port", "P", 80, "Port")
+	traceCmd.PersistentFlags().BoolVarP(&DropOnly, "drop-only", "", true, "only trace the dropped package")
 	traceCmd.PersistentFlags().StringVarP(&OutputFile, "output", "o", "/dev/stdout", "Output file")
 
 	rootCmd.AddCommand(traceCmd)

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -315,6 +315,7 @@ func handleEvents(ctx context.Context, objs *bpfObjects, outputFile string, kfre
 						fmt.Fprintf(writer, "\n")
 					}
 				delete(skb2events, event.Skb)
+                delete(skb2symNames, event.Skb)
 			    }
 		}
 	}

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -295,7 +295,7 @@ func handleEvents(ctx context.Context, objs *bpfObjects, outputFile string, kfre
 			case "__kfree_skb","kfree_skbmem":
 				// most skb end in the call of kfree_skbmem
 			    if !dropOnly || slices.Contains(skb2sysNames[event.Skb],"kfree_skb_reason") {
-					// track dropOnly with drop reason or all skb
+					// trace dropOnly with drop reason or all skb
 					for _,skb_ev := range skb2events[event.Skb] {
 						fmt.Fprintf(writer, "%x mark=%x netns=%010d if=%d(%s) proc=%d(%s) ", skb_ev.Skb, skb_ev.Mark, skb_ev.Netns, skb_ev.Ifindex, TrimNull(string(skb_ev.Ifname[:])), skb_ev.Pid, TrimNull(string(skb_ev.Pname[:])))
 						if event.L3Proto == syscall.ETH_P_IP {

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -294,7 +294,7 @@ func handleEvents(ctx context.Context, objs *bpfObjects, outputFile string, kfre
 		switch sym.Name {
 			case "__kfree_skb","kfree_skbmem":
 				// most skb end in the call of kfree_skbmem
-			    if !dropOnly || slices.Contains(skb2sysNames[event.Skb],"kfree_skb_reason") {
+			    if !dropOnly || slices.Contains(skb2symNames[event.Skb],"kfree_skb_reason") {
 					// trace dropOnly with drop reason or all skb
 					for _,skb_ev := range skb2events[event.Skb] {
 						fmt.Fprintf(writer, "%x mark=%x netns=%010d if=%d(%s) proc=%d(%s) ", skb_ev.Skb, skb_ev.Mark, skb_ev.Netns, skb_ev.Ifindex, TrimNull(string(skb_ev.Ifname[:])), skb_ev.Pid, TrimNull(string(skb_ev.Pname[:])))

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -262,8 +262,8 @@ func handleEvents(ctx context.Context, objs *bpfObjects, outputFile string, kfre
 	var	skb2events map[uint64][]bpfEvent
 	skb2events = make(map[uint64][]bpfEvent)
 	// a map to save slices of bpfEvent of the Skb
-	var skb2sysNames map[uint64][]string
-	skb2sysNames = make(map[uint64][]string)
+	var skb2symNames map[uint64][]string
+	skb2symNames = make(map[uint64][]string)
 	// a map to save slices of function name called with the Skb
 	for {
 		rec, err := eventsReader.Read()
@@ -287,10 +287,10 @@ func handleEvents(ctx context.Context, objs *bpfObjects, outputFile string, kfre
 
 
 		sym := NearestSymbol(event.Pc);
-		if skb2sysNames[event.Skb]==nil {
-			skb2sysNames[event.Skb] = []string{}
+		if skb2symNames[event.Skb]==nil {
+			skb2symNames[event.Skb] = []string{}
 		}
-		skb2sysNames[event.Skb] = append(skb2sysNames[event.Skb],sym.Name)
+		skb2symNames[event.Skb] = append(skb2symNames[event.Skb],sym.Name)
 		switch sym.Name {
 			case "__kfree_skb","kfree_skbmem":
 				// most skb end in the call of kfree_skbmem

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -259,11 +259,9 @@ func handleEvents(ctx context.Context, objs *bpfObjects, outputFile string, kfre
 		PayloadLen  uint16
 	}
 
-	var	skb2events map[uint64][]bpfEvent
-	skb2events = make(map[uint64][]bpfEvent)
+	skb2events := make(map[uint64][]bpfEvent)
 	// a map to save slices of bpfEvent of the Skb
-	var skb2symNames map[uint64][]string
-	skb2symNames = make(map[uint64][]string)
+	skb2symNames := make(map[uint64][]string)
 	// a map to save slices of function name called with the Skb
 	for {
 		rec, err := eventsReader.Read()


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background
#524 
Currently `dae trace` dumps huge amount of packets, most of them are not necessary. In most cases, we care about packets that are dropped by kernel, aka processed by kernel function `kfree_skb_reason`, or called by `kfree_skbmem` but without `consume_skb`.


### Checklist

- [x] The Pull Request has been fully tested
- [x] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- Add `--drop-only` option to where dae only prints the packets dropped by kernel.
- `dae trace` now print all the skbs of a packet until the packet is freed by kernel, whether it runs with `--drop-only` or not.

### Issue Reference

Closes #524 

### Test Result


start tracing
ffff9e800e629d00 mark=0 netns=4026531840 if=2(ens18) proc=735(/usr/bin/dae) 142.250.197.174:80 > 192.168.1.101:33334 tcp_flags=.F payload_len=0 tcp_v4_early_demux
ffff9e800e629d00 mark=0 netns=4026531840 if=2(ens18) proc=735(/usr/bin/dae) 142.250.197.174:80 > 192.168.1.101:33334 tcp_flags=.F payload_len=0 ip_route_input_noref
ffff9e800e629d00 mark=0 netns=4026531840 if=2(ens18) proc=735(/usr/bin/dae) 142.250.197.174:80 > 192.168.1.101:33334 tcp_flags=.F payload_len=0 ip_route_input_slow
ffff9e800e629d00 mark=0 netns=4026531840 if=2(ens18) proc=735(/usr/bin/dae) 142.250.197.174:80 > 192.168.1.101:33334 tcp_flags=.F payload_len=0 fib_validate_source
ffff9e800e629d00 mark=0 netns=4026531840 if=2(ens18) proc=735(/usr/bin/dae) 142.250.197.174:80 > 192.168.1.101:33334 tcp_flags=.F payload_len=0 __fib_validate_source
ffff9e800e629d00 mark=0 netns=4026531840 if=2(ens18) proc=735(/usr/bin/dae) 142.250.197.174:80 > 192.168.1.101:33334 tcp_flags=.F payload_len=0 ip_local_deliver
ffff9e800e629d00 mark=0 netns=4026531840 if=2(ens18) proc=735(/usr/bin/dae) 142.250.197.174:80 > 192.168.1.101:33334 tcp_flags=.F payload_len=0 ip_local_deliver_finish
ffff9e800e629d00 mark=0 netns=4026531840 if=2(ens18) proc=735(/usr/bin/dae) 142.250.197.174:80 > 192.168.1.101:33334 tcp_flags=.F payload_len=0 ip_protocol_deliver_rcu
ffff9e800e629d00 mark=0 netns=4026531840 if=2(ens18) proc=735(/usr/bin/dae) 142.250.197.174:80 > 192.168.1.101:33334 tcp_flags=.F payload_len=0 raw_local_deliver
ffff9e800e629d00 mark=0 netns=4026531840 if=2(ens18) proc=735(/usr/bin/dae) 142.250.197.174:80 > 192.168.1.101:33334 tcp_flags=.F payload_len=0 tcp_v4_rcv
ffff9e800e629d00 mark=0 netns=4026531840 if=2(ens18) proc=735(/usr/bin/dae) 142.250.197.174:80 > 192.168.1.101:33334 tcp_flags=.F payload_len=0 tcp_v4_fill_cb
ffff9e800e629d00 mark=0 netns=4026531840 if=2(ens18) proc=735(/usr/bin/dae) 142.250.197.174:80 > 192.168.1.101:33334 tcp_flags=.F payload_len=0 tcp_timewait_state_process
ffff9e800e629d00 mark=0 netns=4026531840 if=2(ens18) proc=735(/usr/bin/dae) 142.250.197.174:80 > 192.168.1.101:33334 tcp_flags=.F payload_len=0 tcp_v4_send_ack
ffff9e800e629d00 mark=0 netns=4026531840 if=2(ens18) proc=735(/usr/bin/dae) 142.250.197.174:80 > 192.168.1.101:33334 tcp_flags=.F payload_len=0 ip_send_unicast_reply
ffff9e800e629d00 mark=0 netns=4026531840 if=2(ens18) proc=735(/usr/bin/dae) 142.250.197.174:80 > 192.168.1.101:33334 tcp_flags=.F payload_len=0 __ip_options_echo
ffff9e800e629d00 mark=0 netns=4026531840 if=2(ens18) proc=735(/usr/bin/dae) 142.250.197.174:80 > 192.168.1.101:33334 tcp_flags=.F payload_len=0 security_skb_classify_flow
ffff9e800e629d00 mark=0 netns=4026531840 if=2(ens18) proc=735(/usr/bin/dae) 142.250.197.174:80 > 192.168.1.101:33334 tcp_flags=.F payload_len=0 bpf_lsm_xfrm_decode_session
ffff9e800e629d00 mark=0 netns=4026531840 if=2(ens18) proc=735(/usr/bin/dae) 142.250.197.174:80 > 192.168.1.101:33334 tcp_flags=.F payload_len=0 kfree_skb_reason(SKB_DROP_REASON_NOT_SPECIFIED)
ffff9e800e629d00 mark=0 netns=4026531840 if=2(ens18) proc=735(/usr/bin/dae) 142.250.197.174:80 > 192.168.1.101:33334 tcp_flags=.F payload_len=0 skb_release_head_state
ffff9e800e629d00 mark=0 netns=4026531840 if=2(ens18) proc=735(/usr/bin/dae) 142.250.197.174:80 > 192.168.1.101:33334 tcp_flags=.F payload_len=0 skb_release_data
ffff9e800e629d00 mark=0 netns=4026531840 if=2(ens18) proc=735(/usr/bin/dae) 142.250.197.174:80 > 192.168.1.101:33334 tcp_flags=.F payload_len=0 kfree_skbmem

