### PR TITLE
feat(dns): support DoH, DoT, DoH3, DoQ

### DIFF
--- a/component/dns/dns.go
+++ b/component/dns/dns.go
@@ -128,7 +128,7 @@ func New(dns *config.Dns, opt *NewOption) (s *Dns, err error) {
 
 func (s *Dns) CheckUpstreamsFormat() error {
 	for _, upstream := range s.upstream {
-		_, _, _, err := ParseRawUpstream(upstream.Raw)
+		_, _, _, _, err := ParseRawUpstream(upstream.Raw)
 		if err != nil {
 			return err
 		}

--- a/component/dns/upstream.go
+++ b/component/dns/upstream.go
@@ -33,7 +33,7 @@ const (
 	upstreamScheme_TLS           UpstreamScheme = "tls"
 	upstreamScheme_QUIC          UpstreamScheme = "quic"
 	upstreamScheme_HTTPS         UpstreamScheme = "https"
-	upstreamScheme_HTTP3         UpstreamScheme = "http3"
+	upstreamScheme_HTTP3         UpstreamScheme = "h3"
 )
 
 func (s UpstreamScheme) ContainsTcp() bool {

--- a/component/dns/upstream.go
+++ b/component/dns/upstream.go
@@ -53,14 +53,14 @@ func ParseRawUpstream(raw *url.URL) (scheme UpstreamScheme, hostname string, por
 	case upstreamScheme_TCP_UDP_Alias:
 		scheme = UpstreamScheme_TCP_UDP
 		fallthrough
-	case upstreamScheme_H3_Alias:
-		scheme = UpstreamScheme_H3
-		fallthrough
 	case UpstreamScheme_TCP, UpstreamScheme_UDP, UpstreamScheme_TCP_UDP:
 		__port = raw.Port()
 		if __port == "" {
 			__port = "53"
 		}
+	case upstreamScheme_H3_Alias:
+		scheme = UpstreamScheme_H3
+		fallthrough
 	case UpstreamScheme_HTTPS, UpstreamScheme_H3:
 		__port = raw.Port()
 		if __port == "" {

--- a/component/dns/upstream.go
+++ b/component/dns/upstream.go
@@ -31,7 +31,6 @@ const (
 	UpstreamScheme_TCP_UDP       UpstreamScheme = "tcp+udp"
 	upstreamScheme_TCP_UDP_Alias UpstreamScheme = "udp+tcp"
 	UpstreamScheme_TLS           UpstreamScheme = "tls"
-	UpstreamScheme_QUIC          UpstreamScheme = "quic"
 	UpstreamScheme_HTTPS         UpstreamScheme = "https"
 	upstreamScheme_H3_Alias      UpstreamScheme = "http3"
 	UpstreamScheme_H3            UpstreamScheme = "h3"
@@ -66,7 +65,7 @@ func ParseRawUpstream(raw *url.URL) (scheme UpstreamScheme, hostname string, por
 		if __port == "" {
 			__port = "443"
 		}
-	case UpstreamScheme_QUIC, UpstreamScheme_TLS:
+	case UpstreamScheme_TLS:
 		__port = raw.Port()
 		if __port == "" {
 			__port = "853"
@@ -135,7 +134,7 @@ func (u *Upstream) SupportedNetworks() (ipversions []consts.IpVersionStr, l4prot
 	switch u.Scheme {
 	case UpstreamScheme_TCP, UpstreamScheme_HTTPS, UpstreamScheme_TLS:
 		l4protos = []consts.L4ProtoStr{consts.L4ProtoStr_TCP}
-	case UpstreamScheme_UDP, UpstreamScheme_QUIC, UpstreamScheme_H3:
+	case UpstreamScheme_UDP, UpstreamScheme_H3:
 		l4protos = []consts.L4ProtoStr{consts.L4ProtoStr_UDP}
 	case UpstreamScheme_TCP_UDP:
 		// UDP first.

--- a/component/dns/upstream.go
+++ b/component/dns/upstream.go
@@ -30,6 +30,10 @@ const (
 	UpstreamScheme_UDP           UpstreamScheme = "udp"
 	UpstreamScheme_TCP_UDP       UpstreamScheme = "tcp+udp"
 	upstreamScheme_TCP_UDP_Alias UpstreamScheme = "udp+tcp"
+	upstreamScheme_TLS           UpstreamScheme = "tls"
+	upstreamScheme_QUIC          UpstreamScheme = "quic"
+	upstreamScheme_HTTPS         UpstreamScheme = "https"
+	upstreamScheme_HTTP3         UpstreamScheme = "http3"
 )
 
 func (s UpstreamScheme) ContainsTcp() bool {
@@ -52,6 +56,16 @@ func ParseRawUpstream(raw *url.URL) (scheme UpstreamScheme, hostname string, por
 		__port = raw.Port()
 		if __port == "" {
 			__port = "53"
+		}
+	case upstreamScheme_HTTPS, upstreamScheme_HTTP3:
+		__port = raw.Port()
+		if __port == "" {
+			__port = "443"
+		}
+	case upstreamScheme_QUIC, upstreamScheme_TLS:
+		__port = raw.Port()
+		if __port == "" {
+			__port = "853"
 		}
 	default:
 		return "", "", 0, fmt.Errorf("unexpected scheme: %v", raw.Scheme)
@@ -115,9 +129,9 @@ func (u *Upstream) SupportedNetworks() (ipversions []consts.IpVersionStr, l4prot
 		}
 	}
 	switch u.Scheme {
-	case UpstreamScheme_TCP:
+	case UpstreamScheme_TCP, upstreamScheme_HTTPS, upstreamScheme_TLS:
 		l4protos = []consts.L4ProtoStr{consts.L4ProtoStr_TCP}
-	case UpstreamScheme_UDP:
+	case UpstreamScheme_UDP, upstreamScheme_QUIC, upstreamScheme_HTTP3:
 		l4protos = []consts.L4ProtoStr{consts.L4ProtoStr_UDP}
 	case UpstreamScheme_TCP_UDP:
 		// UDP first.

--- a/component/dns/upstream.go
+++ b/component/dns/upstream.go
@@ -33,7 +33,7 @@ const (
 	UpstreamScheme_TLS           UpstreamScheme = "tls"
 	UpstreamScheme_QUIC          UpstreamScheme = "quic"
 	UpstreamScheme_HTTPS         UpstreamScheme = "https"
-	UpstreamScheme_HTTP3         UpstreamScheme = "http3"
+	upstreamScheme_H3_Alias      UpstreamScheme = "http3"
 	UpstreamScheme_H3            UpstreamScheme = "h3"
 )
 
@@ -53,12 +53,15 @@ func ParseRawUpstream(raw *url.URL) (scheme UpstreamScheme, hostname string, por
 	case upstreamScheme_TCP_UDP_Alias:
 		scheme = UpstreamScheme_TCP_UDP
 		fallthrough
+	case upstreamScheme_H3_Alias:
+		scheme = UpstreamScheme_H3
+		fallthrough
 	case UpstreamScheme_TCP, UpstreamScheme_UDP, UpstreamScheme_TCP_UDP:
 		__port = raw.Port()
 		if __port == "" {
 			__port = "53"
 		}
-	case UpstreamScheme_HTTPS, UpstreamScheme_HTTP3, UpstreamScheme_H3:
+	case UpstreamScheme_HTTPS, UpstreamScheme_H3:
 		__port = raw.Port()
 		if __port == "" {
 			__port = "443"
@@ -132,7 +135,7 @@ func (u *Upstream) SupportedNetworks() (ipversions []consts.IpVersionStr, l4prot
 	switch u.Scheme {
 	case UpstreamScheme_TCP, UpstreamScheme_HTTPS, UpstreamScheme_TLS:
 		l4protos = []consts.L4ProtoStr{consts.L4ProtoStr_TCP}
-	case UpstreamScheme_UDP, UpstreamScheme_QUIC, UpstreamScheme_HTTP3, UpstreamScheme_H3:
+	case UpstreamScheme_UDP, UpstreamScheme_QUIC, UpstreamScheme_H3:
 		l4protos = []consts.L4ProtoStr{consts.L4ProtoStr_UDP}
 	case UpstreamScheme_TCP_UDP:
 		// UDP first.

--- a/component/dns/upstream.go
+++ b/component/dns/upstream.go
@@ -30,10 +30,11 @@ const (
 	UpstreamScheme_UDP           UpstreamScheme = "udp"
 	UpstreamScheme_TCP_UDP       UpstreamScheme = "tcp+udp"
 	upstreamScheme_TCP_UDP_Alias UpstreamScheme = "udp+tcp"
-	upstreamScheme_TLS           UpstreamScheme = "tls"
-	upstreamScheme_QUIC          UpstreamScheme = "quic"
-	upstreamScheme_HTTPS         UpstreamScheme = "https"
-	upstreamScheme_HTTP3         UpstreamScheme = "h3"
+	UpstreamScheme_TLS           UpstreamScheme = "tls"
+	UpstreamScheme_QUIC          UpstreamScheme = "quic"
+	UpstreamScheme_HTTPS         UpstreamScheme = "https"
+	UpstreamScheme_HTTP3         UpstreamScheme = "http3"
+	UpstreamScheme_H3            UpstreamScheme = "h3"
 )
 
 func (s UpstreamScheme) ContainsTcp() bool {
@@ -57,12 +58,12 @@ func ParseRawUpstream(raw *url.URL) (scheme UpstreamScheme, hostname string, por
 		if __port == "" {
 			__port = "53"
 		}
-	case upstreamScheme_HTTPS, upstreamScheme_HTTP3:
+	case UpstreamScheme_HTTPS, UpstreamScheme_HTTP3, UpstreamScheme_H3:
 		__port = raw.Port()
 		if __port == "" {
 			__port = "443"
 		}
-	case upstreamScheme_QUIC, upstreamScheme_TLS:
+	case UpstreamScheme_QUIC, UpstreamScheme_TLS:
 		__port = raw.Port()
 		if __port == "" {
 			__port = "853"
@@ -129,9 +130,9 @@ func (u *Upstream) SupportedNetworks() (ipversions []consts.IpVersionStr, l4prot
 		}
 	}
 	switch u.Scheme {
-	case UpstreamScheme_TCP, upstreamScheme_HTTPS, upstreamScheme_TLS:
+	case UpstreamScheme_TCP, UpstreamScheme_HTTPS, UpstreamScheme_TLS:
 		l4protos = []consts.L4ProtoStr{consts.L4ProtoStr_TCP}
-	case UpstreamScheme_UDP, upstreamScheme_QUIC, upstreamScheme_HTTP3:
+	case UpstreamScheme_UDP, UpstreamScheme_QUIC, UpstreamScheme_HTTP3, UpstreamScheme_H3:
 		l4protos = []consts.L4ProtoStr{consts.L4ProtoStr_UDP}
 	case UpstreamScheme_TCP_UDP:
 		// UDP first.

--- a/component/dns/upstream.go
+++ b/component/dns/upstream.go
@@ -31,6 +31,7 @@ const (
 	UpstreamScheme_TCP_UDP       UpstreamScheme = "tcp+udp"
 	upstreamScheme_TCP_UDP_Alias UpstreamScheme = "udp+tcp"
 	UpstreamScheme_TLS           UpstreamScheme = "tls"
+	UpstreamScheme_QUIC          UpstreamScheme = "quic"
 	UpstreamScheme_HTTPS         UpstreamScheme = "https"
 	upstreamScheme_H3_Alias      UpstreamScheme = "http3"
 	UpstreamScheme_H3            UpstreamScheme = "h3"
@@ -65,7 +66,7 @@ func ParseRawUpstream(raw *url.URL) (scheme UpstreamScheme, hostname string, por
 		if __port == "" {
 			__port = "443"
 		}
-	case UpstreamScheme_TLS:
+	case UpstreamScheme_QUIC, UpstreamScheme_TLS:
 		__port = raw.Port()
 		if __port == "" {
 			__port = "853"
@@ -134,7 +135,7 @@ func (u *Upstream) SupportedNetworks() (ipversions []consts.IpVersionStr, l4prot
 	switch u.Scheme {
 	case UpstreamScheme_TCP, UpstreamScheme_HTTPS, UpstreamScheme_TLS:
 		l4protos = []consts.L4ProtoStr{consts.L4ProtoStr_TCP}
-	case UpstreamScheme_UDP, UpstreamScheme_H3:
+	case UpstreamScheme_UDP, UpstreamScheme_QUIC, UpstreamScheme_H3:
 		l4protos = []consts.L4ProtoStr{consts.L4ProtoStr_UDP}
 	case UpstreamScheme_TCP_UDP:
 		// UDP first.

--- a/component/dns/upstream.go
+++ b/component/dns/upstream.go
@@ -47,8 +47,9 @@ func (s UpstreamScheme) ContainsTcp() bool {
 	}
 }
 
-func ParseRawUpstream(raw *url.URL) (scheme UpstreamScheme, hostname string, port uint16, err error) {
+func ParseRawUpstream(raw *url.URL) (scheme UpstreamScheme, hostname string, port uint16, path string, err error) {
 	var __port string
+	var __path string
 	switch scheme = UpstreamScheme(raw.Scheme); scheme {
 	case upstreamScheme_TCP_UDP_Alias:
 		scheme = UpstreamScheme_TCP_UDP
@@ -66,32 +67,37 @@ func ParseRawUpstream(raw *url.URL) (scheme UpstreamScheme, hostname string, por
 		if __port == "" {
 			__port = "443"
 		}
+		__path = raw.Path
+		if __path == "" {
+			__path = "/dns-query"
+		}
 	case UpstreamScheme_QUIC, UpstreamScheme_TLS:
 		__port = raw.Port()
 		if __port == "" {
 			__port = "853"
 		}
 	default:
-		return "", "", 0, fmt.Errorf("unexpected scheme: %v", raw.Scheme)
+		return "", "", 0, "", fmt.Errorf("unexpected scheme: %v", raw.Scheme)
 	}
 	_port, err := strconv.ParseUint(__port, 10, 16)
 	if err != nil {
-		return "", "", 0, fmt.Errorf("failed to parse dns_upstream port: %v", err)
+		return "", "", 0, "", fmt.Errorf("failed to parse dns_upstream port: %v", err)
 	}
 	port = uint16(_port)
 	hostname = raw.Hostname()
-	return scheme, hostname, port, nil
+	return scheme, hostname, port, __path, nil
 }
 
 type Upstream struct {
 	Scheme   UpstreamScheme
 	Hostname string
 	Port     uint16
+	Path     string
 	*netutils.Ip46
 }
 
 func NewUpstream(ctx context.Context, upstream *url.URL, resolverNetwork string) (up *Upstream, err error) {
-	scheme, hostname, port, err := ParseRawUpstream(upstream)
+	scheme, hostname, port, path, err := ParseRawUpstream(upstream)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrFormat, err)
 	}
@@ -118,6 +124,7 @@ func NewUpstream(ctx context.Context, upstream *url.URL, resolverNetwork string)
 		Scheme:   scheme,
 		Hostname: hostname,
 		Port:     port,
+		Path:     path,
 		Ip46:     ip46,
 	}, nil
 }
@@ -145,7 +152,7 @@ func (u *Upstream) SupportedNetworks() (ipversions []consts.IpVersionStr, l4prot
 }
 
 func (u *Upstream) String() string {
-	return string(u.Scheme) + "://" + net.JoinHostPort(u.Hostname, strconv.Itoa(int(u.Port)))
+	return string(u.Scheme) + "://" + net.JoinHostPort(u.Hostname, strconv.Itoa(int(u.Port))) + u.Path
 }
 
 type UpstreamResolver struct {

--- a/control/dns.go
+++ b/control/dns.go
@@ -1,0 +1,428 @@
+package control
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/daeuniverse/dae/common"
+	"github.com/daeuniverse/dae/common/consts"
+	"github.com/daeuniverse/dae/component/dns"
+	"github.com/daeuniverse/outbound/netproxy"
+	"github.com/daeuniverse/outbound/pool"
+	tc "github.com/daeuniverse/outbound/protocol/tuic/common"
+	"github.com/daeuniverse/quic-go"
+	"github.com/daeuniverse/quic-go/http3"
+	dnsmessage "github.com/miekg/dns"
+)
+
+type DnsForwarder interface {
+	ForwardDNS(ctx context.Context, data []byte) (*dnsmessage.Msg, error)
+	Close() error
+}
+
+var forwarderCache = make(map[string]DnsForwarder)
+
+func newDnsForwarder(upstream *dns.Upstream, dialArgument dialArgument) (DnsForwarder, error) {
+	if forwarder, ok := forwarderCache[upstream.String()]; ok {
+		return forwarder, nil
+	}
+	forwarder, err := func() (DnsForwarder, error) {
+		switch dialArgument.l4proto {
+		case consts.L4ProtoStr_TCP:
+			switch upstream.Scheme {
+			case dns.UpstreamScheme_TCP, dns.UpstreamScheme_TCP_UDP:
+				return &DoTCP{Upstream: *upstream, Dialer: dialArgument.bestDialer, dialArgument: dialArgument}, nil
+			case dns.UpstreamScheme_TLS:
+				return &DoTLS{Upstream: *upstream, Dialer: dialArgument.bestDialer, dialArgument: dialArgument}, nil
+			case dns.UpstreamScheme_HTTPS:
+				return &DoH{Upstream: *upstream, Dialer: dialArgument.bestDialer, dialArgument: dialArgument, http3: false}, nil
+			default:
+				return nil, fmt.Errorf("unexpected scheme: %v", upstream.Scheme)
+			}
+		case consts.L4ProtoStr_UDP:
+			switch upstream.Scheme {
+			case dns.UpstreamScheme_UDP, dns.UpstreamScheme_TCP_UDP:
+				return &DoUDP{Upstream: *upstream, Dialer: dialArgument.bestDialer, dialArgument: dialArgument}, nil
+			case dns.UpstreamScheme_QUIC:
+				return &DoQ{Upstream: *upstream, Dialer: dialArgument.bestDialer, dialArgument: dialArgument}, nil
+			case dns.UpstreamScheme_H3:
+				return &DoH{Upstream: *upstream, Dialer: dialArgument.bestDialer, dialArgument: dialArgument, http3: true}, nil
+			default:
+				return nil, fmt.Errorf("unexpected scheme: %v", upstream.Scheme)
+			}
+		default:
+			return nil, fmt.Errorf("unexpected l4proto: %v", dialArgument.l4proto)
+		}
+	}()
+	if err != nil {
+		return nil, err
+	}
+	forwarderCache[upstream.String()] = forwarder
+	return forwarder, nil
+}
+
+type DoH struct {
+	dns.Upstream
+	netproxy.Dialer
+	dialArgument dialArgument
+	http3        bool
+	client       *http.Client
+}
+
+func (d *DoH) ForwardDNS(ctx context.Context, data []byte) (*dnsmessage.Msg, error) {
+	if d.client == nil {
+		var roundTripper http.RoundTripper
+		if d.http3 {
+			roundTripper = d.getHttp3RoundTripper()
+		} else {
+			roundTripper = d.getHttpRoundTripper()
+		}
+
+		d.client = &http.Client{
+			Transport: roundTripper,
+		}
+	}
+	return sendHttpDNS(d.client, d.dialArgument.bestTarget.String(), &d.Upstream, data)
+}
+
+func (d *DoH) getHttpRoundTripper() *http.Transport {
+	httpTransport := http.Transport{
+		TLSClientConfig: &tls.Config{
+			ServerName:         d.Upstream.Hostname,
+			InsecureSkipVerify: false,
+		},
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			conn, err := d.dialArgument.bestDialer.DialContext(
+				ctx,
+				common.MagicNetwork("tcp", d.dialArgument.mark, d.dialArgument.mptcp),
+				d.dialArgument.bestTarget.String(),
+			)
+			if err != nil {
+				return nil, err
+			}
+			return &netproxy.FakeNetConn{Conn: conn}, nil
+		},
+	}
+
+	return &httpTransport
+}
+
+func (d *DoH) getHttp3RoundTripper() *http3.RoundTripper {
+	roundTripper := &http3.RoundTripper{
+		TLSClientConfig: &tls.Config{
+			ServerName:         d.Upstream.Hostname,
+			NextProtos:         []string{"h3"},
+			InsecureSkipVerify: false,
+		},
+		QuicConfig: &quic.Config{},
+		Dial: func(ctx context.Context, addr string, tlsCfg *tls.Config, cfg *quic.Config) (quic.EarlyConnection, error) {
+			udpAddr := net.UDPAddrFromAddrPort(d.dialArgument.bestTarget)
+			conn, err := d.dialArgument.bestDialer.DialContext(
+				ctx,
+				common.MagicNetwork("udp", d.dialArgument.mark, d.dialArgument.mptcp),
+				d.dialArgument.bestTarget.String(),
+			)
+			if err != nil {
+				return nil, err
+			}
+			fakePkt := netproxy.NewFakeNetPacketConn(conn.(netproxy.PacketConn), net.UDPAddrFromAddrPort(tc.GetUniqueFakeAddrPort()), udpAddr)
+			c, e := quic.DialEarly(ctx, fakePkt, udpAddr, tlsCfg, cfg)
+			return c, e
+		},
+	}
+	return roundTripper
+}
+
+func (d *DoH) Close() error {
+	return nil
+}
+
+type DoQ struct {
+	dns.Upstream
+	netproxy.Dialer
+	dialArgument dialArgument
+	connection   quic.EarlyConnection
+}
+
+func (d *DoQ) ForwardDNS(ctx context.Context, data []byte) (*dnsmessage.Msg, error) {
+	if d.connection == nil {
+		qc, err := d.createConnection(ctx)
+		if err != nil {
+			return nil, err
+		}
+		d.connection = qc
+	}
+
+	stream, err := d.connection.OpenStreamSync(ctx)
+	if err != nil {
+		qc, err := d.createConnection(ctx)
+		if err != nil {
+			return nil, err
+		}
+		d.connection = qc
+		stream, err = d.connection.OpenStreamSync(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+	defer func() {
+		_ = stream.Close()
+	}()
+
+	// According https://datatracker.ietf.org/doc/html/rfc9250#section-4.2.1
+	// msg id should set to 0 when transport over QUIC.
+	// thanks https://github.com/natesales/q/blob/1cb2639caf69bd0a9b46494a3c689130df8fb24a/transport/quic.go#L97
+	binary.BigEndian.PutUint16(data[0:2], 0)
+
+	msg, err := sendStreamDNS(stream, data)
+	if err != nil {
+		return nil, err
+	}
+	return msg, nil
+}
+func (d *DoQ) createConnection(ctx context.Context) (quic.EarlyConnection, error) {
+
+	udpAddr := net.UDPAddrFromAddrPort(d.dialArgument.bestTarget)
+	conn, err := d.dialArgument.bestDialer.DialContext(
+		ctx,
+		common.MagicNetwork("udp", d.dialArgument.mark, d.dialArgument.mptcp),
+		d.dialArgument.bestTarget.String(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	fakePkt := netproxy.NewFakeNetPacketConn(conn.(netproxy.PacketConn), net.UDPAddrFromAddrPort(tc.GetUniqueFakeAddrPort()), udpAddr)
+	tlsCfg := &tls.Config{
+		NextProtos:         []string{"doq"},
+		InsecureSkipVerify: false,
+		ServerName:         d.Upstream.Hostname,
+	}
+	addr := net.UDPAddrFromAddrPort(d.dialArgument.bestTarget)
+	qc, err := quic.DialEarly(ctx, fakePkt, addr, tlsCfg, nil)
+	if err != nil {
+		return nil, err
+	}
+	return qc, nil
+
+}
+
+func (d *DoQ) Close() error {
+	return nil
+}
+
+type DoTLS struct {
+	dns.Upstream
+	netproxy.Dialer
+	dialArgument dialArgument
+	conn         netproxy.Conn
+}
+
+func (d *DoTLS) ForwardDNS(ctx context.Context, data []byte) (*dnsmessage.Msg, error) {
+	conn, err := d.dialArgument.bestDialer.DialContext(
+		ctx,
+		common.MagicNetwork("tcp", d.dialArgument.mark, d.dialArgument.mptcp),
+		d.dialArgument.bestTarget.String(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	tlsConn := tls.Client(&netproxy.FakeNetConn{Conn: conn}, &tls.Config{
+		InsecureSkipVerify: false,
+		ServerName:         d.Upstream.Hostname,
+	})
+	if err = tlsConn.Handshake(); err != nil {
+		return nil, err
+	}
+	d.conn = tlsConn
+
+	return sendStreamDNS(tlsConn, data)
+}
+
+func (d *DoTLS) Close() error {
+	if d.conn != nil {
+		return d.conn.Close()
+	}
+	return nil
+}
+
+type DoTCP struct {
+	dns.Upstream
+	netproxy.Dialer
+	dialArgument dialArgument
+	conn         netproxy.Conn
+}
+
+func (d *DoTCP) ForwardDNS(ctx context.Context, data []byte) (*dnsmessage.Msg, error) {
+	conn, err := d.dialArgument.bestDialer.DialContext(
+		ctx,
+		common.MagicNetwork("tcp", d.dialArgument.mark, d.dialArgument.mptcp),
+		d.dialArgument.bestTarget.String(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	d.conn = conn
+	return sendStreamDNS(conn, data)
+}
+
+func (d *DoTCP) Close() error {
+	if d.conn != nil {
+		return d.conn.Close()
+	}
+	return nil
+}
+
+type DoUDP struct {
+	dns.Upstream
+	netproxy.Dialer
+	dialArgument dialArgument
+	conn         netproxy.Conn
+}
+
+func (d *DoUDP) ForwardDNS(ctx context.Context, data []byte) (*dnsmessage.Msg, error) {
+	conn, err := d.dialArgument.bestDialer.DialContext(
+		ctx,
+		common.MagicNetwork("udp", d.dialArgument.mark, d.dialArgument.mptcp),
+		d.dialArgument.bestTarget.String(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	timeout := 5 * time.Second
+	_ = conn.SetDeadline(time.Now().Add(timeout))
+	dnsReqCtx, cancelDnsReqCtx := context.WithTimeout(context.TODO(), timeout)
+	defer cancelDnsReqCtx()
+
+	go func() {
+		// Send DNS request every seconds.
+		for {
+			_, err = conn.Write(data)
+			// if err != nil {
+			// 	if c.log.IsLevelEnabled(logrus.DebugLevel) {
+			// 		c.log.WithFields(logrus.Fields{
+			// 			"to":      dialArgument.bestTarget.String(),
+			// 			"pid":     req.routingResult.Pid,
+			// 			"pname":   ProcessName2String(req.routingResult.Pname[:]),
+			// 			"mac":     Mac2String(req.routingResult.Mac[:]),
+			// 			"from":    req.realSrc.String(),
+			// 			"network": networkType.String(),
+			// 			"err":     err.Error(),
+			// 		}).Debugln("Failed to write UDP(DNS) packet request.")
+			// 	}
+			// 	return
+			// }
+			select {
+			case <-dnsReqCtx.Done():
+				return
+			case <-time.After(1 * time.Second):
+			}
+		}
+	}()
+
+	// We can block here because we are in a coroutine.
+	respBuf := pool.GetFullCap(consts.EthernetMtu)
+	defer pool.Put(respBuf)
+	// Wait for response.
+	n, err := conn.Read(respBuf)
+	if err != nil {
+		return nil, err
+	}
+	var msg dnsmessage.Msg
+	if err = msg.Unpack(respBuf[:n]); err != nil {
+		return nil, err
+	}
+	return &msg, nil
+}
+
+func (d *DoUDP) Close() error {
+	if d.conn != nil {
+		return d.conn.Close()
+	}
+	return nil
+}
+
+func sendHttpDNS(client *http.Client, target string, upstream *dns.Upstream, data []byte) (respMsg *dnsmessage.Msg, err error) {
+	// disable redirect https://github.com/daeuniverse/dae/pull/649#issuecomment-2379577896
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return fmt.Errorf("do not use a server that will redirect, upstream: %v", upstream.String())
+	}
+	serverURL := url.URL{
+		Scheme: "https",
+		Host:   target,
+		Path:   upstream.Path,
+	}
+	q := serverURL.Query()
+	// According https://datatracker.ietf.org/doc/html/rfc8484#section-4
+	// msg id should set to 0 when transport over HTTPS for cache friendly.
+	binary.BigEndian.PutUint16(data[0:2], 0)
+	q.Set("dns", base64.RawURLEncoding.EncodeToString(data))
+	serverURL.RawQuery = q.Encode()
+
+	req, err := http.NewRequest(http.MethodGet, serverURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/dns-message")
+	req.Host = upstream.Hostname
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	buf, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	var msg dnsmessage.Msg
+	if err = msg.Unpack(buf); err != nil {
+		return nil, err
+	}
+	return &msg, nil
+}
+
+func sendStreamDNS(stream io.ReadWriter, data []byte) (respMsg *dnsmessage.Msg, err error) {
+	// We should write two byte length in the front of stream DNS request.
+	bReq := pool.Get(2 + len(data))
+	defer pool.Put(bReq)
+	binary.BigEndian.PutUint16(bReq, uint16(len(data)))
+	copy(bReq[2:], data)
+	_, err = stream.Write(bReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to write DNS req: %w", err)
+	}
+
+	// Read two byte length.
+	if _, err = io.ReadFull(stream, bReq[:2]); err != nil {
+		return nil, fmt.Errorf("failed to read DNS resp payload length: %w", err)
+	}
+	respLen := int(binary.BigEndian.Uint16(bReq))
+	// Try to reuse the buf.
+	var buf []byte
+	if len(bReq) < respLen {
+		buf = pool.Get(respLen)
+		defer pool.Put(buf)
+	} else {
+		buf = bReq
+	}
+	var n int
+	if n, err = io.ReadFull(stream, buf[:respLen]); err != nil {
+		return nil, fmt.Errorf("failed to read DNS resp payload: %w", err)
+	}
+	var msg dnsmessage.Msg
+	if err = msg.Unpack(buf[:n]); err != nil {
+		return nil, err
+	}
+	return &msg, nil
+}

--- a/control/dns.go
+++ b/control/dns.go
@@ -28,12 +28,7 @@ type DnsForwarder interface {
 	Close() error
 }
 
-var forwarderCache = make(map[string]DnsForwarder)
-
 func newDnsForwarder(upstream *dns.Upstream, dialArgument dialArgument) (DnsForwarder, error) {
-	if forwarder, ok := forwarderCache[upstream.String()]; ok {
-		return forwarder, nil
-	}
 	forwarder, err := func() (DnsForwarder, error) {
 		switch dialArgument.l4proto {
 		case consts.L4ProtoStr_TCP:
@@ -65,7 +60,6 @@ func newDnsForwarder(upstream *dns.Upstream, dialArgument dialArgument) (DnsForw
 	if err != nil {
 		return nil, err
 	}
-	forwarderCache[upstream.String()] = forwarder
 	return forwarder, nil
 }
 

--- a/control/dns.go
+++ b/control/dns.go
@@ -163,6 +163,7 @@ func (d *DoQ) ForwardDNS(ctx context.Context, data []byte) (*dnsmessage.Msg, err
 
 	stream, err := d.connection.OpenStreamSync(ctx)
 	if err != nil {
+		// If failed to open stream, we should try to create a new connection.
 		qc, err := d.createConnection(ctx)
 		if err != nil {
 			return nil, err

--- a/control/dns_control.go
+++ b/control/dns_control.go
@@ -848,6 +848,9 @@ func sendHttpDNS(client *http.Client, target string, upstream *dns.Upstream, dat
 		Path:   upstream.Path,
 	}
 	q := serverURL.Query()
+	// According https://datatracker.ietf.org/doc/html/rfc8484#section-4
+	// msg id should set to 0 when transport over HTTPS for cache friendly.
+	binary.BigEndian.PutUint16(data[0:2], 0)
 	q.Set("dns", base64.RawURLEncoding.EncodeToString(data))
 	serverURL.RawQuery = q.Encode()
 

--- a/control/dns_control.go
+++ b/control/dns_control.go
@@ -635,7 +635,7 @@ func (c *DnsController) dialSend(invokingDepth int, req *udpRequest, data []byte
 			}
 			respMsg = &msg
 			cancelDnsReqCtx()
-		} else if upstream.Scheme == "http3" {
+		} else if upstream.Scheme == "h3" {
 			roundTripper := &http3.RoundTripper{
 				TLSClientConfig: &tls.Config{
 					ServerName:         upstream.Hostname,

--- a/control/dns_control.go
+++ b/control/dns_control.go
@@ -662,7 +662,7 @@ func (c *DnsController) dialSend(invokingDepth int, req *udpRequest, data []byte
 			client := &http.Client{
 				Transport: roundTripper,
 			}
-			msg, err := httpDNS(client, dialArgument.bestTarget.String(), upstream.Hostname, data)
+			msg, err := sendHttpDNS(client, dialArgument.bestTarget.String(), upstream.Hostname, data)
 			if err != nil {
 				return err
 			}
@@ -701,7 +701,7 @@ func (c *DnsController) dialSend(invokingDepth int, req *udpRequest, data []byte
 			binary.BigEndian.PutUint16(data[0:2], 0)
 			
 
-			msg, err := streamDNS(stream, data)
+			msg, err := sendStreamDNS(stream, data)
 			if err != nil {
 				return err
 			}
@@ -731,7 +731,7 @@ func (c *DnsController) dialSend(invokingDepth int, req *udpRequest, data []byte
 		_ = conn.SetDeadline(time.Now().Add(4900 * time.Millisecond))
 		switch upstream.Scheme {
 		case dns.UpstreamScheme_TCP, dns.UpstreamScheme_TLS, dns.UpstreamScheme_TCP_UDP:
-			msg, err := streamDNS(conn, data)
+			msg, err := sendStreamDNS(conn, data)
 			if err != nil {
 				return err
 			}
@@ -750,7 +750,7 @@ func (c *DnsController) dialSend(invokingDepth int, req *udpRequest, data []byte
 			client := http.Client{
 				Transport: &httpTransport,
 			}
-			msg, err := httpDNS(&client, dialArgument.bestTarget.String(), upstream.Hostname, data)
+			msg, err := sendHttpDNS(&client, dialArgument.bestTarget.String(), upstream.Hostname, data)
 			if err != nil {
 				return err
 			}
@@ -847,7 +847,7 @@ func (c *DnsController) dialSend(invokingDepth int, req *udpRequest, data []byte
 	return nil
 }
 
-func httpDNS(client *http.Client, target string, host string, data []byte) (respMsg *dnsmessage.Msg, err error) {
+func sendHttpDNS(client *http.Client, target string, host string, data []byte) (respMsg *dnsmessage.Msg, err error) {
 	serverURL := url.URL{
 		Scheme: "https",
 		Host:   target,
@@ -878,8 +878,8 @@ func httpDNS(client *http.Client, target string, host string, data []byte) (resp
 	return respMsg, nil
 }
 
-func streamDNS(stream io.ReadWriter, data []byte) (respMsg *dnsmessage.Msg, err error) {
-	// We should write two byte length in the front of QUIC DNS request.
+func sendStreamDNS(stream io.ReadWriter, data []byte) (respMsg *dnsmessage.Msg, err error) {
+	// We should write two byte length in the front of stream DNS request.
 	bReq := pool.Get(2 + len(data))
 	defer pool.Put(bReq)
 	binary.BigEndian.PutUint16(bReq, uint16(len(data)))

--- a/control/dns_control.go
+++ b/control/dns_control.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"math"
 	"net"
-	"net/http"
 	"net/netip"
 	"strconv"
 	"strings"
@@ -508,8 +507,6 @@ func (c *DnsController) sendReject_(dnsMessage *dnsmessage.Msg, req *udpRequest)
 	}
 	return nil
 }
-
-var clientCache = make(map[string]*http.Client)
 
 func (c *DnsController) dialSend(invokingDepth int, req *udpRequest, data []byte, id uint16, upstream *dns.Upstream, needResp bool) (err error) {
 	if invokingDepth >= MaxDnsLookupDepth {

--- a/control/dns_control.go
+++ b/control/dns_control.go
@@ -663,7 +663,7 @@ func (c *DnsController) dialSend(invokingDepth int, req *udpRequest, data []byte
 			client := &http.Client{
 				Transport: roundTripper,
 			}
-			msg, err := sendHttpDNS(client, dialArgument.bestTarget.String(), upstream.Hostname, data)
+			msg, err := sendHttpDNS(client, dialArgument.bestTarget.String(), upstream.Hostname, upstream.Path, data)
 			if err != nil {
 				return err
 			}
@@ -700,7 +700,6 @@ func (c *DnsController) dialSend(invokingDepth int, req *udpRequest, data []byte
 			// msg id should set to 0 when transport over QUIC.
 			// thanks https://github.com/natesales/q/blob/1cb2639caf69bd0a9b46494a3c689130df8fb24a/transport/quic.go#L97
 			binary.BigEndian.PutUint16(data[0:2], 0)
-			
 
 			msg, err := sendStreamDNS(stream, data)
 			if err != nil {
@@ -751,7 +750,7 @@ func (c *DnsController) dialSend(invokingDepth int, req *udpRequest, data []byte
 			client := http.Client{
 				Transport: &httpTransport,
 			}
-			msg, err := sendHttpDNS(&client, dialArgument.bestTarget.String(), upstream.Hostname, data)
+			msg, err := sendHttpDNS(&client, dialArgument.bestTarget.String(), upstream.Hostname, upstream.Path, data)
 			if err != nil {
 				return err
 			}
@@ -848,11 +847,11 @@ func (c *DnsController) dialSend(invokingDepth int, req *udpRequest, data []byte
 	return nil
 }
 
-func sendHttpDNS(client *http.Client, target string, host string, data []byte) (respMsg *dnsmessage.Msg, err error) {
+func sendHttpDNS(client *http.Client, target string, host string, path string, data []byte) (respMsg *dnsmessage.Msg, err error) {
 	serverURL := url.URL{
 		Scheme: "https",
 		Host:   target,
-		Path:   "/dns-query",
+		Path:   path,
 	}
 
 	req, err := http.NewRequest(http.MethodPost, serverURL.String(), bytes.NewReader(data))
@@ -909,8 +908,7 @@ func sendStreamDNS(stream io.ReadWriter, data []byte) (respMsg *dnsmessage.Msg, 
 	}
 	var msg dnsmessage.Msg
 	if err = msg.Unpack(buf[:n]); err != nil {
-		return  nil, err
+		return nil, err
 	}
 	return &msg, nil
 }
-		

--- a/control/dns_control.go
+++ b/control/dns_control.go
@@ -873,12 +873,7 @@ func httpDNS(client *http.Client, target string, data []byte) (respMsg *dnsmessa
 	return respMsg, nil
 }
 
-type stream interface {
-	io.Reader
-	io.Writer
-}
-
-func streamDNS(stream stream, data []byte) (respMsg *dnsmessage.Msg, err error) {
+func streamDNS(stream io.ReadWriter, data []byte) (respMsg *dnsmessage.Msg, err error) {
 	// We should write two byte length in the front of QUIC DNS request.
 	bReq := pool.Get(2 + len(data))
 	defer pool.Put(bReq)

--- a/control/dns_control.go
+++ b/control/dns_control.go
@@ -6,6 +6,7 @@
 package control
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"encoding/binary"
@@ -854,7 +855,7 @@ func sendHttpDNS(client *http.Client, target string, host string, data []byte) (
 		Path:   "/dns-query",
 	}
 
-	req, err := http.NewRequest(http.MethodPost, serverURL.String(), strings.NewReader(string(data)))
+	req, err := http.NewRequest(http.MethodPost, serverURL.String(), bytes.NewReader(data))
 	if err != nil {
 		return nil, err
 	}

--- a/control/dns_control.go
+++ b/control/dns_control.go
@@ -31,6 +31,7 @@ import (
 	"github.com/daeuniverse/outbound/netproxy"
 	"github.com/daeuniverse/outbound/pkg/fastrand"
 	"github.com/daeuniverse/outbound/pool"
+	tc "github.com/daeuniverse/outbound/protocol/tuic/common"
 	"github.com/daeuniverse/quic-go"
 	"github.com/daeuniverse/quic-go/http3"
 	dnsmessage "github.com/miekg/dns"
@@ -649,7 +650,7 @@ func (c *DnsController) dialSend(invokingDepth int, req *udpRequest, data []byte
 					pkt := conn.(netproxy.PacketConn)
 					fakePkt := &netproxy.FakeNetPacketConn{
 						PacketConn: pkt,
-						LAddr:      net.UDPAddrFromAddrPort(netip.AddrPortFrom(netip.MustParseAddr("::1"), 0)),
+						LAddr:      net.UDPAddrFromAddrPort(tc.GetUniqueFakeAddrPort()),
 						RAddr:      udpAddr,
 					}
 					c, e := quic.DialEarly(ctx, fakePkt, udpAddr, tlsCfg, cfg)

--- a/control/dns_control.go
+++ b/control/dns_control.go
@@ -636,7 +636,7 @@ func (c *DnsController) dialSend(invokingDepth int, req *udpRequest, data []byte
 			}
 			respMsg = &msg
 			cancelDnsReqCtx()
-		case dns.UpstreamScheme_H3, dns.UpstreamScheme_HTTP3:
+		case dns.UpstreamScheme_H3:
 			roundTripper := &http3.RoundTripper{
 				TLSClientConfig: &tls.Config{
 					ServerName:         upstream.Hostname,

--- a/control/dns_control.go
+++ b/control/dns_control.go
@@ -695,6 +695,12 @@ func (c *DnsController) dialSend(invokingDepth int, req *udpRequest, data []byte
 				_ = stream.Close()
 			}()
 
+			// According https://datatracker.ietf.org/doc/html/rfc9250#section-4.2.1
+			// msg id should set to 0 when transport over QUIC.
+			// thanks https://github.com/natesales/q/blob/1cb2639caf69bd0a9b46494a3c689130df8fb24a/transport/quic.go#L97
+			binary.BigEndian.PutUint16(data[0:2], 0)
+			
+
 			msg, err := streamDNS(stream, data)
 			if err != nil {
 				return err

--- a/control/dns_control.go
+++ b/control/dns_control.go
@@ -591,7 +591,7 @@ func (c *DnsController) dialSend(invokingDepth int, req *udpRequest, data []byte
 		_ = conn.SetDeadline(time.Now().Add(timeout))
 		dnsReqCtx, cancelDnsReqCtx := context.WithTimeout(context.TODO(), timeout)
 		defer cancelDnsReqCtx()
-		if upstream.Scheme == "udp" {
+		if upstream.Scheme == dns.UpstreamScheme_UDP {
 			go func() {
 				// Send DNS request every seconds.
 				for {
@@ -635,7 +635,7 @@ func (c *DnsController) dialSend(invokingDepth int, req *udpRequest, data []byte
 			}
 			respMsg = &msg
 			cancelDnsReqCtx()
-		} else if upstream.Scheme == "h3" {
+		} else if upstream.Scheme == dns.UpstreamScheme_H3 || upstream.Scheme == dns.UpstreamScheme_HTTP3 {
 			roundTripper := &http3.RoundTripper{
 				TLSClientConfig: &tls.Config{
 					ServerName:         upstream.Hostname,
@@ -648,8 +648,8 @@ func (c *DnsController) dialSend(invokingDepth int, req *udpRequest, data []byte
 					pkt := conn.(netproxy.PacketConn)
 					fakePkt := &netproxy.FakeNetPacketConn{
 						PacketConn: pkt,
-						LAddr: net.UDPAddrFromAddrPort(netip.AddrPortFrom(netip.MustParseAddr("::1"), 0)),
-						RAddr: udpAddr,
+						LAddr:      net.UDPAddrFromAddrPort(netip.AddrPortFrom(netip.MustParseAddr("::1"), 0)),
+						RAddr:      udpAddr,
 					}
 					c, e := quic.DialEarly(ctx, fakePkt, udpAddr, tlsCfg, cfg)
 					return c, e
@@ -671,7 +671,7 @@ func (c *DnsController) dialSend(invokingDepth int, req *udpRequest, data []byte
 		// We can block here because we are in a coroutine.
 
 		conn, err = dialArgument.bestDialer.DialContext(ctxDial, common.MagicNetwork("tcp", dialArgument.mark, dialArgument.mptcp), dialArgument.bestTarget.String())
-		if upstream.Scheme == "tls" {
+		if upstream.Scheme == dns.UpstreamScheme_TLS {
 			tlsConn := tls.Client(&netproxy.FakeNetConn{Conn: conn}, &tls.Config{
 				InsecureSkipVerify: false,
 				ServerName:         upstream.Hostname,
@@ -688,7 +688,7 @@ func (c *DnsController) dialSend(invokingDepth int, req *udpRequest, data []byte
 		}()
 
 		_ = conn.SetDeadline(time.Now().Add(4900 * time.Millisecond))
-		if upstream.Scheme == "tcp" || upstream.Scheme == "tls" {
+		if upstream.Scheme == dns.UpstreamScheme_TCP || upstream.Scheme == dns.UpstreamScheme_TLS {
 
 			// We should write two byte length in the front of TCP DNS request.
 			bReq := pool.Get(2 + len(data))
@@ -722,7 +722,7 @@ func (c *DnsController) dialSend(invokingDepth int, req *udpRequest, data []byte
 				return err
 			}
 			respMsg = &msg
-		} else if upstream.Scheme == "https" {
+		} else if upstream.Scheme == dns.UpstreamScheme_HTTPS {
 
 			httpTransport := http.Transport{
 				DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

dae lacks support for some encrypted DNS protocols, this PR adds support for DoH, DoT, DoH3, DoQ 

TODO

- [x] support config DoH and DoH3 url path
- [x] dns.google.com compatible issue
- [x] Reuse httpClient
- [x] Set id to 0 when send DoH/DoQ request, set id back when send response to the client [^dohid] [^doqid]

[^dohid]:  https://datatracker.ietf.org/doc/html/rfc8484#section-4.1
[^doqid]:https://www.rfc-editor.org/rfc/rfc9250.html#name-dns-message-ids

### Checklist

- [x] The Pull Request has been fully tested
- [x] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- feat: support DoH, DoT, DoH3, DoQ 

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #321
Closes #583

### Test Result

<!--- Attach test result here. -->

time="Sep 24 15:58:37" level=trace msg="Received UDP(DNS) 192.168.33.244:41532 <-> 192.168.33.1:53: wq.io. A"
time="Sep 24 15:58:37" level=trace msg="Request to DNS upstream" question=[{wq.io. 1 1}] upstream="tls://dns.google:853"
time="Sep 24 15:58:37" level=trace msg="Choose DNS path" choose="tcp+4" ipversions=[4 6] l4protos=[tcp] upstream="tls://dns.google:853" use="8.8.8.8:853"
time="Sep 24 15:58:37" level=trace msg=Accept question=[{wq.io. 1 1}] upstream="tls://dns.google:853"
time="Sep 24 15:58:37" level=info msg="192.168.33.244:41532 <-> 8.8.8.8:853" _qname=wq.io. dialer=direct dscp=0 mac="08:00:27:95:8e:32" network="tcp4(DNS)" outbound=direct pid=50022 pname=dig policy=fixed qtype=A
time="Sep 24 15:58:37" level=trace msg="Update DNS record cache" _qname=wq.io. ans="wq.io.(A): 107.170.234.66" rcode=0

time="Sep 24 15:57:36" level=trace msg="Received UDP(DNS) 192.168.33.244:50965 <-> 192.168.33.1:53: wq.io. A"
time="Sep 24 15:57:36" level=trace msg="Request to DNS upstream" question=[{wq.io. 1 1}] upstream="http3://dns.alidns.com:443"
time="Sep 24 15:57:36" level=trace msg="Choose DNS path" choose="udp+4" ipversions=[4 6] l4protos=[udp] upstream="http3://dns.alidns.com:443" use="223.5.5.5:443"
time="Sep 24 15:57:36" level=trace msg=Accept question=[{wq.io. 1 1}] upstream="http3://dns.alidns.com:443"
time="Sep 24 15:57:36" level=info msg="192.168.33.244:50965 <-> 223.5.5.5:443" _qname=wq.io. dialer=direct dscp=0 mac="08:00:27:95:8e:32" network="udp4(DNS)" outbound=direct pid=49833 pname=dig policy=fixed qtype=A
time="Sep 24 15:57:36" level=trace msg="Update DNS record cache" _qname=wq.io. ans="wq.io.(A): 107.170.234.66" rcode=0

time="Sep 24 15:56:57" level=trace msg="Received UDP(DNS) 192.168.33.244:39025 <-> 192.168.33.1:53: wq.io. A"
time="Sep 24 15:56:57" level=trace msg="Request to DNS upstream" question=[{wq.io. 1 1}] upstream="https://dns.alidns.com:443"
time="Sep 24 15:56:57" level=trace msg="Choose DNS path" choose="tcp+4" ipversions=[4 6] l4protos=[tcp] upstream="https://dns.alidns.com:443" use="223.5.5.5:443"
time="Sep 24 15:56:57" level=trace msg=Accept question=[{wq.io. 1 1}] upstream="https://dns.alidns.com:443"
time="Sep 24 15:56:57" level=info msg="192.168.33.244:39025 <-> 223.5.5.5:443" _qname=wq.io. dialer=direct dscp=0 mac="08:00:27:95:8e:32" network="tcp4(DNS)" outbound=direct pid=49693 pname=dig policy=fixed qtype=A
time="Sep 24 15:56:57" level=trace msg="Update DNS record cache" _qname=wq.io. ans="wq.io.(A): 107.170.234.66" rcode=0