### PR TITLE
feat: support bandwidth configuration

### DIFF
--- a/component/outbound/dialer/dialer.go
+++ b/component/outbound/dialer/dialer.go
@@ -68,7 +68,9 @@ func NewGlobalOption(global *config.Global, log *logrus.Logger) *GlobalOption {
 		ExtraOption: D.ExtraOption{
 			AllowInsecure:     global.AllowInsecure,
 			TlsImplementation: global.TlsImplementation,
-			UtlsImitate:       global.UtlsImitate},
+			UtlsImitate:       global.UtlsImitate,
+			BandwidthMaxTx:    global.BandwidthMaxTx,
+			BandwidthMaxRx:    global.BandwidthMaxRx},
 		Log:               log,
 		TcpCheckOptionRaw: TcpCheckOptionRaw{Raw: global.TcpCheckUrl, Log: log, ResolverNetwork: common.MagicNetwork("udp", global.SoMarkFromDae, global.Mptcp), Method: global.TcpCheckHttpMethod},
 		CheckDnsOptionRaw: CheckDnsOptionRaw{Raw: global.UdpCheckDns, ResolverNetwork: common.MagicNetwork("udp", global.SoMarkFromDae, global.Mptcp), Somark: global.SoMarkFromDae},

--- a/config/config.go
+++ b/config/config.go
@@ -43,6 +43,9 @@ type Global struct {
 	UtlsImitate            string        `mapstructure:"utls_imitate" default:"chrome_auto"`
 	PprofPort              uint16        `mapstructure:"pprof_port" default:"0"`
 	Mptcp                  bool          `mapstructure:"mptcp" default:"false"`
+	// TODO: support input in human-readable format (e.g., 100Mbps, 1Gbps)
+	BandwidthMaxTx uint64 `mapstructure:"bandwidth_max_tx" default:"0"`
+	BandwidthMaxRx uint64 `mapstructure:"bandwidth_max_rx" default:"0"`
 }
 
 type Utls struct {

--- a/example.dae
+++ b/example.dae
@@ -101,6 +101,11 @@ global {
     # Multipath TCP (MPTCP) support. If is true, dae will try to use MPTCP to connect all nodes, but it will only take
     # effects when the node supports MPTCP. It can use for load balance and failover to multiple interfaces and IPs.
     mptcp: false
+
+    # The maximum bandwidth for accessing the Internet. It is useful for some specific protocols (e.g., Hysteria2), 
+    # which will perform better with bandwith information provided. The unit is **byte** per second.
+    bandwidth_max_tx: 26214400 # 200Mbps == 25MB/s == 26214400 B/s uplink
+    bandwidth_max_rx: 131072000 # 1Gbps == 125MB/s == 131072000 B/s downlink
 }
 
 # Subscriptions defined here will be resolved as nodes and merged as a part of the global node pool.

--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	google.golang.org/grpc v1.57.0 // indirect
 )
 
-// replace github.com/daeuniverse/outbound => ../outbound
+replace github.com/daeuniverse/outbound => github.com/mnixry/outbound v0.0.0-20240919003433-25791206b863
 
 // replace github.com/daeuniverse/quic-go => ../quic-go
 

--- a/go.mod
+++ b/go.mod
@@ -8,13 +8,14 @@ require (
 	github.com/bits-and-blooms/bloom/v3 v3.5.0
 	github.com/cilium/ebpf v0.12.3
 	github.com/daeuniverse/dae-config-dist/go/dae_config v0.0.0-20230604120805-1c27619b592d
-	github.com/daeuniverse/outbound v0.0.0-20240926143218-3cf58cdd942f
+	github.com/daeuniverse/outbound v0.0.0-20240926154105-c01ad3a54a38
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/json-iterator/go v1.1.12
 	github.com/mholt/archiver/v3 v3.5.1
 	github.com/miekg/dns v1.1.58
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/okzk/sdnotify v0.0.0-20180710141335-d9becc38acbd
+	github.com/panjf2000/ants v1.3.0
 	github.com/safchain/ethtool v0.3.0
 	github.com/shirou/gopsutil/v4 v4.24.5
 	github.com/sirupsen/logrus v1.9.3
@@ -50,7 +51,6 @@ require (
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/nwaples/rardecode v1.1.0 // indirect
 	github.com/onsi/ginkgo/v2 v2.11.0 // indirect
-	github.com/panjf2000/ants v1.3.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
@@ -96,7 +96,7 @@ require (
 	google.golang.org/grpc v1.57.0 // indirect
 )
 
-replace github.com/daeuniverse/outbound => github.com/mnixry/outbound v0.0.0-20240921063838-5f2aa05357f0
+// replace github.com/daeuniverse/outbound => ../outbound
 
 // replace github.com/daeuniverse/quic-go => ../quic-go
 

--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	google.golang.org/grpc v1.57.0 // indirect
 )
 
-replace github.com/daeuniverse/outbound => github.com/mnixry/outbound v0.0.0-20240919190537-75554f8247d9
+replace github.com/daeuniverse/outbound => github.com/mnixry/outbound v0.0.0-20240921063838-5f2aa05357f0
 
 // replace github.com/daeuniverse/quic-go => ../quic-go
 

--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	google.golang.org/grpc v1.57.0 // indirect
 )
 
