### PR TITLE
docs: Google DNS should use dns.google instead of dns.google.com

### DIFF
--- a/component/routing/domain_matcher/benchmark_test.go
+++ b/component/routing/domain_matcher/benchmark_test.go
@@ -138,7 +138,7 @@ routing {
 	domain(suffix: test-ipv6.com)->direct
 	domain(geosite:bing)->us
 	domain(_https._tcp.mirrors.ustc.edu.cn)->us
-    domain(full:dns.google.com) -> direct
+    domain(full:dns.google) -> direct
 	domain(geosite:category-ads-all) -> block
     domain(geosite:cn) -> direct
 }`)

--- a/config/config.go
+++ b/config/config.go
@@ -26,7 +26,7 @@ type Global struct {
 	//DirectTcpCheckUrl string `mapstructure:"direct_tcp_check_url" default:"http://www.qualcomm.cn/generate_204"`
 	TcpCheckUrl                []string      `mapstructure:"tcp_check_url" default:"http://cp.cloudflare.com,1.1.1.1,2606:4700:4700::1111"`
 	TcpCheckHttpMethod         string        `mapstructure:"tcp_check_http_method" default:"HEAD"` // Use 'HEAD' because some server implementations bypass accounting for this kind of traffic.
-	UdpCheckDns                []string      `mapstructure:"udp_check_dns" default:"dns.google.com:53,8.8.8.8,2001:4860:4860::8888"`
+	UdpCheckDns                []string      `mapstructure:"udp_check_dns" default:"dns.google:53,8.8.8.8,2001:4860:4860::8888"`
 	CheckInterval              time.Duration `mapstructure:"check_interval" default:"30s"`
 	CheckTolerance             time.Duration `mapstructure:"check_tolerance" default:"0"`
 	LanInterface               []string      `mapstructure:"lan_interface"`

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -196,7 +196,7 @@ subscription {
 # See https://github.com/daeuniverse/dae/blob/main/docs/en/configuration/dns.md for full examples.
 dns {
   upstream {
-    googledns: 'tcp+udp://dns.google.com:53'
+    googledns: 'tcp+udp://dns.google:53'
     alidns: 'udp://dns.alidns.com:53'
   }
   routing {

--- a/docs/en/configuration/dns.md
+++ b/docs/en/configuration/dns.md
@@ -26,7 +26,7 @@ dns {
         # If dial_mode is "ip", the upstream DNS answer SHOULD NOT be polluted, so domestic public DNS is not recommended.
 
         alidns: 'udp://dns.alidns.com:53'
-        googledns: 'tcp+udp://dns.google.com:53'
+        googledns: 'tcp+udp://dns.google:53'
     }
     # The routing format of 'request' and 'response' is similar with section 'routing'.
     # See https://github.com/daeuniverse/dae/blob/main/docs/en/configuration/routing.md
@@ -76,7 +76,7 @@ dns {
 # Use alidns for China mainland domains and googledns for others.
 dns {
   upstream {
-    googledns: 'tcp+udp://dns.google.com:53'
+    googledns: 'tcp+udp://dns.google:53'
     alidns: 'udp://dns.alidns.com:53'
   }
   routing {
@@ -96,7 +96,7 @@ dns {
 # Use alidns for all DNS queries and fallback to googledns if pollution result detected.
 dns {
   upstream {
-    googledns: 'tcp+udp://dns.google.com:53'
+    googledns: 'tcp+udp://dns.google:53'
     alidns: 'udp://dns.alidns.com:53'
   }
   routing {

--- a/docs/en/configuration/external-dns.md
+++ b/docs/en/configuration/external-dns.md
@@ -7,13 +7,13 @@ If you use a external DNS like AdguardHome, you could refer to the following gui
 
 ## External DNS on localhost
 
-If you set up an external DNS on localhost, you may want to let the DNS queries to `dns.google.com` proxied. For example, if you have the following configuration in AdguardHome:
+If you set up an external DNS on localhost, you may want to let the DNS queries to `dns.google` proxied. For example, if you have the following configuration in AdguardHome:
 
 ```
 Listen on: the same machine with dae, port 53.
 
 China mainland: udp://223.5.5.5:53
