### PR TITLE
fix(sniffer): remove useless EOF warning logs printing

### DIFF
--- a/component/sniffing/sniffer.go
+++ b/component/sniffing/sniffer.go
@@ -107,12 +107,9 @@ func (s *Sniffer) SniffTcp() (d string, err error) {
 		if s.stream {
 			go func() {
 				// Read once.
-				n, err := s.buf.ReadFromOnce(s.r)
+				_, err = s.buf.ReadFromOnce(s.r)
 				if err != nil {
 					s.dataError = err
-				}
-				if n == 0 {
-					s.dataError = io.EOF
 				}
 				close(s.dataReady)
 			}()


### PR DESCRIPTION
```
level=warning msg="handleConn: %!w(<nil>): EOF"
...
```

In my opinion, these logs are quite useless.

<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