-replace github.com/daeuniverse/outbound => github.com/mnixry/outbound v0.0.0-20240919003433-25791206b863
+replace github.com/daeuniverse/outbound => github.com/mnixry/outbound v0.0.0-20240919190537-75554f8247d9
 
 // replace github.com/daeuniverse/quic-go => ../quic-go
 

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBS
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/daeuniverse/dae-config-dist/go/dae_config v0.0.0-20230604120805-1c27619b592d h1:hnC39MjR7xt5kZjrKlef7DXKFDkiX8MIcDXYC/6Jf9Q=
 github.com/daeuniverse/dae-config-dist/go/dae_config v0.0.0-20230604120805-1c27619b592d/go.mod h1:VGWGgv7pCP5WGyHGUyb9+nq/gW0yBm+i/GfCNATOJ1M=
+github.com/daeuniverse/outbound v0.0.0-20240926154105-c01ad3a54a38 h1:O+lD0zchAn+rn76Y4ol2G9qiGdF7nVYwCyrPqpMvRkc=
+github.com/daeuniverse/outbound v0.0.0-20240926154105-c01ad3a54a38/go.mod h1:0dkFMC58MVUWMB19jwQuXEg1G16uAIAtdAU7v+yWXYs=
 github.com/daeuniverse/quic-go v0.0.0-20240413031024-943f218e0810 h1:YtEYouFaNrg9sV9vf3UabvKShKn6sD0QaCdOxCwaF3g=
 github.com/daeuniverse/quic-go v0.0.0-20240413031024-943f218e0810/go.mod h1:61o2uZUGLrlv1i+oO2rx9sVX0vbf8cHzdSHt7h6lMnM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -114,8 +116,6 @@ github.com/mholt/archiver/v3 v3.5.1 h1:rDjOBX9JSF5BvoJGvjqK479aL70qh9DIpZCl+k7Cl
 github.com/mholt/archiver/v3 v3.5.1/go.mod h1:e3dqJ7H78uzsRSEACH1joayhuSyhnonssnDhppzS1L4=
 github.com/miekg/dns v1.1.58 h1:ca2Hdkz+cDg/7eNF6V56jjzuZ4aCAE+DbVkILdQWG/4=
 github.com/miekg/dns v1.1.58/go.mod h1:Ypv+3b/KadlvW9vJfXOTf300O4UqaHFzFCuHz+rPkBY=
-github.com/mnixry/outbound v0.0.0-20240921063838-5f2aa05357f0 h1:+5MvVaE0Guqe+UaRFRjA43jmvbnKcmZoA+v6yHfezxs=
-github.com/mnixry/outbound v0.0.0-20240921063838-5f2aa05357f0/go.mod h1:0dkFMC58MVUWMB19jwQuXEg1G16uAIAtdAU7v+yWXYs=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/mholt/archiver/v3 v3.5.1 h1:rDjOBX9JSF5BvoJGvjqK479aL70qh9DIpZCl+k7Cl
 github.com/mholt/archiver/v3 v3.5.1/go.mod h1:e3dqJ7H78uzsRSEACH1joayhuSyhnonssnDhppzS1L4=
 github.com/miekg/dns v1.1.58 h1:ca2Hdkz+cDg/7eNF6V56jjzuZ4aCAE+DbVkILdQWG/4=
 github.com/miekg/dns v1.1.58/go.mod h1:Ypv+3b/KadlvW9vJfXOTf300O4UqaHFzFCuHz+rPkBY=
-github.com/mnixry/outbound v0.0.0-20240919190537-75554f8247d9 h1:yZqhyMYwxnPYf/dhuiCemGj03RCplvj6+sO+lZojJHw=
-github.com/mnixry/outbound v0.0.0-20240919190537-75554f8247d9/go.mod h1:0dkFMC58MVUWMB19jwQuXEg1G16uAIAtdAU7v+yWXYs=
+github.com/mnixry/outbound v0.0.0-20240921063838-5f2aa05357f0 h1:+5MvVaE0Guqe+UaRFRjA43jmvbnKcmZoA+v6yHfezxs=
+github.com/mnixry/outbound v0.0.0-20240921063838-5f2aa05357f0/go.mod h1:0dkFMC58MVUWMB19jwQuXEg1G16uAIAtdAU7v+yWXYs=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,6 @@ github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBS
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/daeuniverse/dae-config-dist/go/dae_config v0.0.0-20230604120805-1c27619b592d h1:hnC39MjR7xt5kZjrKlef7DXKFDkiX8MIcDXYC/6Jf9Q=
 github.com/daeuniverse/dae-config-dist/go/dae_config v0.0.0-20230604120805-1c27619b592d/go.mod h1:VGWGgv7pCP5WGyHGUyb9+nq/gW0yBm+i/GfCNATOJ1M=