-Others: https://dns.google.com/dns-query
+Others: https://dns.google/dns-query
 ```
 
 You should configure dae as follows:
@@ -26,7 +26,7 @@ You should configure dae as follows:
    pname(AdGuardHome) && l4proto(udp) && dport(53) -> must_direct
    ```
 
-   And make sure domain `dns.google.com` will be proxied in routing rules.
+   And make sure domain `dns.google` will be proxied in routing rules.
 
 3. Add upstream and request to section "dns".
 
@@ -53,13 +53,13 @@ You should configure dae as follows:
 
 ## External DNS on another machine in LAN
 
-If you set up a external DNS on another machine in LAN, you may want to let the DNS queries to `dns.google.com` proxied. For example, if you have following configuration in `AdguardHome`:
+If you set up a external DNS on another machine in LAN, you may want to let the DNS queries to `dns.google` proxied. For example, if you have following configuration in `AdguardHome`:
 
 ```
 Listen on: 192.168.30.3:53 (mac address: 8c:16:45:36:1c:5a)
 
 China mainland: udp://223.5.5.5:53
-Others: https://dns.google.com/dns-query
+Others: https://dns.google/dns-query
 ```
 
 You should configure dae as follows:
@@ -74,7 +74,7 @@ You should configure dae as follows:
    # mac(8c:16:45:36:1c:5a) && l4proto(udp) && dport(53) -> must_direct
    ```
 
-   And make sure domain `dns.google.com` will be proxied in routing rules.
+   And make sure domain `dns.google` will be proxied in routing rules.
 
 3. Add upstream and request to section "dns".
 

--- a/docs/en/configuration/routing.md
+++ b/docs/en/configuration/routing.md
@@ -18,7 +18,7 @@ fallback: my_group
 ### Domain rule
 domain(suffix: v2raya.org) -> my_group
 # equals to domain(v2raya.org) -> my_group
-domain(full: dns.google.com) -> my_group
+domain(full: dns.google) -> my_group
 domain(keyword: facebook) -> my_group
 domain(regex: '\.goo.*\.com$') -> my_group
 domain(geosite:category-ads) -> block

--- a/docs/en/configuration/separate-config.md
+++ b/docs/en/configuration/separate-config.md
@@ -34,7 +34,7 @@ global {
     log_level: warn
 
     tcp_check_url: 'http://cp.cloudflare.com'
-    udp_check_dns: 'dns.google.com:53'
+    udp_check_dns: 'dns.google:53'
     check_interval: 600s
     check_tolerance: 50ms
 
@@ -55,7 +55,7 @@ global {
 dns {
     upstream {
         alidns: 'udp://dns.alidns.com:53'
-        googledns: 'tcp+udp://dns.google.com:53'
+        googledns: 'tcp+udp://dns.google:53'
     }
 
     routing {

--- a/docs/en/tutorials/run-on-macos.md
+++ b/docs/en/tutorials/run-on-macos.md
@@ -118,7 +118,7 @@ subscription {
 # See https://github.com/daeuniverse/dae/blob/main/docs/en/configuration/dns.md for full examples.
 dns {
   upstream {
-    googledns: 'tcp+udp://dns.google.com:53'
+    googledns: 'tcp+udp://dns.google:53'
     alidns: 'udp://dns.alidns.com:53'
   }
   routing {

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -190,7 +190,7 @@ subscription {
 # 更多的 DNS 样例见 https://github.com/daeuniverse/dae/blob/main/docs/en/configuration/dns.md
 dns {
   upstream {
-    googledns: 'tcp+udp://dns.google.com:53'
+    googledns: 'tcp+udp://dns.google:53'
     alidns: 'udp://dns.alidns.com:53'
   }
   routing {
@@ -234,7 +234,7 @@ routing {
 ```shell
 dns {
   upstream {
-    googledns: 'tcp+udp://dns.google.com:53'
+    googledns: 'tcp+udp://dns.google:53'
     alidns: 'udp://dns.alidns.com:53'
   }
   routing {

--- a/docs/zh/configuration/dns.md
+++ b/docs/zh/configuration/dns.md
@@ -24,7 +24,7 @@ dns {
         # 若 dial_mode 设为 'ip'，请确保上游 DNS 无污染，不推荐使用国内公共 DNS。
 
         alidns: 'udp://dns.alidns.com:53'
-        googledns: 'tcp+udp://dns.google.com:53'
+        googledns: 'tcp+udp://dns.google:53'
     }
     # 'request' 和 'response' 的 routing 格式和全局的 'routing' 类似。
     # 参考 https://github.com/daeuniverse/dae/blob/main/docs/zh/configuration/routing.md
@@ -75,7 +75,7 @@ dns {
 # 对于中国大陆域名使用 alidns，其他使用 googledns 查询。
 dns {
   upstream {
-    googledns: 'tcp+udp://dns.google.com:53'
+    googledns: 'tcp+udp://dns.google:53'
     alidns: 'udp://dns.alidns.com:53'
   }
   routing {
@@ -95,7 +95,7 @@ dns {
 # 默认使用 alidns，如果疑似污染使用 googledns 重查。
 dns {
   upstream {
-    googledns: 'tcp+udp://dns.google.com:53'
+    googledns: 'tcp+udp://dns.google:53'
     alidns: 'udp://dns.alidns.com:53'
   }
   routing {

--- a/docs/zh/configuration/routing.md
+++ b/docs/zh/configuration/routing.md
@@ -18,7 +18,7 @@ fallback: my_group
 ### 域名规则
 domain(suffix: v2raya.org) -> my_group
 # 相当于 domain(v2raya.org) -> my_group
-domain(full: dns.google.com) -> my_group
+domain(full: dns.google) -> my_group
 domain(keyword: facebook) -> my_group
 domain(regex: '\.goo.*\.com$') -> my_group
 domain(geosite:category-ads) -> block

--- a/example.dae
+++ b/example.dae
@@ -56,8 +56,8 @@ global {
     # TCP DNS connectivity of nodes.
     # First is URL, others are IP addresses if given.
     # This DNS should have both IPv4 and IPv6 if you have double stack in local.
-    #udp_check_dns: 'dns.google.com:53'
-    udp_check_dns: 'dns.google.com:53,8.8.8.8,2001:4860:4860::8888'
+    #udp_check_dns: 'dns.google:53'
+    udp_check_dns: 'dns.google:53,8.8.8.8,2001:4860:4860::8888'
 
     check_interval: 30s
 
@@ -152,7 +152,7 @@ dns {
         # If dial_mode is "ip", the upstream DNS answer SHOULD NOT be polluted, so domestic public DNS is not recommended.
 
         alidns: 'udp://dns.alidns.com:53'
-        googledns: 'tcp+udp://dns.google.com:53'
+        googledns: 'tcp+udp://dns.google:53'
     }
     routing {
         # According to the request of dns query, decide to use which DNS upstream.
@@ -231,7 +231,7 @@ group {
         # Override tcp_check_http_method in global
         #tcp_check_http_method: HEAD
         # Override udp_check_dns in global
-        #udp_check_dns: 'dns.google.com:53,8.8.8.8,2001:4860:4860::8888'
+        #udp_check_dns: 'dns.google:53,8.8.8.8,2001:4860:4860::8888'
         # Override check_interval in global
         #check_interval: 30s
         # Override check_tolerance in global


### PR DESCRIPTION


<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->
Since Google recommend to use dns.google as a DoH server and we are trying add DoH support, and use both of them as a UDP or TCP DNS server is equal, so we can change the default config and docs early

https://developers.google.com/speed/public-dns/docs/doh/migration?hl=zh-cn#base64url 

https://github.com/daeuniverse/dae/pull/649#issuecomment-2379577896
### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
