### PR TITLE
fix: compatible issue when DNS msg not be compressed

### DIFF
--- a/control/dns_control.go
+++ b/control/dns_control.go
@@ -484,7 +484,6 @@ func (c *DnsController) handle_(
 	}
 
 	// Re-pack DNS packet.
-	dnsMessage.Compress = true
 	data, err := dnsMessage.Pack()
 	if err != nil {
 		return fmt.Errorf("pack DNS packet: %w", err)
@@ -499,12 +498,12 @@ func (c *DnsController) sendReject_(dnsMessage *dnsmessage.Msg, req *udpRequest)
 	dnsMessage.Response = true
 	dnsMessage.RecursionAvailable = true
 	dnsMessage.Truncated = false
+	dnsMessage.Compress = true
 	if c.log.IsLevelEnabled(logrus.TraceLevel) {
 		c.log.WithFields(logrus.Fields{
 			"question": dnsMessage.Question,
 		}).Traceln("Reject")
 	}
-	dnsMessage.Compress = true
 	data, err := dnsMessage.Pack()
 	if err != nil {
 		return fmt.Errorf("pack DNS packet: %w", err)

--- a/control/dns_control.go
+++ b/control/dns_control.go
@@ -166,6 +166,7 @@ func (c *DnsController) LookupDnsRespCache_(msg *dnsmessage.Msg, cacheKey string
 	cache := c.LookupDnsRespCache(cacheKey, ignoreFixedTtl)
 	if cache != nil {
 		cache.FillInto(msg)
+		msg.Compress = true
 		b, err := msg.Pack()
 		if err != nil {
 			c.log.Warnf("failed to pack: %v", err)
@@ -483,6 +484,7 @@ func (c *DnsController) handle_(
 	}
 
 	// Re-pack DNS packet.
+	dnsMessage.Compress = true
 	data, err := dnsMessage.Pack()
 	if err != nil {
 		return fmt.Errorf("pack DNS packet: %w", err)
@@ -502,6 +504,7 @@ func (c *DnsController) sendReject_(dnsMessage *dnsmessage.Msg, req *udpRequest)
 			"question": dnsMessage.Question,
 		}).Traceln("Reject")
 	}
+	dnsMessage.Compress = true
 	data, err := dnsMessage.Pack()
 	if err != nil {
 		return fmt.Errorf("pack DNS packet: %w", err)
@@ -756,6 +759,7 @@ func (c *DnsController) dialSend(invokingDepth int, req *udpRequest, data []byte
 	if needResp {
 		// Keep the id the same with request.
 		respMsg.Id = id
+		respMsg.Compress = true
 		data, err = respMsg.Pack()
 		if err != nil {
 			return err


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

在 PS5 上打开糖豆人会卡在启动界面，一段时间后提示网络异常，抓包显示其一直在尝试发送 api.epicgames.dev 的 DNS 请求，猜测可能是 DNS 方面的问题，对比正常配置时的 DNS 数据包，发现正常配置时，DNS 响应中的域名对应数据都是一个很短的十六进制数字且都以 C0 开头
![CleanShot 2024-09-21 at 18 07 57@2x](https://github.com/user-attachments/assets/c938323d-c0ab-48d4-948c-07cb0dd2083a)
而异常的时候，域名对应的数据都是一个完整域名的十六进制
![CleanShot 2024-09-23 at 10 17 46@2x](https://github.com/user-attachments/assets/644f6107-dc54-42f5-b696-4b2a3a169ef3)

查询资料后得知这是 DNS 协议中的压缩选项，定义在 RFC 1035 中 https://datatracker.ietf.org/doc/html/rfc1035#section-4.1.4
所以怀疑是糖豆人客户端不兼容未压缩的 DNS 消息导致的，在修改代码开启压缩后，糖豆人正常启动，如测试结果所示，DNS 消息都正常压缩了

另外查看了国内阿里和腾讯的 DNS 都是默认开启压缩的，也就是业界是推荐默认开启压缩的，所以此改动应该不会造成兼容性问题，RFC 1305 中也提到客户端应该能解析两种格式的消息
阿里的
![CleanShot 2024-09-21 at 18 22 00@2x](https://github.com/user-attachments/assets/262f3d70-3016-4b59-af27-8936feb5c2e8)
腾讯的
![CleanShot 2024-09-21 at 18 23 57@2x](https://github.com/user-attachments/assets/4e809d73-5a47-4bad-916e-fa16cdc5d0a2)
抓包数据 
[归档.zip](https://github.com/user-attachments/files/17083645/default.zip)

### Checklist

- [x] The Pull Request has been fully tested
- [x] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- fix: compatible issue when DNS msg not be compressed

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #338

### Test Result

![CleanShot 2024-09-21 at 18 20 20@2x](https://github.com/user-attachments/assets/4dc74965-9f0d-4a83-9d51-7e4b9edb4f85)