-github.com/daeuniverse/outbound v0.0.0-20240911144232-d470a59233a5 h1:L450vqT1TO+Ygzd8buBMna8d4/0asT0q74qitGTWSl4=
-github.com/daeuniverse/outbound v0.0.0-20240911144232-d470a59233a5/go.mod h1:0dkFMC58MVUWMB19jwQuXEg1G16uAIAtdAU7v+yWXYs=
 github.com/daeuniverse/quic-go v0.0.0-20240413031024-943f218e0810 h1:YtEYouFaNrg9sV9vf3UabvKShKn6sD0QaCdOxCwaF3g=
 github.com/daeuniverse/quic-go v0.0.0-20240413031024-943f218e0810/go.mod h1:61o2uZUGLrlv1i+oO2rx9sVX0vbf8cHzdSHt7h6lMnM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -113,6 +111,8 @@ github.com/mholt/archiver/v3 v3.5.1 h1:rDjOBX9JSF5BvoJGvjqK479aL70qh9DIpZCl+k7Cl
 github.com/mholt/archiver/v3 v3.5.1/go.mod h1:e3dqJ7H78uzsRSEACH1joayhuSyhnonssnDhppzS1L4=
 github.com/miekg/dns v1.1.58 h1:ca2Hdkz+cDg/7eNF6V56jjzuZ4aCAE+DbVkILdQWG/4=
 github.com/miekg/dns v1.1.58/go.mod h1:Ypv+3b/KadlvW9vJfXOTf300O4UqaHFzFCuHz+rPkBY=
+github.com/mnixry/outbound v0.0.0-20240919003433-25791206b863 h1:Ft99/APv5dN/fjMoDZq6A2K7VZ5uBlunCRgv932nQnk=
+github.com/mnixry/outbound v0.0.0-20240919003433-25791206b863/go.mod h1:0dkFMC58MVUWMB19jwQuXEg1G16uAIAtdAU7v+yWXYs=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/mholt/archiver/v3 v3.5.1 h1:rDjOBX9JSF5BvoJGvjqK479aL70qh9DIpZCl+k7Cl
 github.com/mholt/archiver/v3 v3.5.1/go.mod h1:e3dqJ7H78uzsRSEACH1joayhuSyhnonssnDhppzS1L4=
 github.com/miekg/dns v1.1.58 h1:ca2Hdkz+cDg/7eNF6V56jjzuZ4aCAE+DbVkILdQWG/4=
 github.com/miekg/dns v1.1.58/go.mod h1:Ypv+3b/KadlvW9vJfXOTf300O4UqaHFzFCuHz+rPkBY=
-github.com/mnixry/outbound v0.0.0-20240919003433-25791206b863 h1:Ft99/APv5dN/fjMoDZq6A2K7VZ5uBlunCRgv932nQnk=
-github.com/mnixry/outbound v0.0.0-20240919003433-25791206b863/go.mod h1:0dkFMC58MVUWMB19jwQuXEg1G16uAIAtdAU7v+yWXYs=
+github.com/mnixry/outbound v0.0.0-20240919190537-75554f8247d9 h1:yZqhyMYwxnPYf/dhuiCemGj03RCplvj6+sO+lZojJHw=
+github.com/mnixry/outbound v0.0.0-20240919190537-75554f8247d9/go.mod h1:0dkFMC58MVUWMB19jwQuXEg1G16uAIAtdAU7v+yWXYs=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->
ref: https://github.com/daeuniverse/outbound/pull/21

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- Implement bandwidth config parsing in dae:

	```
	global {
		...
	
	    # The maximum bandwidth for accessing the Internet. It is useful for some specific protocols (e.g., Hysteria2), 
	    # which will perform better with bandwith information provided. The unit is **byte** per second.
	    bandwidth_max_tx: 26214400 # 200Mbps == 25MB/s == 26214400 B/s uplink
	    bandwidth_max_rx: 131072000 # 1Gbps == 125MB/s == 131072000 B/s downlink
	}
	```

- Improve handling for `insecure` parameter in hysteria2 URI parsing.

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
