### PR TITLE
refactor: reuse existing functions & format code

### DIFF
--- a/control/kern/tproxy.c
+++ b/control/kern/tproxy.c
@@ -1877,6 +1877,7 @@ int local_tcp_sockops(struct bpf_sock_ops *skops)
 	case BPF_SOCK_OPS_PASSIVE_ESTABLISHED_CB: // dae sockets
 	{
 		struct tuples_key rev_tuple = {};
+
 		copy_reversed_tuples(&tuple, &rev_tuple);
 
 		struct routing_result *routing_result;

--- a/control/kern/tproxy.c
+++ b/control/kern/tproxy.c
@@ -1639,17 +1639,23 @@ int tproxy_dae0_ingress(struct __sk_buff *skb)
 	struct redirect_tuple redirect_tuple = {};
 
 	if (skb->protocol == bpf_htons(ETH_P_IP)) {
-		bpf_skb_load_bytes(skb, ETH_HLEN + offsetof(struct iphdr, daddr),
+		bpf_skb_load_bytes(skb,
+				   ETH_HLEN + offsetof(struct iphdr, daddr),
 				   &redirect_tuple.sip.u6_addr32[3],
 				   sizeof(redirect_tuple.sip.u6_addr32[3]));
-		bpf_skb_load_bytes(skb, ETH_HLEN + offsetof(struct iphdr, saddr),
+		bpf_skb_load_bytes(skb,
+				   ETH_HLEN + offsetof(struct iphdr, saddr),
 				   &redirect_tuple.dip.u6_addr32[3],
 				   sizeof(redirect_tuple.dip.u6_addr32[3]));
 	} else {
-		bpf_skb_load_bytes(skb, ETH_HLEN + offsetof(struct ipv6hdr, daddr),
-				   &redirect_tuple.sip, sizeof(redirect_tuple.sip));
-		bpf_skb_load_bytes(skb, ETH_HLEN + offsetof(struct ipv6hdr, saddr),
-				   &redirect_tuple.dip, sizeof(redirect_tuple.dip));
+		bpf_skb_load_bytes(skb,
+				   ETH_HLEN + offsetof(struct ipv6hdr, daddr),
+				   &redirect_tuple.sip,
+				   sizeof(redirect_tuple.sip));
+		bpf_skb_load_bytes(skb,
+				   ETH_HLEN + offsetof(struct ipv6hdr, saddr),
+				   &redirect_tuple.dip,
+				   sizeof(redirect_tuple.dip));
 	}
 	struct redirect_entry *redirect_entry =
 		bpf_map_lookup_elem(&redirect_track, &redirect_tuple);
@@ -1871,12 +1877,7 @@ int local_tcp_sockops(struct bpf_sock_ops *skops)
 	case BPF_SOCK_OPS_PASSIVE_ESTABLISHED_CB: // dae sockets
 	{
 		struct tuples_key rev_tuple = {};
-
-		rev_tuple.l4proto = IPPROTO_TCP;
-		rev_tuple.sport = tuple.dport;
-		rev_tuple.dport = tuple.sport;
-		__builtin_memcpy(&rev_tuple.sip, &tuple.dip, IPV6_BYTE_LENGTH);
-		__builtin_memcpy(&rev_tuple.dip, &tuple.sip, IPV6_BYTE_LENGTH);
+		copy_reversed_tuples(&tuple, &rev_tuple);
 
 		struct routing_result *routing_result;
 


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

- Fucntion ```copy_reversed_tuples()``` can be reused.
- Code is not formatted.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- Reuse function ```copy_reversed_tuples()``` & format code

### Test Result

<!--- Attach test result here. -->
