### PR TITLE
ci(workflows/bpf-test): add BPF test to cover route logic

### DIFF
--- a/.github/workflows/bpf-test.yml
+++ b/.github/workflows/bpf-test.yml
@@ -1,0 +1,28 @@
+name: BPF Test
+
+on:
+  pull_request:
+    paths:
+      - "**/*.c"
+      - "**/*.h"
+      - "go.mod"
+      - "go.sum"
+      - ".github/workflows/bpf-test.yml"
+
+permissions: read-all
+
+jobs:
+  bpf_tests:
+    name: BPF Unit Test
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Run BPF tests
+        run: |
+          git submodule update --init
+          sudo make ebpf-test || (echo "Run 'make ebpf-test' locally to investigate failures"; exit 1)
+

--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,7 @@ ebpf-test: submodule clean-ebpf
     unset GOARM && \
     echo $(STRIP_FLAG) && \
     go generate ./control/kern/tests/bpf_test.go && \
+    go clean -testcache && \
     go test -v ./control/kern/tests/...
 
 ## End Ebpf

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,8 @@ clean-ebpf:
 		rm -f control/bpf_bpf*.o
 	@rm -f trace/bpf_bpf*.go && \
 		rm -f trace/bpf_bpf*.o
+	@rm -f control/kern/tests/bpftest_bpf*.go && \
+		rm -f control/kern/tests/bpftest_bpf*.o
 fmt:
 	go fmt ./...
 
@@ -98,5 +100,18 @@ ebpf: submodule clean-ebpf
 
 ebpf-lint:
 	./scripts/checkpatch.pl --no-tree --strict --no-summary --show-types --color=always control/kern/tproxy.c --ignore COMMIT_COMMENT_SYMBOL,NOT_UNIFIED_DIFF,COMMIT_LOG_LONG_LINE,LONG_LINE_COMMENT,VOLATILE,ASSIGN_IN_IF,PREFER_DEFINED_ATTRIBUTE_MACRO,CAMELCASE,LEADING_SPACE,OPEN_ENDED_LINE,SPACING,BLOCK_COMMENT_STYLE
+
+ebpf-test: export BPF_CLANG := $(CLANG)
+ebpf-test: export BPF_STRIP_FLAG := $(STRIP_FLAG)
+ebpf-test: export BPF_CFLAGS := $(CFLAGS)
+ebpf-test: export BPF_TARGET := $(TARGET)
+ebpf-test: export BPF_TRACE_TARGET := $(GOARCH)
+ebpf-test: submodule clean-ebpf
+	@unset GOOS && \
+    unset GOARCH && \
+    unset GOARM && \
+    echo $(STRIP_FLAG) && \
+    go generate ./control/kern/tests/bpf_test.go && \
+    go test -v ./control/kern/tests/...
 
 ## End Ebpf

--- a/control/kern/tests/bpf_test.c
+++ b/control/kern/tests/bpf_test.c
@@ -170,13 +170,134 @@ int testcheck_port_80_match(struct __sk_buff *skb)
 		return TC_ACT_SHOT;
 	}
 
-	if (routing_result->must != false) {
-		bpf_printk("routing_result->must != false\n");
+	if (routing_result->must != 0) {
+		bpf_printk("routing_result->must != 0\n");
 		return TC_ACT_SHOT;
 	}
 
 	if (routing_result->outbound != 2) {
 		bpf_printk("routing_result->outbound != 2\n");
+		return TC_ACT_SHOT;
+	}
+
+	return TC_ACT_OK;
+}
+
+SEC("tc/pktgen/port_80_mismatch")
+int testpktgen_port_80_mismatch(struct __sk_buff *skb)
+{
+	bpf_skb_change_tail(skb, ETH_HLEN + IP4_HLEN + TCP_HLEN, 0);
+
+	void *data = (void *)(long)skb->data;
+	void *data_end = (void *)(long)skb->data_end;
+
+	struct ethhdr *eth = data;
+	if ((void *)(eth + 1) > data_end) {
+		bpf_printk("data + sizeof(*eth) > data_end\n");
+		return TC_ACT_SHOT;
+	}
+	eth->h_proto = bpf_htons(ETH_P_IP);
+
+	struct iphdr *ip = data + ETH_HLEN;
+	if ((void *)(ip + 1) > data_end) {
+		bpf_printk("data + sizeof(*ip) > data_end\n");
+		return TC_ACT_SHOT;
+	}
+	ip->ihl = 5;
+	ip->version = 4;
+	ip->protocol = IPPROTO_TCP;
+	ip->saddr = bpf_htonl(0xc0a80001); // 192.168.0.1
+	ip->daddr = bpf_htonl(0x01010101); // 1.1.1.1
+
+	struct tcphdr *tcp = data + ETH_HLEN + IP4_HLEN;
+	if ((void *)(tcp + 1) > data_end) {
+		bpf_printk("data + sizeof(*tcp) > data_end\n");
+		return TC_ACT_SHOT;
+	}
+	tcp->source = bpf_htons(19233);
+	tcp->dest = bpf_htons(79);
+	tcp->syn = 1;
+
+	return TC_ACT_OK;
+}
+
+SEC("tc/setup/port_80_mismatch")
+int testsetup_port_80_mismatch(struct __sk_buff *skb)
+{
+	__u32 linklen = ETH_HLEN;
+	bpf_map_update_elem(&linklen_map, &one_key, &linklen, BPF_ANY);
+
+	struct match_set ms = {};
+	struct port_range pr = {80, 80};
+	ms.port_range = pr;
+	ms.not = false;
+	ms.type = MatchType_Port;
+	ms.outbound = 2;
+	ms.must = false;
+	ms.mark = 0;
+	bpf_map_update_elem(&routing_map, &zero_key, &ms, BPF_ANY);
+
+	__builtin_memset(&ms.__value, 0, sizeof(ms.__value));
+	ms.not = false;
+	ms.type = MatchType_Fallback;
+	ms.outbound = 0;
+	ms.must = true;
+	ms.mark = 0;
+	bpf_map_update_elem(&routing_map, &one_key, &ms, BPF_ANY);
+
+	bpf_tail_call(skb, &entry_call_map, 0);
+	return TC_ACT_OK;
+}
+
+SEC("tc/check/port_80_mismatch")
+int testcheck_port_80_mismatch(struct __sk_buff *skb)
+{
+	__u32 *status_code;
+
+	void *data = (void *)(long)skb->data;
+	void *data_end = (void *)(long)skb->data_end;
+
+	if (data + sizeof(*status_code) > data_end) {
+		bpf_printk("data + sizeof(*status_code) > data_end\n");
+		return TC_ACT_SHOT;
+	}
+
+	status_code = data;
+	if (*status_code != TC_ACT_OK) {
+		bpf_printk("status_code(%d) != TC_ACT_OK\n", *status_code);
+		return TC_ACT_SHOT;
+	}
+
+	struct ethhdr *eth = data + sizeof(*status_code);
+	if ((void *)(eth + 1) > data_end) {
+		bpf_printk("data + sizeof(*eth) > data_end\n");
+		return TC_ACT_SHOT;
+	}
+	if (eth->h_proto != bpf_htons(ETH_P_IP)) {
+		bpf_printk("eth->h_proto != 0x0800\n");
+		return TC_ACT_SHOT;
+	}
+
+	struct iphdr *ip = (void *)eth + ETH_HLEN;
+	if ((void *)(ip + 1) > data_end) {
+		bpf_printk("data + sizeof(*ip) > data_end\n");
+		return TC_ACT_SHOT;
+	}
+	if (ip->protocol != IPPROTO_TCP) {
+		bpf_printk("ip->protocol != IPPROTO_TCP\n");
+		return TC_ACT_SHOT;
+	}
+	if (ip->daddr != bpf_htonl(0x01010101)) {
+		bpf_printk("ip->daddr != 1.1.1.1\n");
+	}
+
+	struct tcphdr *tcp = (void *)ip + IP4_HLEN;
+	if ((void *)(tcp + 1) > data_end) {
+		bpf_printk("data + sizeof(*tcp) > data_end\n");
+		return TC_ACT_SHOT;
+	}
+	if (tcp->dest != bpf_htons(79)) {
+		bpf_printk("tcp->dest != 79\n");
 		return TC_ACT_SHOT;
 	}
 

--- a/control/kern/tests/bpf_test.c
+++ b/control/kern/tests/bpf_test.c
@@ -750,3 +750,132 @@ int testcheck_ipset_mismatch(struct __sk_buff *skb)
 
 	return TC_ACT_OK;
 }
+
+SEC("tc/pktgen/source_ipset_match")
+int testpktgen_source_ipset_match(struct __sk_buff *skb)
+{
+	bpf_skb_change_tail(skb, ETH_HLEN + IP4_HLEN + TCP_HLEN, 0);
+
+	void *data = (void *)(long)skb->data;
+	void *data_end = (void *)(long)skb->data_end;
+
+	struct ethhdr *eth = data;
+	if ((void *)(eth + 1) > data_end) {
+		bpf_printk("data + sizeof(*eth) > data_end\n");
+		return TC_ACT_SHOT;
+	}
+	eth->h_proto = bpf_htons(ETH_P_IP);
+
+	struct iphdr *ip = data + ETH_HLEN;
+	if ((void *)(ip + 1) > data_end) {
+		bpf_printk("data + sizeof(*ip) > data_end\n");
+		return TC_ACT_SHOT;
+	}
+	ip->ihl = 5;
+	ip->version = 4;
+	ip->protocol = IPPROTO_TCP;
+	ip->saddr = bpf_htonl(0xc0a83201); // 192.168.50.1
+	ip->daddr = bpf_htonl(0xe0010002); // 224.1.0.2
+
+	struct tcphdr *tcp = data + ETH_HLEN + IP4_HLEN;
+	if ((void *)(tcp + 1) > data_end) {
+		bpf_printk("data + sizeof(*tcp) > data_end\n");
+		return TC_ACT_SHOT;
+	}
+	tcp->source = bpf_htons(19233);
+	tcp->dest = bpf_htons(80);
+	tcp->syn = 1;
+
+	return TC_ACT_OK;
+}
+
+SEC("tc/setup/source_ipset_match")
+int testsetup_source_ipset_match(struct __sk_buff *skb)
+{
+	__u32 linklen = ETH_HLEN;
+	bpf_map_update_elem(&linklen_map, &one_key, &linklen, BPF_ANY);
+
+	/* sip(192.168.50.0/24) -> direct */
+	struct match_set ms = {};
+	ms.not = false;
+	ms.type = MatchType_SourceIpSet;
+	ms.outbound = 0;
+	ms.must = false;
+	ms.mark = 0;
+	bpf_map_update_elem(&routing_map, &zero_key, &ms, BPF_ANY);
+
+	struct lpm_key lpm_key = {};
+	lpm_key.trie_key.prefixlen = 120;
+	lpm_key.data[2] = bpf_ntohl(0xffff);
+	lpm_key.data[3] = bpf_ntohl(0xc0a83200); // 192.168.50.0
+	__u32 lpm_value = bpf_ntohl(0x01000000);
+	bpf_map_update_elem(&unused_lpm_type, &lpm_key, &lpm_value, BPF_ANY);
+
+	/* fallback: proxy */
+	__builtin_memset(&ms.__value, 0, sizeof(ms.__value));
+	ms.not = false;
+	ms.type = MatchType_Fallback;
+	ms.outbound = 2;
+	ms.must = false;
+	ms.mark = 0;
+	bpf_map_update_elem(&routing_map, &one_key, &ms, BPF_ANY);
+
+	bpf_tail_call(skb, &entry_call_map, 0);
+	return TC_ACT_OK;
+}
+
+SEC("tc/check/source_ipset_match")
+int testcheck_source_ipset_match(struct __sk_buff *skb)
+{
+	__u32 *status_code;
+
+	void *data = (void *)(long)skb->data;
+	void *data_end = (void *)(long)skb->data_end;
+
+	if (data + sizeof(*status_code) > data_end) {
+		bpf_printk("data + sizeof(*status_code) > data_end\n");
+		return TC_ACT_SHOT;
+	}
+
+	status_code = data;
+	if (*status_code != TC_ACT_OK) {
+		bpf_printk("status_code(%d) != TC_ACT_OK\n", *status_code);
+		return TC_ACT_SHOT;
+	}
+
+	struct ethhdr *eth = data + sizeof(*status_code);
+	if ((void *)(eth + 1) > data_end) {
+		bpf_printk("data + sizeof(*eth) > data_end\n");
+		return TC_ACT_SHOT;
+	}
+	if (eth->h_proto != bpf_htons(ETH_P_IP)) {
+		bpf_printk("eth->h_proto != 0x0800\n");
+		return TC_ACT_SHOT;
+	}
+
+	struct iphdr *ip = (void *)eth + ETH_HLEN;
+	if ((void *)(ip + 1) > data_end) {
+		bpf_printk("data + sizeof(*ip) > data_end\n");
+		return TC_ACT_SHOT;
+	}
+	if (ip->protocol != IPPROTO_TCP) {
+		bpf_printk("ip->protocol != IPPROTO_TCP\n");
+		return TC_ACT_SHOT;
+	}
+	if (ip->daddr != bpf_htonl(0xe0010002)) {
+		bpf_printk("ip->daddr != 224.1.0.2\n");
+		return TC_ACT_SHOT;
+	}
+
+	struct tcphdr *tcp = (void *)ip + IP4_HLEN;
+	if ((void *)(tcp + 1) > data_end) {
+		bpf_printk("data + sizeof(*tcp) > data_end\n");
+		return TC_ACT_SHOT;
+	}
+	if (tcp->dest != bpf_htons(80)) {
+		bpf_printk("tcp->dest != 80\n");
+		return TC_ACT_SHOT;
+	}
+
+	return TC_ACT_OK;
+}

--- a/control/kern/tests/bpf_test.c
+++ b/control/kern/tests/bpf_test.c
@@ -7,6 +7,9 @@
 
 #include "../tproxy.c"
 
+#define IP4_HLEN sizeof(struct iphdr)
+#define TCP_HLEN sizeof(struct tcphdr)
+
 struct {
 	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
 	__uint(key_size, sizeof(__u32));
@@ -14,39 +17,78 @@ struct {
 	__array(values, int());
 } entry_call_map SEC(".maps") = {
 	.values = {
-		[0] = &tproxy_dae0peer_ingress,
+		[0] = &tproxy_wan_egress,
 	},
 };
 
-SEC("tc/pktgen/0")
-int testpktgen_0(struct __sk_buff *skb)
+SEC("tc/pktgen/port_80_match")
+int testpktgen_port_80_match(struct __sk_buff *skb)
 {
-	// set l2 header
-	bpf_skb_change_tail(skb, 14, 0);
+	bpf_skb_change_tail(skb, ETH_HLEN + IP4_HLEN + TCP_HLEN, 0);
+
 	void *data = (void *)(long)skb->data;
 	void *data_end = (void *)(long)skb->data_end;
+
 	struct ethhdr *eth = data;
 	if ((void *)(eth + 1) > data_end) {
 		bpf_printk("data + sizeof(*eth) > data_end\n");
 		return TC_ACT_SHOT;
 	}
-	eth->h_proto = 0x0800;
-	eth->h_source[0] = 0x0a;
-	eth->h_dest[5] = 0x0b;
+	eth->h_proto = bpf_htons(ETH_P_IP);
+
+	struct iphdr *ip = data + ETH_HLEN;
+	if ((void *)(ip + 1) > data_end) {
+		bpf_printk("data + sizeof(*ip) > data_end\n");
+		return TC_ACT_SHOT;
+	}
+	ip->ihl = 5;
+	ip->version = 4;
+	ip->protocol = IPPROTO_TCP;
+	ip->saddr = bpf_htonl(0xc0a80001); // 192.168.0.1
+	ip->daddr = bpf_htonl(0x01010101); // 1.1.1.1
+
+	struct tcphdr *tcp = data + ETH_HLEN + IP4_HLEN;
+	if ((void *)(tcp + 1) > data_end) {
+		bpf_printk("data + sizeof(*tcp) > data_end\n");
+		return TC_ACT_SHOT;
+	}
+	tcp->source = bpf_htons(19233);
+	tcp->dest = bpf_htons(80);
+	tcp->syn = 1;
+
 	return TC_ACT_OK;
 }
 
-SEC("tc/setup/0")
-int testsetup_0(struct __sk_buff *skb)
+SEC("tc/setup/port_80_match")
+int testsetup_port_80_match(struct __sk_buff *skb)
 {
-	skb->cb[0] = TPROXY_MARK;
-	skb->cb[1] = IPPROTO_TCP;
+	__u32 linklen = ETH_HLEN;
+	bpf_map_update_elem(&linklen_map, &one_key, &linklen, BPF_ANY);
+
+	struct match_set ms = {};
+	struct port_range pr = {80, 80};
+	ms.port_range = pr;
+	ms.not = false;
+	ms.type = MatchType_Port;
+	ms.outbound = 2;
+	ms.must = false;
+	ms.mark = 0;
+	bpf_map_update_elem(&routing_map, &zero_key, &ms, BPF_ANY);
+
+	__builtin_memset(&ms.__value, 0, sizeof(ms.__value));
+	ms.not = false;
+	ms.type = MatchType_Fallback;
+	ms.outbound = 0;
+	ms.must = true;
+	ms.mark = 0;
+	bpf_map_update_elem(&routing_map, &one_key, &ms, BPF_ANY);
+
 	bpf_tail_call(skb, &entry_call_map, 0);
 	return TC_ACT_OK;
 }
 
-SEC("tc/check/0")
-int testcheck_0(struct __sk_buff *skb)
+SEC("tc/check/port_80_match")
+int testcheck_port_80_match(struct __sk_buff *skb)
 {
 	__u32 *status_code;
 
@@ -59,8 +101,18 @@ int testcheck_0(struct __sk_buff *skb)
 	}
 
 	status_code = data;
-	if (*status_code != TC_ACT_OK) {
-		bpf_printk("status_code != TC_ACT_OK\n");
+	if (*status_code != TC_ACT_REDIRECT) {
+		bpf_printk("status_code(%d) != TC_ACT_REDIRECT\n", *status_code);
+		return TC_ACT_SHOT;
+	}
+
+	if (skb->cb[0] != TPROXY_MARK) {
+		bpf_printk("skb->cb[0] != TPROXY_MARK\n");
+		return TC_ACT_SHOT;
+	}
+
+	if (skb->cb[1] != IPPROTO_TCP) {
+		bpf_printk("skb->cb[1] != IPPROTO_TCP\n");
 		return TC_ACT_SHOT;
 	}
 
@@ -69,16 +121,62 @@ int testcheck_0(struct __sk_buff *skb)
 		bpf_printk("data + sizeof(*eth) > data_end\n");
 		return TC_ACT_SHOT;
 	}
-	if (eth->h_proto != 0x0800) {
+	if (eth->h_proto != bpf_htons(ETH_P_IP)) {
 		bpf_printk("eth->h_proto != 0x0800\n");
 		return TC_ACT_SHOT;
 	}
-	if (eth->h_source[0] != 0x0a) {
-		bpf_printk("eth->h_source[0] != 0x0a\n");
+
+	struct iphdr *ip = (void *)eth + ETH_HLEN;
+	if ((void *)(ip + 1) > data_end) {
+		bpf_printk("data + sizeof(*ip) > data_end\n");
 		return TC_ACT_SHOT;
 	}
-	if (eth->h_dest[5] != 0x0b) {
-		bpf_printk("eth->h_dest[5] != 0x0b\n");
+	if (ip->protocol != IPPROTO_TCP) {
+		bpf_printk("ip->protocol != IPPROTO_TCP\n");
+		return TC_ACT_SHOT;
+	}
+	if (ip->daddr != bpf_htonl(0x01010101)) {
+		bpf_printk("ip->daddr != 1.1.1.1\n");
+	}
+
+	struct tcphdr *tcp = (void *)ip + IP4_HLEN;
+	if ((void *)(tcp + 1) > data_end) {
+		bpf_printk("data + sizeof(*tcp) > data_end\n");
+		return TC_ACT_SHOT;
+	}
+	if (tcp->dest != bpf_htons(80)) {
+		bpf_printk("tcp->dest != 80\n");
+		return TC_ACT_SHOT;
+	}
+
+	struct tuples tuples = {};
+	tuples.five.sip.u6_addr32[2] = bpf_htonl(0xffff);
+	tuples.five.sip.u6_addr32[3] = ip->saddr;
+	tuples.five.dip.u6_addr32[2] = bpf_htonl(0xffff);
+	tuples.five.dip.u6_addr32[3] = ip->daddr;
+	tuples.five.sport = tcp->source;
+	tuples.five.dport = tcp->dest;
+	tuples.five.l4proto = ip->protocol;
+
+	struct routing_result *routing_result;
+	routing_result = bpf_map_lookup_elem(&routing_tuples_map, &tuples.five);
+	if (!routing_result) {
+		bpf_printk("routing_result == NULL\n");
+		return TC_ACT_SHOT;
+	}
+
+	if (routing_result->mark != 0) {
+		bpf_printk("routing_result->mark != 0\n");
+		return TC_ACT_SHOT;
+	}
+
+	if (routing_result->must != false) {
+		bpf_printk("routing_result->must != false\n");
+		return TC_ACT_SHOT;
+	}
+
+	if (routing_result->outbound != 2) {
+		bpf_printk("routing_result->outbound != 2\n");
 		return TC_ACT_SHOT;
 	}
 

--- a/control/kern/tests/bpf_test.c
+++ b/control/kern/tests/bpf_test.c
@@ -8,10 +8,7 @@
 #define __PRINT_ROUTING_RESULT
 
 #include "../tproxy.c"
-
-#define IP4_HLEN sizeof(struct iphdr)
-#define IP6_HLEN sizeof(struct ipv6hdr)
-#define TCP_HLEN sizeof(struct tcphdr)
+#include "./bpf_test.h"
 
 struct {
 	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
@@ -27,39 +24,8 @@ struct {
 SEC("tc/pktgen/port_match")
 int testpktgen_port_match(struct __sk_buff *skb)
 {
-	bpf_skb_change_tail(skb, ETH_HLEN + IP4_HLEN + TCP_HLEN, 0);
-
-	void *data = (void *)(long)skb->data;
-	void *data_end = (void *)(long)skb->data_end;
-
-	struct ethhdr *eth = data;
-	if ((void *)(eth + 1) > data_end) {
-		bpf_printk("data + sizeof(*eth) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-	eth->h_proto = bpf_htons(ETH_P_IP);
-
-	struct iphdr *ip = data + ETH_HLEN;
-	if ((void *)(ip + 1) > data_end) {
-		bpf_printk("data + sizeof(*ip) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-	ip->ihl = 5;
-	ip->version = 4;
-	ip->protocol = IPPROTO_TCP;
-	ip->saddr = bpf_htonl(0xc0a80001); // 192.168.0.1
-	ip->daddr = bpf_htonl(0x01010101); // 1.1.1.1
-
-	struct tcphdr *tcp = data + ETH_HLEN + IP4_HLEN;
-	if ((void *)(tcp + 1) > data_end) {
-		bpf_printk("data + sizeof(*tcp) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-	tcp->source = bpf_htons(19233);
-	tcp->dest = bpf_htons(80);
-	tcp->syn = 1;
-
-	return TC_ACT_OK;
+	// 192.168.0.1:19233 -> 1.1.1.1:80
+	return set_ipv4_tcp(skb, 0xc0a80001, 0x01010101, 19233, 80);
 }
 
 SEC("tc/setup/port_match")
@@ -74,19 +40,13 @@ int testsetup_port_match(struct __sk_buff *skb)
 	ms.port_range = pr;
 	ms.not = false;
 	ms.type = MatchType_Port;
-	ms.outbound = 2;
+	ms.outbound = OUTBOUND_USER_DEFINED_MIN;
 	ms.must = false;
 	ms.mark = 0;
 	bpf_map_update_elem(&routing_map, &zero_key, &ms, BPF_ANY);
 
 	/* fallback: must_direct */
-	__builtin_memset(&ms.__value, 0, sizeof(ms.__value));
-	ms.not = false;
-	ms.type = MatchType_Fallback;
-	ms.outbound = 0;
-	ms.must = true;
-	ms.mark = 0;
-	bpf_map_update_elem(&routing_map, &one_key, &ms, BPF_ANY);
+	set_routing_fallback(OUTBOUND_DIRECT, true);
 
 	bpf_tail_call(skb, &entry_call_map, 0);
 	return TC_ACT_OK;
@@ -95,136 +55,18 @@ int testsetup_port_match(struct __sk_buff *skb)
 SEC("tc/check/port_match")
 int testcheck_port_match(struct __sk_buff *skb)
 {
-	__u32 *status_code;
-
-	void *data = (void *)(long)skb->data;
-	void *data_end = (void *)(long)skb->data_end;
-
-	if (data + sizeof(*status_code) > data_end) {
-		bpf_printk("data + sizeof(*status_code) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-
-	status_code = data;
-	if (*status_code != TC_ACT_REDIRECT) {
-		bpf_printk("status_code(%d) != TC_ACT_REDIRECT\n", *status_code);
-		return TC_ACT_SHOT;
-	}
-
-	if (skb->cb[0] != TPROXY_MARK) {
-		bpf_printk("skb->cb[0] != TPROXY_MARK\n");
-		return TC_ACT_SHOT;
-	}
-
-	if (skb->cb[1] != IPPROTO_TCP) {
-		bpf_printk("skb->cb[1] != IPPROTO_TCP\n");
-		return TC_ACT_SHOT;
-	}
-
-	struct ethhdr *eth = data + sizeof(*status_code);
-	if ((void *)(eth + 1) > data_end) {
-		bpf_printk("data + sizeof(*eth) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-	if (eth->h_proto != bpf_htons(ETH_P_IP)) {
-		bpf_printk("eth->h_proto != 0x0800\n");
-		return TC_ACT_SHOT;
-	}
-
-	struct iphdr *ip = (void *)eth + ETH_HLEN;
-	if ((void *)(ip + 1) > data_end) {
-		bpf_printk("data + sizeof(*ip) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-	if (ip->protocol != IPPROTO_TCP) {
-		bpf_printk("ip->protocol != IPPROTO_TCP\n");
-		return TC_ACT_SHOT;
-	}
-	if (ip->daddr != bpf_htonl(0x01010101)) {
-		bpf_printk("ip->daddr != 1.1.1.1\n");
-		return TC_ACT_SHOT;
-	}
-
-	struct tcphdr *tcp = (void *)ip + IP4_HLEN;
-	if ((void *)(tcp + 1) > data_end) {
-		bpf_printk("data + sizeof(*tcp) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-	if (tcp->dest != bpf_htons(80)) {
-		bpf_printk("tcp->dest != 80\n");
-		return TC_ACT_SHOT;
-	}
-
-	struct tuples tuples = {};
-	tuples.five.sip.u6_addr32[2] = bpf_htonl(0xffff);
-	tuples.five.sip.u6_addr32[3] = ip->saddr;
-	tuples.five.dip.u6_addr32[2] = bpf_htonl(0xffff);
-	tuples.five.dip.u6_addr32[3] = ip->daddr;
-	tuples.five.sport = tcp->source;
-	tuples.five.dport = tcp->dest;
-	tuples.five.l4proto = ip->protocol;
-
-	struct routing_result *routing_result;
-	routing_result = bpf_map_lookup_elem(&routing_tuples_map, &tuples.five);
-	if (!routing_result) {
-		bpf_printk("routing_result == NULL\n");
-		return TC_ACT_SHOT;
-	}
-
-	if (routing_result->mark != 0) {
-		bpf_printk("routing_result->mark != 0\n");
-		return TC_ACT_SHOT;
-	}
-
-	if (routing_result->must != 0) {
-		bpf_printk("routing_result->must != 0\n");
-		return TC_ACT_SHOT;
-	}
-
-	if (routing_result->outbound != 2) {
-		bpf_printk("routing_result->outbound != 2\n");
-		return TC_ACT_SHOT;
-	}
-
-	return TC_ACT_OK;
+	// 192.168.0.1:19233 -> 1.1.1.1:80
+	return check_routing_ipv4_tcp(skb,
+				      TC_ACT_REDIRECT,
+				      0xc0a80001, 0x01010101,
+				      19233, 80);
 }
 
 SEC("tc/pktgen/port_mismatch")
 int testpktgen_port_mismatch(struct __sk_buff *skb)
 {
-	bpf_skb_change_tail(skb, ETH_HLEN + IP4_HLEN + TCP_HLEN, 0);
-
-	void *data = (void *)(long)skb->data;
-	void *data_end = (void *)(long)skb->data_end;
-
-	struct ethhdr *eth = data;
-	if ((void *)(eth + 1) > data_end) {
-		bpf_printk("data + sizeof(*eth) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-	eth->h_proto = bpf_htons(ETH_P_IP);
-
-	struct iphdr *ip = data + ETH_HLEN;
-	if ((void *)(ip + 1) > data_end) {
-		bpf_printk("data + sizeof(*ip) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-	ip->ihl = 5;
-	ip->version = 4;
-	ip->protocol = IPPROTO_TCP;
-	ip->saddr = bpf_htonl(0xc0a80001); // 192.168.0.1
-	ip->daddr = bpf_htonl(0x01010101); // 1.1.1.1
-
-	struct tcphdr *tcp = data + ETH_HLEN + IP4_HLEN;
-	if ((void *)(tcp + 1) > data_end) {
-		bpf_printk("data + sizeof(*tcp) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-	tcp->source = bpf_htons(19233);
-	tcp->dest = bpf_htons(79);
-	tcp->syn = 1;
-
-	return TC_ACT_OK;
+	// 192.168.0.1:19233 -> 1.1.1.1:80
+	return set_ipv4_tcp(skb, 0xc0a80001, 0x01010101, 19233, 79);
 }
 
 SEC("tc/setup/port_mismatch")
@@ -245,13 +87,7 @@ int testsetup_port_mismatch(struct __sk_buff *skb)
 	bpf_map_update_elem(&routing_map, &zero_key, &ms, BPF_ANY);
 
 	/* fallback: must_direct */
-	__builtin_memset(&ms.__value, 0, sizeof(ms.__value));
-	ms.not = false;
-	ms.type = MatchType_Fallback;
-	ms.outbound = 0;
-	ms.must = true;
-	ms.mark = 0;
-	bpf_map_update_elem(&routing_map, &one_key, &ms, BPF_ANY);
+	set_routing_fallback(OUTBOUND_DIRECT, true);
 
 	bpf_tail_call(skb, &entry_call_map, 0);
 	return TC_ACT_OK;
@@ -260,95 +96,18 @@ int testsetup_port_mismatch(struct __sk_buff *skb)
 SEC("tc/check/port_mismatch")
 int testcheck_port_mismatch(struct __sk_buff *skb)
 {
-	__u32 *status_code;
-
-	void *data = (void *)(long)skb->data;
-	void *data_end = (void *)(long)skb->data_end;
-
-	if (data + sizeof(*status_code) > data_end) {
-		bpf_printk("data + sizeof(*status_code) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-
-	status_code = data;
-	if (*status_code != TC_ACT_OK) {
-		bpf_printk("status_code(%d) != TC_ACT_OK\n", *status_code);
-		return TC_ACT_SHOT;
-	}
-
-	struct ethhdr *eth = data + sizeof(*status_code);
-	if ((void *)(eth + 1) > data_end) {
-		bpf_printk("data + sizeof(*eth) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-	if (eth->h_proto != bpf_htons(ETH_P_IP)) {
-		bpf_printk("eth->h_proto != 0x0800\n");
-		return TC_ACT_SHOT;
-	}
-
-	struct iphdr *ip = (void *)eth + ETH_HLEN;
-	if ((void *)(ip + 1) > data_end) {
-		bpf_printk("data + sizeof(*ip) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-	if (ip->protocol != IPPROTO_TCP) {
-		bpf_printk("ip->protocol != IPPROTO_TCP\n");
-		return TC_ACT_SHOT;
-	}
-	if (ip->daddr != bpf_htonl(0x01010101)) {
-		bpf_printk("ip->daddr != 1.1.1.1\n");
-		return TC_ACT_SHOT;
-	}
-
-	struct tcphdr *tcp = (void *)ip + IP4_HLEN;
-	if ((void *)(tcp + 1) > data_end) {
-		bpf_printk("data + sizeof(*tcp) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-	if (tcp->dest != bpf_htons(79)) {
-		bpf_printk("tcp->dest != 79\n");
-		return TC_ACT_SHOT;
-	}
-
-	return TC_ACT_OK;
+	// 192.168.0.1:19233 -> 1.1.1.1:79
+	return check_routing_ipv4_tcp(skb,
+				      TC_ACT_OK,
+				      0xc0a80001, 0x01010101,
+				      19233, 79);
 }
 
 SEC("tc/pktgen/ipset_match_v4")
 int testpktgen_ipset_match_v4(struct __sk_buff *skb)
 {
-	bpf_skb_change_tail(skb, ETH_HLEN + IP4_HLEN + TCP_HLEN, 0);
-
-	void *data = (void *)(long)skb->data;
-	void *data_end = (void *)(long)skb->data_end;
-
-	struct ethhdr *eth = data;
-	if ((void *)(eth + 1) > data_end) {
-		bpf_printk("data + sizeof(*eth) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-	eth->h_proto = bpf_htons(ETH_P_IP);
-
-	struct iphdr *ip = data + ETH_HLEN;
-	if ((void *)(ip + 1) > data_end) {
-		bpf_printk("data + sizeof(*ip) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-	ip->ihl = 5;
-	ip->version = 4;
-	ip->protocol = IPPROTO_TCP;
-	ip->saddr = bpf_htonl(0xc0a80001); // 192.168.0.1
-	ip->daddr = bpf_htonl(0xe0010002); // 224.1.0.2
-
-	struct tcphdr *tcp = data + ETH_HLEN + IP4_HLEN;
-	if ((void *)(tcp + 1) > data_end) {
-		bpf_printk("data + sizeof(*tcp) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-	tcp->source = bpf_htons(19233);
-	tcp->dest = bpf_htons(80);
-	tcp->syn = 1;
-
-	return TC_ACT_OK;
+	// 192.168.0.1:19233 -> 224.1.0.2:80
+	return set_ipv4_tcp(skb, 0xc0a80001, 0xe0010002, 19233, 80);
 }
 
 SEC("tc/setup/ipset_match_v4")
@@ -357,7 +116,7 @@ int testsetup_ipset_match_v4(struct __sk_buff *skb)
 	__u32 linklen = ETH_HLEN;
 	bpf_map_update_elem(&linklen_map, &one_key, &linklen, BPF_ANY);
 
-	/* dip(224.0.0.0/8, 'ff00::/8') -> direct */
+	/* dip(224.1.0.0/16) -> direct */
 	struct match_set ms = {};
 	ms.not = false;
 	ms.type = MatchType_IpSet;
@@ -367,25 +126,14 @@ int testsetup_ipset_match_v4(struct __sk_buff *skb)
 	bpf_map_update_elem(&routing_map, &zero_key, &ms, BPF_ANY);
 
 	struct lpm_key lpm_key = {};
-	lpm_key.trie_key.prefixlen = 112;
+	lpm_key.trie_key.prefixlen = 112; // */16
 	lpm_key.data[2] = bpf_ntohl(0xffff);
 	lpm_key.data[3] = bpf_ntohl(0xe0010000); // 224.1.0.0
 	__u32 lpm_value = bpf_ntohl(0x01000000);
 	bpf_map_update_elem(&unused_lpm_type, &lpm_key, &lpm_value, BPF_ANY);
 
-	__builtin_memset(&lpm_key, 0, sizeof(lpm_key));
-	lpm_key.trie_key.prefixlen = 8;
-	lpm_key.data[0] = bpf_ntohl(0xff000000); // ff00::
-	bpf_map_update_elem(&unused_lpm_type, &lpm_key, &lpm_value, BPF_ANY);
-
 	/* fallback: proxy */
-	__builtin_memset(&ms.__value, 0, sizeof(ms.__value));
-	ms.not = false;
-	ms.type = MatchType_Fallback;
-	ms.outbound = 2;
-	ms.must = false;
-	ms.mark = 0;
-	bpf_map_update_elem(&routing_map, &one_key, &ms, BPF_ANY);
+	set_routing_fallback(OUTBOUND_USER_DEFINED_MIN, false);
 
 	bpf_tail_call(skb, &entry_call_map, 0);
 	return TC_ACT_OK;
@@ -394,234 +142,18 @@ int testsetup_ipset_match_v4(struct __sk_buff *skb)
 SEC("tc/check/ipset_match_v4")
 int testcheck_ipset_match_v4(struct __sk_buff *skb)
 {
-	__u32 *status_code;
-
-	void *data = (void *)(long)skb->data;
-	void *data_end = (void *)(long)skb->data_end;
-
-	if (data + sizeof(*status_code) > data_end) {
-		bpf_printk("data + sizeof(*status_code) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-
-	status_code = data;
-	if (*status_code != TC_ACT_OK) {
-		bpf_printk("status_code(%d) != TC_ACT_OK\n", *status_code);
-		return TC_ACT_SHOT;
-	}
-
-	struct ethhdr *eth = data + sizeof(*status_code);
-	if ((void *)(eth + 1) > data_end) {
-		bpf_printk("data + sizeof(*eth) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-	if (eth->h_proto != bpf_htons(ETH_P_IP)) {
-		bpf_printk("eth->h_proto != 0x0800\n");
-		return TC_ACT_SHOT;
-	}
-
-	struct iphdr *ip = (void *)eth + ETH_HLEN;
-	if ((void *)(ip + 1) > data_end) {
-		bpf_printk("data + sizeof(*ip) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-	if (ip->protocol != IPPROTO_TCP) {
-		bpf_printk("ip->protocol != IPPROTO_TCP\n");
-		return TC_ACT_SHOT;
-	}
-	if (ip->daddr != bpf_htonl(0xe0010002)) {
-		bpf_printk("ip->daddr != 224.1.0.2\n");
-		return TC_ACT_SHOT;
-	}
-
-	struct tcphdr *tcp = (void *)ip + IP4_HLEN;
-	if ((void *)(tcp + 1) > data_end) {
-		bpf_printk("data + sizeof(*tcp) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-	if (tcp->dest != bpf_htons(80)) {
-		bpf_printk("tcp->dest != 80\n");
-		return TC_ACT_SHOT;
-	}
-
-	return TC_ACT_OK;
-}
-
-SEC("tc/pktgen/ipset_match_v6")
-int testpktgen_ipset_match_v6(struct __sk_buff *skb)
-{
-	bpf_skb_change_tail(skb, ETH_HLEN + IP6_HLEN + TCP_HLEN, 0);
-
-	void *data = (void *)(long)skb->data;
-	void *data_end = (void *)(long)skb->data_end;
-
-	struct ethhdr *eth = data;
-	if ((void *)(eth + 1) > data_end) {
-		bpf_printk("data + sizeof(*eth) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-	eth->h_proto = bpf_htons(ETH_P_IPV6);
-
-	struct ipv6hdr *ip6 = data + ETH_HLEN;
-	if ((void *)(ip6 + 1) > data_end) {
-		bpf_printk("data + sizeof(*ip6) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-	ip6->version = 6;
-	ip6->nexthdr = IPPROTO_TCP;
-	__builtin_memset(&ip6->saddr, 0, sizeof(ip6->saddr));
-	ip6->saddr.in6_u.u6_addr32[0] = bpf_htonl(0x20010db8); // 2001:db8::
-	ip6->saddr.in6_u.u6_addr32[3] = bpf_htonl(0x1); // 2001:db8::1
-	__builtin_memset(&ip6->daddr, 0, sizeof(ip6->daddr));
-	ip6->daddr.in6_u.u6_addr32[0] = bpf_htonl(0xff000000); // ff00::
-	ip6->daddr.in6_u.u6_addr32[3] = bpf_htonl(0x2); // ff00::2
-
-	struct tcphdr *tcp = data + ETH_HLEN + IP6_HLEN;
-	if ((void *)(tcp + 1) > data_end) {
-		bpf_printk("data + sizeof(*tcp) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-	tcp->source = bpf_htons(19233);
-	tcp->dest = bpf_htons(80);
-	tcp->syn = 1;
-
-	return TC_ACT_OK;
-}
-
-SEC("tc/setup/ipset_match_v6")
-int testsetup_ipset_match_v6(struct __sk_buff *skb)
-{
-	__u32 linklen = ETH_HLEN;
-	bpf_map_update_elem(&linklen_map, &one_key, &linklen, BPF_ANY);
-
-	/* dip(224.0.0.0/8, 'ff00::/8') -> direct */
-	struct match_set ms = {};
-	ms.not = false;
-	ms.type = MatchType_IpSet;
-	ms.outbound = 0;
-	ms.must = false;
-	ms.mark = 0;
-	bpf_map_update_elem(&routing_map, &zero_key, &ms, BPF_ANY);
-
-	struct lpm_key lpm_key = {};
-	lpm_key.trie_key.prefixlen = 112;
-	lpm_key.data[2] = bpf_ntohl(0xffff);
-	lpm_key.data[3] = bpf_ntohl(0xe0010000); // 224.1.0.0
-	__u32 lpm_value = bpf_ntohl(0x01000000);
-	bpf_map_update_elem(&unused_lpm_type, &lpm_key, &lpm_value, BPF_ANY);
-
-	__builtin_memset(&lpm_key, 0, sizeof(lpm_key));
-	lpm_key.trie_key.prefixlen = 8;
-	lpm_key.data[0] = bpf_ntohl(0xff000000); // ff00::
-	bpf_map_update_elem(&unused_lpm_type, &lpm_key, &lpm_value, BPF_ANY);
-
-	/* fallback: proxy */
-	__builtin_memset(&ms.__value, 0, sizeof(ms.__value));
-	ms.not = false;
-	ms.type = MatchType_Fallback;
-	ms.outbound = 2;
-	ms.must = false;
-	ms.mark = 0;
-	bpf_map_update_elem(&routing_map, &one_key, &ms, BPF_ANY);
-
-	bpf_tail_call(skb, &entry_call_map, 0);
-	return TC_ACT_OK;
-}
-
-SEC("tc/check/ipset_match_v6")
-int testcheck_ipset_match_v6(struct __sk_buff *skb)
-{
-	__u32 *status_code;
-
-	void *data = (void *)(long)skb->data;
-	void *data_end = (void *)(long)skb->data_end;
-
-	if (data + sizeof(*status_code) > data_end) {
-		bpf_printk("data + sizeof(*status_code) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-
-	status_code = data;
-	if (*status_code != TC_ACT_OK) {
-		bpf_printk("status_code(%d) != TC_ACT_OK\n", *status_code);
-		return TC_ACT_SHOT;
-	}
-
-	struct ethhdr *eth = data + sizeof(*status_code);
-	if ((void *)(eth + 1) > data_end) {
-		bpf_printk("data + sizeof(*eth) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-	if (eth->h_proto != bpf_htons(ETH_P_IPV6)) {
-		bpf_printk("eth->h_proto != ETH_P_IPV6\n");
-		return TC_ACT_SHOT;
-	}
-
-	struct ipv6hdr *ip6 = (void *)eth + ETH_HLEN;
-	if ((void *)(ip6 + 1) > data_end) {
-		bpf_printk("data + sizeof(*ip6) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-
-	if (ip6->nexthdr != IPPROTO_TCP) {
-		bpf_printk("ip6->next_header != IPPROTO_TCP\n");
-		return TC_ACT_SHOT;
-	}
-
-	if (ip6->daddr.in6_u.u6_addr32[0] != bpf_htonl(0xff000000)) {
-		bpf_printk("ip6->daddr.in6_u.u6_addr32[0] != 0xff000000\n");
-		return TC_ACT_SHOT;
-	}
-
-	struct tcphdr *tcp = (void *)ip6 + IP6_HLEN;
-	if ((void *)(tcp + 1) > data_end) {
-		bpf_printk("data + sizeof(*tcp) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-	if (tcp->dest != bpf_htons(80)) {
-		bpf_printk("tcp->dest != 80\n");
-		return TC_ACT_SHOT;
-	}
-
-	return TC_ACT_OK;
+	// 192.168.0.1:19233 -> 224.1.0.2:80
+	return check_routing_ipv4_tcp(skb,
+				      TC_ACT_OK,
+				      0xc0a80001, 0xe0010002,
+				      19233, 80);
 }
 
 SEC("tc/pktgen/ipset_mismatch")
 int testpktgen_ipset_mismatch(struct __sk_buff *skb)
 {
-	bpf_skb_change_tail(skb, ETH_HLEN + IP4_HLEN + TCP_HLEN, 0);
-
-	void *data = (void *)(long)skb->data;
-	void *data_end = (void *)(long)skb->data_end;
-
-	struct ethhdr *eth = data;
-	if ((void *)(eth + 1) > data_end) {
-		bpf_printk("data + sizeof(*eth) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-	eth->h_proto = bpf_htons(ETH_P_IP);
-
-	struct iphdr *ip = data + ETH_HLEN;
-	if ((void *)(ip + 1) > data_end) {
-		bpf_printk("data + sizeof(*ip) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-	ip->ihl = 5;
-	ip->version = 4;
-	ip->protocol = IPPROTO_TCP;
-	ip->saddr = bpf_htonl(0xc0a80001); // 192.168.0.1
-	ip->daddr = bpf_htonl(0xe1010002); // 225.1.0.2
-
-	struct tcphdr *tcp = data + ETH_HLEN + IP4_HLEN;
-	if ((void *)(tcp + 1) > data_end) {
-		bpf_printk("data + sizeof(*tcp) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-	tcp->source = bpf_htons(19233);
-	tcp->dest = bpf_htons(80);
-	tcp->syn = 1;
-
-	return TC_ACT_OK;
+	// 192.168.0.1:19233 -> 225.1.0.2:80
+	return set_ipv4_tcp(skb, 0xc0a80001, 0xe1010002, 19233, 80);
 }
 
 SEC("tc/setup/ipset_mismatch")
@@ -630,7 +162,7 @@ int testsetup_ipset_mismatch(struct __sk_buff *skb)
 	__u32 linklen = ETH_HLEN;
 	bpf_map_update_elem(&linklen_map, &one_key, &linklen, BPF_ANY);
 
-	/* dip(224.0.0.0/8, 'ff00::/8') -> direct */
+	// dip(224.1.0.0/16) -> direct
 	struct match_set ms = {};
 	ms.not = false;
 	ms.type = MatchType_IpSet;
@@ -640,25 +172,14 @@ int testsetup_ipset_mismatch(struct __sk_buff *skb)
 	bpf_map_update_elem(&routing_map, &zero_key, &ms, BPF_ANY);
 
 	struct lpm_key lpm_key = {};
-	lpm_key.trie_key.prefixlen = 112;
+	lpm_key.trie_key.prefixlen = 112; // */16
 	lpm_key.data[2] = bpf_ntohl(0xffff);
 	lpm_key.data[3] = bpf_ntohl(0xe0010000); // 224.1.0.0
 	__u32 lpm_value = bpf_ntohl(0x01000000);
 	bpf_map_update_elem(&unused_lpm_type, &lpm_key, &lpm_value, BPF_ANY);
 
-	__builtin_memset(&lpm_key, 0, sizeof(lpm_key));
-	lpm_key.trie_key.prefixlen = 8;
-	lpm_key.data[0] = bpf_ntohl(0xff000000); // ff00::
-	bpf_map_update_elem(&unused_lpm_type, &lpm_key, &lpm_value, BPF_ANY);
-
 	/* fallback: proxy */
-	__builtin_memset(&ms.__value, 0, sizeof(ms.__value));
-	ms.not = false;
-	ms.type = MatchType_Fallback;
-	ms.outbound = 2;
-	ms.must = false;
-	ms.mark = 0;
-	bpf_map_update_elem(&routing_map, &one_key, &ms, BPF_ANY);
+	set_routing_fallback(OUTBOUND_USER_DEFINED_MIN, false);
 
 	bpf_tail_call(skb, &entry_call_map, 0);
 	return TC_ACT_OK;
@@ -667,126 +188,18 @@ int testsetup_ipset_mismatch(struct __sk_buff *skb)
 SEC("tc/check/ipset_mismatch")
 int testcheck_ipset_mismatch(struct __sk_buff *skb)
 {
-	__u32 *status_code;
-
-	void *data = (void *)(long)skb->data;
-	void *data_end = (void *)(long)skb->data_end;
-
-	if (data + sizeof(*status_code) > data_end) {
-		bpf_printk("data + sizeof(*status_code) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-
-	status_code = data;
-	if (*status_code != TC_ACT_REDIRECT) {
-		bpf_printk("status_code(%d) != TC_ACT_REDIRECT\n", *status_code);
-		return TC_ACT_SHOT;
-	}
-
-	struct ethhdr *eth = data + sizeof(*status_code);
-	if ((void *)(eth + 1) > data_end) {
-		bpf_printk("data + sizeof(*eth) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-	if (eth->h_proto != bpf_htons(ETH_P_IP)) {
-		bpf_printk("eth->h_proto != 0x0800\n");
-		return TC_ACT_SHOT;
-	}
-
-	struct iphdr *ip = (void *)eth + ETH_HLEN;
-	if ((void *)(ip + 1) > data_end) {
-		bpf_printk("data + sizeof(*ip) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-	if (ip->protocol != IPPROTO_TCP) {
-		bpf_printk("ip->protocol != IPPROTO_TCP\n");
-		return TC_ACT_SHOT;
-	}
-	if (ip->daddr != bpf_htonl(0xe1010002)) {
-		bpf_printk("ip->daddr != 225.1.0.2\n");
-		return TC_ACT_SHOT;
-	}
-
-	struct tcphdr *tcp = (void *)ip + IP4_HLEN;
-	if ((void *)(tcp + 1) > data_end) {
-		bpf_printk("data + sizeof(*tcp) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-	if (tcp->dest != bpf_htons(80)) {
-		bpf_printk("tcp->dest != 80\n");
-		return TC_ACT_SHOT;
-	}
-
-	struct tuples tuples = {};
-	tuples.five.sip.u6_addr32[2] = bpf_htonl(0xffff);
-	tuples.five.sip.u6_addr32[3] = ip->saddr;
-	tuples.five.dip.u6_addr32[2] = bpf_htonl(0xffff);
-	tuples.five.dip.u6_addr32[3] = ip->daddr;
-	tuples.five.sport = tcp->source;
-	tuples.five.dport = tcp->dest;
-	tuples.five.l4proto = ip->protocol;
-
-	struct routing_result *routing_result;
-	routing_result = bpf_map_lookup_elem(&routing_tuples_map, &tuples.five);
-	if (!routing_result) {
-		bpf_printk("routing_result == NULL\n");
-		return TC_ACT_SHOT;
-	}
-
-	if (routing_result->mark != 0) {
-		bpf_printk("routing_result->mark != 0\n");
-		return TC_ACT_SHOT;
-	}
-
-	if (routing_result->must != 0) {
-		bpf_printk("routing_result->must != 0\n");
-		return TC_ACT_SHOT;
-	}
-
-	if (routing_result->outbound != 2) {
-		bpf_printk("routing_result->outbound != 2\n");
-		return TC_ACT_SHOT;
-	}
-
-	return TC_ACT_OK;
+	// 192.168.0.1:19233 -> 225.1.0.2:80
+	return check_routing_ipv4_tcp(skb,
+				      TC_ACT_REDIRECT,
+				      0xc0a80001, 0xe1010002,
+				      19233, 80);
 }
 
 SEC("tc/pktgen/source_ipset_match")
 int testpktgen_source_ipset_match(struct __sk_buff *skb)
 {
-	bpf_skb_change_tail(skb, ETH_HLEN + IP4_HLEN + TCP_HLEN, 0);
-
-	void *data = (void *)(long)skb->data;
-	void *data_end = (void *)(long)skb->data_end;
-
-	struct ethhdr *eth = data;
-	if ((void *)(eth + 1) > data_end) {
-		bpf_printk("data + sizeof(*eth) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-	eth->h_proto = bpf_htons(ETH_P_IP);
-
-	struct iphdr *ip = data + ETH_HLEN;
-	if ((void *)(ip + 1) > data_end) {
-		bpf_printk("data + sizeof(*ip) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-	ip->ihl = 5;
-	ip->version = 4;
-	ip->protocol = IPPROTO_TCP;
-	ip->saddr = bpf_htonl(0xc0a83201); // 192.168.50.1
-	ip->daddr = bpf_htonl(0xe0010002); // 224.1.0.2
-
-	struct tcphdr *tcp = data + ETH_HLEN + IP4_HLEN;
-	if ((void *)(tcp + 1) > data_end) {
-		bpf_printk("data + sizeof(*tcp) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-	tcp->source = bpf_htons(19233);
-	tcp->dest = bpf_htons(80);
-	tcp->syn = 1;
-
-	return TC_ACT_OK;
+	// 192.168.50.1:19233 -> 224.1.0.2:80
+	return set_ipv4_tcp(skb, 0xc0a83201, 0xe0010002, 19233, 80);
 }
 
 SEC("tc/setup/source_ipset_match")
@@ -812,13 +225,7 @@ int testsetup_source_ipset_match(struct __sk_buff *skb)
 	bpf_map_update_elem(&unused_lpm_type, &lpm_key, &lpm_value, BPF_ANY);
 
 	/* fallback: proxy */
-	__builtin_memset(&ms.__value, 0, sizeof(ms.__value));
-	ms.not = false;
-	ms.type = MatchType_Fallback;
-	ms.outbound = 2;
-	ms.must = false;
-	ms.mark = 0;
-	bpf_map_update_elem(&routing_map, &one_key, &ms, BPF_ANY);
+	set_routing_fallback(OUTBOUND_USER_DEFINED_MIN, false);
 
 	bpf_tail_call(skb, &entry_call_map, 0);
 	return TC_ACT_OK;
@@ -827,55 +234,9 @@ int testsetup_source_ipset_match(struct __sk_buff *skb)
 SEC("tc/check/source_ipset_match")
 int testcheck_source_ipset_match(struct __sk_buff *skb)
 {
-	__u32 *status_code;
-
-	void *data = (void *)(long)skb->data;
-	void *data_end = (void *)(long)skb->data_end;
-
-	if (data + sizeof(*status_code) > data_end) {
-		bpf_printk("data + sizeof(*status_code) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-
-	status_code = data;
-	if (*status_code != TC_ACT_OK) {
-		bpf_printk("status_code(%d) != TC_ACT_OK\n", *status_code);
-		return TC_ACT_SHOT;
-	}
-
-	struct ethhdr *eth = data + sizeof(*status_code);
-	if ((void *)(eth + 1) > data_end) {
-		bpf_printk("data + sizeof(*eth) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-	if (eth->h_proto != bpf_htons(ETH_P_IP)) {
-		bpf_printk("eth->h_proto != 0x0800\n");
-		return TC_ACT_SHOT;
-	}
-
-	struct iphdr *ip = (void *)eth + ETH_HLEN;
-	if ((void *)(ip + 1) > data_end) {
-		bpf_printk("data + sizeof(*ip) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-	if (ip->protocol != IPPROTO_TCP) {
-		bpf_printk("ip->protocol != IPPROTO_TCP\n");
-		return TC_ACT_SHOT;
-	}
-	if (ip->daddr != bpf_htonl(0xe0010002)) {
-		bpf_printk("ip->daddr != 224.1.0.2\n");
-		return TC_ACT_SHOT;
-	}
-
-	struct tcphdr *tcp = (void *)ip + IP4_HLEN;
-	if ((void *)(tcp + 1) > data_end) {
-		bpf_printk("data + sizeof(*tcp) > data_end\n");
-		return TC_ACT_SHOT;
-	}
-	if (tcp->dest != bpf_htons(80)) {
-		bpf_printk("tcp->dest != 80\n");
-		return TC_ACT_SHOT;
-	}
-
-	return TC_ACT_OK;
+	// 192.168.50.1:19233 -> 224.1.0.2:80
+	return check_routing_ipv4_tcp(skb,
+				      TC_ACT_OK,
+				      0xc0a83201, 0xe0010002,
+				      19233, 80);
 }

--- a/control/kern/tests/bpf_test.c
+++ b/control/kern/tests/bpf_test.c
@@ -24,8 +24,7 @@ struct {
 SEC("tc/pktgen/dport_match")
 int testpktgen_dport_match(struct __sk_buff *skb)
 {
-	// 192.168.0.1:19233 -> 1.1.1.1:80
-	return set_ipv4_tcp(skb, 0xc0a80001, 0x01010101, 19233, 80);
+	return set_ipv4_tcp(skb, IPV4(192,168,0,1), IPV4(1,1,1,1), 19233, 80);
 }
 
 SEC("tc/setup/dport_match")
@@ -55,18 +54,16 @@ int testsetup_dport_match(struct __sk_buff *skb)
 SEC("tc/check/dport_match")
 int testcheck_dport_match(struct __sk_buff *skb)
 {
-	// 192.168.0.1:19233 -> 1.1.1.1:80
 	return check_routing_ipv4_tcp(skb,
 				      TC_ACT_REDIRECT,
-				      0xc0a80001, 0x01010101,
+				      IPV4(192,168,0,1), IPV4(1,1,1,1),
 				      19233, 80);
 }
 
 SEC("tc/pktgen/dport_mismatch")
 int testpktgen_dport_mismatch(struct __sk_buff *skb)
 {
-	// 192.168.0.1:19233 -> 1.1.1.1:80
-	return set_ipv4_tcp(skb, 0xc0a80001, 0x01010101, 19233, 79);
+	return set_ipv4_tcp(skb, IPV4(192,168,0,1), IPV4(1,1,1,1), 19233, 79);
 }
 
 SEC("tc/setup/dport_mismatch")
@@ -96,18 +93,16 @@ int testsetup_dport_mismatch(struct __sk_buff *skb)
 SEC("tc/check/dport_mismatch")
 int testcheck_dport_mismatch(struct __sk_buff *skb)
 {
-	// 192.168.0.1:19233 -> 1.1.1.1:79
 	return check_routing_ipv4_tcp(skb,
 				      TC_ACT_OK,
-				      0xc0a80001, 0x01010101,
+				      IPV4(192,168,0,1), IPV4(1,1,1,1),
 				      19233, 79);
 }
 
 SEC("tc/pktgen/ipset_match")
 int testpktgen_ipset_match(struct __sk_buff *skb)
 {
-	// 192.168.0.1:19233 -> 224.1.0.2:80
-	return set_ipv4_tcp(skb, 0xc0a80001, 0xe0010002, 19233, 80);
+	return set_ipv4_tcp(skb, IPV4(192,168,0,1), IPV4(224,1,0,2), 19233, 80);
 }
 
 SEC("tc/setup/ipset_match")
@@ -142,18 +137,16 @@ int testsetup_ipset_match(struct __sk_buff *skb)
 SEC("tc/check/ipset_match")
 int testcheck_ipset_match(struct __sk_buff *skb)
 {
-	// 192.168.0.1:19233 -> 224.1.0.2:80
 	return check_routing_ipv4_tcp(skb,
 				      TC_ACT_OK,
-				      0xc0a80001, 0xe0010002,
+				      IPV4(192,168,0,1), IPV4(224,1,0,2),
 				      19233, 80);
 }
 
 SEC("tc/pktgen/ipset_mismatch")
 int testpktgen_ipset_mismatch(struct __sk_buff *skb)
 {
-	// 192.168.0.1:19233 -> 225.1.0.2:80
-	return set_ipv4_tcp(skb, 0xc0a80001, 0xe1010002, 19233, 80);
+	return set_ipv4_tcp(skb, IPV4(192,168,0,1), IPV4(225,1,0,2), 19233, 80);
 }
 
 SEC("tc/setup/ipset_mismatch")
@@ -188,18 +181,16 @@ int testsetup_ipset_mismatch(struct __sk_buff *skb)
 SEC("tc/check/ipset_mismatch")
 int testcheck_ipset_mismatch(struct __sk_buff *skb)
 {
-	// 192.168.0.1:19233 -> 225.1.0.2:80
 	return check_routing_ipv4_tcp(skb,
 				      TC_ACT_REDIRECT,
-				      0xc0a80001, 0xe1010002,
+				      IPV4(192,168,0,1), IPV4(225,1,0,2),
 				      19233, 80);
 }
 
 SEC("tc/pktgen/source_ipset_match")
 int testpktgen_source_ipset_match(struct __sk_buff *skb)
 {
-	// 192.168.50.1:19233 -> 224.1.0.2:80
-	return set_ipv4_tcp(skb, 0xc0a83201, 0xe0010002, 19233, 80);
+	return set_ipv4_tcp(skb, IPV4(192,168,50,1), IPV4(224,1,0,2), 19233, 80);
 }
 
 SEC("tc/setup/source_ipset_match")
@@ -234,18 +225,16 @@ int testsetup_source_ipset_match(struct __sk_buff *skb)
 SEC("tc/check/source_ipset_match")
 int testcheck_source_ipset_match(struct __sk_buff *skb)
 {
-	// 192.168.50.1:19233 -> 224.1.0.2:80
 	return check_routing_ipv4_tcp(skb,
 				      TC_ACT_OK,
-				      0xc0a83201, 0xe0010002,
+				      IPV4(192,168,50,1), IPV4(224,1,0,2),
 				      19233, 80);
 }
 
 SEC("tc/pktgen/source_ipset_mismatch")
 int testpktgen_source_ipset_mismatch(struct __sk_buff *skb)
 {
-	// 192.168.51.1:19233 -> 224.1.0.2:80
-	return set_ipv4_tcp(skb, 0xc0a83301, 0xe0010002, 19233, 80);
+	return set_ipv4_tcp(skb, IPV4(192,168,51,1), IPV4(224,1,0,2), 19233, 80);
 }
 
 SEC("tc/setup/source_ipset_mismatch")
@@ -280,18 +269,16 @@ int testsetup_source_ipset_mismatch(struct __sk_buff *skb)
 SEC("tc/check/source_ipset_mismatch")
 int testcheck_source_ipset_mismatch(struct __sk_buff *skb)
 {
-	// 192.168.51.1:19233 -> 224.1.0.2:80
 	return check_routing_ipv4_tcp(skb,
 				      TC_ACT_REDIRECT,
-				      0xc0a83301, 0xe0010002,
+				      IPV4(192,168,51,1), IPV4(224,1,0,2),
 				      19233, 80);
 }
 
 SEC("tc/pktgen/sport_match")
 int testpktgen_sport_match(struct __sk_buff *skb)
 {
-	// 192.168.0.1:19233 -> 1.1.1.1:80
-	return set_ipv4_tcp(skb, 0xc0a80001, 0x01010101, 19233, 80);
+	return set_ipv4_tcp(skb, IPV4(192,168,0,1), IPV4(1,1,1,1), 19233, 80);
 }
 
 SEC("tc/setup/sport_match")
@@ -321,18 +308,16 @@ int testsetup_sport_match(struct __sk_buff *skb)
 SEC("tc/check/sport_match")
 int testcheck_sport_match(struct __sk_buff *skb)
 {
-	// 192.168.0.1:19233 -> 1.1.1.1:80
 	return check_routing_ipv4_tcp(skb,
 				      TC_ACT_REDIRECT,
-				      0xc0a80001, 0x01010101,
+				      IPV4(192,168,0,1), IPV4(1,1,1,1),
 				      19233, 80);
 }
 
 SEC("tc/pktgen/sport_mismatch")
 int testpktgen_sport_mismatch(struct __sk_buff *skb)
 {
-	// 192.168.0.1:19233 -> 1.1.1.1:80
-	return set_ipv4_tcp(skb, 0xc0a80001, 0x01010101, 19233, 79);
+	return set_ipv4_tcp(skb, IPV4(192,168,0,1), IPV4(1,1,1,1), 19233, 79);
 }
 
 SEC("tc/setup/sport_mismatch")
@@ -362,18 +347,16 @@ int testsetup_sport_mismatch(struct __sk_buff *skb)
 SEC("tc/check/sport_mismatch")
 int testcheck_sport_mismatch(struct __sk_buff *skb)
 {
-	// 192.168.0.1:19233 -> 1.1.1.1:79
 	return check_routing_ipv4_tcp(skb,
 				      TC_ACT_OK,
-				      0xc0a80001, 0x01010101,
+				      IPV4(192,168,0,1), IPV4(1,1,1,1),
 				      19233, 79);
 }
 
 SEC("tc/pktgen/l4proto_match")
 int testpktgen_l4proto_match(struct __sk_buff *skb)
 {
-	// 192.168.0.1:19233 -> 1.1.1.1:80
-	return set_ipv4_tcp(skb, 0xc0a80001, 0x01010101, 19233, 79);
+	return set_ipv4_tcp(skb, IPV4(192,168,0,1), IPV4(1,1,1,1), 19233, 79);
 }
 
 SEC("tc/setup/l4proto_match")
@@ -402,18 +385,16 @@ int testsetup_l4proto_match(struct __sk_buff *skb)
 SEC("tc/check/l4proto_match")
 int testcheck_l4proto_match(struct __sk_buff *skb)
 {
-	// 192.168.0.1:19233 -> 1.1.1.1:79
 	return check_routing_ipv4_tcp(skb,
 				      TC_ACT_REDIRECT,
-				      0xc0a80001, 0x01010101,
+				      IPV4(192,168,0,1), IPV4(1,1,1,1),
 				      19233, 79);
 }
 
 SEC("tc/pktgen/l4proto_mismatch")
 int testpktgen_l4proto_mismatch(struct __sk_buff *skb)
 {
-	// 192.168.0.1:19233 -> 1.1.1.1:80
-	return set_ipv4_tcp(skb, 0xc0a80001, 0x01010101, 19233, 79);
+	return set_ipv4_tcp(skb, IPV4(192,168,0,1), IPV4(1,1,1,1), 19233, 79);
 }
 
 SEC("tc/setup/l4proto_mismatch")
@@ -442,18 +423,16 @@ int testsetup_l4proto_mismatch(struct __sk_buff *skb)
 SEC("tc/check/l4proto_mismatch")
 int testcheck_l4proto_mismatch(struct __sk_buff *skb)
 {
-	// 192.168.0.1:19233 -> 1.1.1.1:79
 	return check_routing_ipv4_tcp(skb,
 				      TC_ACT_OK,
-				      0xc0a80001, 0x01010101,
+				      IPV4(192,168,0,1), IPV4(1,1,1,1),
 				      19233, 79);
 }
 
 SEC("tc/pktgen/ipversion_match")
 int testpktgen_ipversion_match(struct __sk_buff *skb)
 {
-	// 192.168.0.1:19233 -> 1.1.1.1:80
-	return set_ipv4_tcp(skb, 0xc0a80001, 0x01010101, 19233, 79);
+	return set_ipv4_tcp(skb, IPV4(192,168,0,1), IPV4(1,1,1,1), 19233, 79);
 }
 
 SEC("tc/setup/ipversion_match")
@@ -482,18 +461,16 @@ int testsetup_ipversion_match(struct __sk_buff *skb)
 SEC("tc/check/ipversion_match")
 int testcheck_ipversion_match(struct __sk_buff *skb)
 {
-	// 192.168.0.1:19233 -> 1.1.1.1:79
 	return check_routing_ipv4_tcp(skb,
 				      TC_ACT_REDIRECT,
-				      0xc0a80001, 0x01010101,
+				      IPV4(192,168,0,1), IPV4(1,1,1,1),
 				      19233, 79);
 }
 
 SEC("tc/pktgen/ipversion_mismatch")
 int testpktgen_ipversion_mismatch(struct __sk_buff *skb)
 {
-	// 192.168.0.1:19233 -> 1.1.1.1:80
-	return set_ipv4_tcp(skb, 0xc0a80001, 0x01010101, 19233, 79);
+	return set_ipv4_tcp(skb, IPV4(192,168,0,1), IPV4(1,1,1,1), 19233, 79);
 }
 
 SEC("tc/setup/ipversion_mismatch")
@@ -522,18 +499,16 @@ int testsetup_ipversion_mismatch(struct __sk_buff *skb)
 SEC("tc/check/ipversion_mismatch")
 int testcheck_ipversion_mismatch(struct __sk_buff *skb)
 {
-	// 192.168.0.1:19233 -> 1.1.1.1:79
 	return check_routing_ipv4_tcp(skb,
 				      TC_ACT_OK,
-				      0xc0a80001, 0x01010101,
+				      IPV4(192,168,0,1), IPV4(1,1,1,1),
 				      19233, 79);
 }
 
 SEC("tc/pktgen/mac_match")
 int testpktgen_mac_match(struct __sk_buff *skb)
 {
-	// 192.168.0.1:19233 -> 1.1.1.1:80
-	return set_ipv4_tcp(skb, 0xc0a80001, 0x01010101, 19233, 79);
+	return set_ipv4_tcp(skb, IPV4(192,168,0,1), IPV4(1,1,1,1), 19233, 79);
 }
 
 SEC("tc/setup/mac_match")
@@ -584,18 +559,16 @@ int testcheck_mac_match(struct __sk_buff *skb)
 	data[15] = 0xb;
 	bpf_map_delete_elem(&unused_lpm_type, &lpm_key);
 
-	// 192.168.0.1:19233 -> 1.1.1.1:79
 	return check_routing_ipv4_tcp(skb,
 				      TC_ACT_REDIRECT,
-				      0xc0a80001, 0x01010101,
+				      IPV4(192,168,0,1), IPV4(1,1,1,1),
 				      19233, 79);
 }
 
 SEC("tc/pktgen/mac_mismatch")
 int testpktgen_mac_mismatch(struct __sk_buff *skb)
 {
-	// 192.168.0.1:19233 -> 1.1.1.1:80
-	return set_ipv4_tcp(skb, 0xc0a80001, 0x01010101, 19233, 79);
+	return set_ipv4_tcp(skb, IPV4(192,168,0,1), IPV4(1,1,1,1), 19233, 79);
 }
 
 SEC("tc/setup/mac_mismatch")
@@ -635,18 +608,16 @@ int testsetup_mac_mismatch(struct __sk_buff *skb)
 SEC("tc/check/mac_mismatch")
 int testcheck_mac_mismatch(struct __sk_buff *skb)
 {
-	// 192.168.0.1:19233 -> 1.1.1.1:79
 	return check_routing_ipv4_tcp(skb,
 				      TC_ACT_OK,
-				      0xc0a80001, 0x01010101,
+				      IPV4(192,168,0,1), IPV4(1,1,1,1),
 				      19233, 79);
 }
 
 SEC("tc/pktgen/dscp_match")
 int testpktgen_dscp_match(struct __sk_buff *skb)
 {
-	// 192.168.0.1:19233 -> 1.1.1.1:80
-	return set_ipv4_tcp(skb, 0xc0a80001, 0x01010101, 19233, 79);
+	return set_ipv4_tcp(skb, IPV4(192,168,0,1), IPV4(1,1,1,1), 19233, 79);
 }
 
 SEC("tc/setup/dscp_match")
@@ -675,18 +646,16 @@ int testsetup_dscp_match(struct __sk_buff *skb)
 SEC("tc/check/dscp_match")
 int testcheck_dscp_match(struct __sk_buff *skb)
 {
-	// 192.168.0.1:19233 -> 1.1.1.1:79
 	return check_routing_ipv4_tcp(skb,
 				      TC_ACT_REDIRECT,
-				      0xc0a80001, 0x01010101,
+				      IPV4(192,168,0,1), IPV4(1,1,1,1),
 				      19233, 79);
 }
 
 SEC("tc/pktgen/dscp_mismatch")
 int testpktgen_dscp_mismatch(struct __sk_buff *skb)
 {
-	// 192.168.0.1:19233 -> 1.1.1.1:80
-	return set_ipv4_tcp(skb, 0xc0a80001, 0x01010101, 19233, 79);
+	return set_ipv4_tcp(skb, IPV4(192,168,0,1), IPV4(1,1,1,1), 19233, 79);
 }
 
 SEC("tc/setup/dscp_mismatch")
@@ -715,18 +684,16 @@ int testsetup_dscp_mismatch(struct __sk_buff *skb)
 SEC("tc/check/dscp_mismatch")
 int testcheck_dscp_mismatch(struct __sk_buff *skb)
 {
-	// 192.168.0.1:19233 -> 1.1.1.1:79
 	return check_routing_ipv4_tcp(skb,
 				      TC_ACT_OK,
-				      0xc0a80001, 0x01010101,
+				      IPV4(192,168,0,1), IPV4(1,1,1,1),
 				      19233, 79);
 }
 
 SEC("tc/pktgen/and_match_1")
 int testpktgen_and_match_1(struct __sk_buff *skb)
 {
-	// 192.168.0.1:19233 -> 1.1.1.1:80
-	return set_ipv4_tcp(skb, 0xc0a80001, 0x01010101, 19233, 79);
+	return set_ipv4_tcp(skb, IPV4(192,168,0,1), IPV4(1,1,1,1), 19233, 79);
 }
 
 SEC("tc/setup/and_match_1")
@@ -796,18 +763,16 @@ int testsetup_and_match_1(struct __sk_buff *skb)
 SEC("tc/check/and_match_1")
 int testcheck_and_match_1(struct __sk_buff *skb)
 {
-	// 192.168.0.1:19233 -> 1.1.1.1:79
 	return check_routing_ipv4_tcp(skb,
 				      TC_ACT_REDIRECT,
-				      0xc0a80001, 0x01010101,
+				      IPV4(192,168,0,1), IPV4(1,1,1,1),
 				      19233, 79);
 }
 
 SEC("tc/pktgen/and_match_2")
 int testpktgen_and_match_2(struct __sk_buff *skb)
 {
-	// 192.168.0.1:19233 -> 1.1.1.1:8443
-	return set_ipv4_tcp(skb, 0xc0a80001, 0x01010101, 19233, 8443);
+	return set_ipv4_tcp(skb, IPV4(192,168,0,1), IPV4(1,1,1,1), 19233, 8443);
 }
 
 SEC("tc/setup/and_match_2")
@@ -877,18 +842,16 @@ int testsetup_and_match_2(struct __sk_buff *skb)
 SEC("tc/check/and_match_2")
 int testcheck_and_match_2(struct __sk_buff *skb)
 {
-	// 192.168.0.1:19233 -> 1.1.1.1:8443
 	return check_routing_ipv4_tcp(skb,
 				      TC_ACT_REDIRECT,
-				      0xc0a80001, 0x01010101,
+				      IPV4(192,168,0,1), IPV4(1,1,1,1),
 				      19233, 8443);
 }
 
 SEC("tc/pktgen/and_mismatch")
 int testpktgen_and_mismatch(struct __sk_buff *skb)
 {
-	// 192.168.0.1:19233 -> 1.1.1.1:2333
-	return set_ipv4_tcp(skb, 0xc0a80001, 0x01010101, 19233, 2333);
+	return set_ipv4_tcp(skb, IPV4(192,168,0,1), IPV4(1,1,1,1), 19233, 2333);
 }
 
 SEC("tc/setup/and_mismatch")
@@ -958,9 +921,8 @@ int testsetup_and_mismatch(struct __sk_buff *skb)
 SEC("tc/check/and_mismatch")
 int testcheck_and_mismatch(struct __sk_buff *skb)
 {
-	// 192.168.0.1:19233 -> 1.1.1.1:2333
 	return check_routing_ipv4_tcp(skb,
 				      TC_ACT_OK,
-				      0xc0a80001, 0x01010101,
+				      IPV4(192,168,0,1), IPV4(1,1,1,1),
 				      19233, 2333);
 }

--- a/control/kern/tests/bpf_test.c
+++ b/control/kern/tests/bpf_test.c
@@ -142,6 +142,7 @@ int testcheck_port_match(struct __sk_buff *skb)
 	}
 	if (ip->daddr != bpf_htonl(0x01010101)) {
 		bpf_printk("ip->daddr != 1.1.1.1\n");
+		return TC_ACT_SHOT;
 	}
 
 	struct tcphdr *tcp = (void *)ip + IP4_HLEN;
@@ -296,6 +297,7 @@ int testcheck_port_mismatch(struct __sk_buff *skb)
 	}
 	if (ip->daddr != bpf_htonl(0x01010101)) {
 		bpf_printk("ip->daddr != 1.1.1.1\n");
+		return TC_ACT_SHOT;
 	}
 
 	struct tcphdr *tcp = (void *)ip + IP4_HLEN;
@@ -427,8 +429,9 @@ int testcheck_ipset_match_v4(struct __sk_buff *skb)
 		bpf_printk("ip->protocol != IPPROTO_TCP\n");
 		return TC_ACT_SHOT;
 	}
-	if (ip->daddr != bpf_htonl(0xe0000002)) {
-		bpf_printk("ip->daddr != 224.0.0.2\n");
+	if (ip->daddr != bpf_htonl(0xe0010002)) {
+		bpf_printk("ip->daddr != 224.1.0.2\n");
+		return TC_ACT_SHOT;
 	}
 
 	struct tcphdr *tcp = (void *)ip + IP4_HLEN;
@@ -577,6 +580,171 @@ int testcheck_ipset_match_v6(struct __sk_buff *skb)
 	}
 	if (tcp->dest != bpf_htons(80)) {
 		bpf_printk("tcp->dest != 80\n");
+		return TC_ACT_SHOT;
+	}
+
+	return TC_ACT_OK;
+}
+
+SEC("tc/pktgen/ipset_mismatch")
+int testpktgen_ipset_mismatch(struct __sk_buff *skb)
+{
+	bpf_skb_change_tail(skb, ETH_HLEN + IP4_HLEN + TCP_HLEN, 0);
+
+	void *data = (void *)(long)skb->data;
+	void *data_end = (void *)(long)skb->data_end;
+
+	struct ethhdr *eth = data;
+	if ((void *)(eth + 1) > data_end) {
+		bpf_printk("data + sizeof(*eth) > data_end\n");
+		return TC_ACT_SHOT;
+	}
+	eth->h_proto = bpf_htons(ETH_P_IP);
+
+	struct iphdr *ip = data + ETH_HLEN;
+	if ((void *)(ip + 1) > data_end) {
+		bpf_printk("data + sizeof(*ip) > data_end\n");
+		return TC_ACT_SHOT;
+	}
+	ip->ihl = 5;
+	ip->version = 4;
+	ip->protocol = IPPROTO_TCP;
+	ip->saddr = bpf_htonl(0xc0a80001); // 192.168.0.1
+	ip->daddr = bpf_htonl(0xe1010002); // 225.1.0.2
+
+	struct tcphdr *tcp = data + ETH_HLEN + IP4_HLEN;
+	if ((void *)(tcp + 1) > data_end) {
+		bpf_printk("data + sizeof(*tcp) > data_end\n");
+		return TC_ACT_SHOT;
+	}
+	tcp->source = bpf_htons(19233);
+	tcp->dest = bpf_htons(80);
+	tcp->syn = 1;
+
+	return TC_ACT_OK;
+}
+
+SEC("tc/setup/ipset_mismatch")
+int testsetup_ipset_mismatch(struct __sk_buff *skb)
+{
+	__u32 linklen = ETH_HLEN;
+	bpf_map_update_elem(&linklen_map, &one_key, &linklen, BPF_ANY);
+
+	/* dip(224.0.0.0/8, 'ff00::/8') -> direct */
+	struct match_set ms = {};
+	ms.not = false;
+	ms.type = MatchType_IpSet;
+	ms.outbound = 0;
+	ms.must = false;
+	ms.mark = 0;
+	bpf_map_update_elem(&routing_map, &zero_key, &ms, BPF_ANY);
+
+	struct lpm_key lpm_key = {};
+	lpm_key.trie_key.prefixlen = 112;
+	lpm_key.data[2] = bpf_ntohl(0xffff);
+	lpm_key.data[3] = bpf_ntohl(0xe0010000); // 224.1.0.0
+	__u32 lpm_value = bpf_ntohl(0x01000000);
+	bpf_map_update_elem(&unused_lpm_type, &lpm_key, &lpm_value, BPF_ANY);
+
+	__builtin_memset(&lpm_key, 0, sizeof(lpm_key));
+	lpm_key.trie_key.prefixlen = 8;
+	lpm_key.data[0] = bpf_ntohl(0xff000000); // ff00::
+	bpf_map_update_elem(&unused_lpm_type, &lpm_key, &lpm_value, BPF_ANY);
+
+	/* fallback: proxy */
+	__builtin_memset(&ms.__value, 0, sizeof(ms.__value));
+	ms.not = false;
+	ms.type = MatchType_Fallback;
+	ms.outbound = 2;
+	ms.must = false;
+	ms.mark = 0;
+	bpf_map_update_elem(&routing_map, &one_key, &ms, BPF_ANY);
+
+	bpf_tail_call(skb, &entry_call_map, 0);
+	return TC_ACT_OK;
+}
+
+SEC("tc/check/ipset_mismatch")
+int testcheck_ipset_mismatch(struct __sk_buff *skb)
+{
+	__u32 *status_code;
+
+	void *data = (void *)(long)skb->data;
+	void *data_end = (void *)(long)skb->data_end;
+
+	if (data + sizeof(*status_code) > data_end) {
+		bpf_printk("data + sizeof(*status_code) > data_end\n");
+		return TC_ACT_SHOT;
+	}
+
+	status_code = data;
+	if (*status_code != TC_ACT_REDIRECT) {
+		bpf_printk("status_code(%d) != TC_ACT_REDIRECT\n", *status_code);
+		return TC_ACT_SHOT;
+	}
+
+	struct ethhdr *eth = data + sizeof(*status_code);
+	if ((void *)(eth + 1) > data_end) {
+		bpf_printk("data + sizeof(*eth) > data_end\n");
+		return TC_ACT_SHOT;
+	}
+	if (eth->h_proto != bpf_htons(ETH_P_IP)) {
+		bpf_printk("eth->h_proto != 0x0800\n");
+		return TC_ACT_SHOT;
+	}
+
+	struct iphdr *ip = (void *)eth + ETH_HLEN;
+	if ((void *)(ip + 1) > data_end) {
+		bpf_printk("data + sizeof(*ip) > data_end\n");
+		return TC_ACT_SHOT;
+	}
+	if (ip->protocol != IPPROTO_TCP) {
+		bpf_printk("ip->protocol != IPPROTO_TCP\n");
+		return TC_ACT_SHOT;
+	}
+	if (ip->daddr != bpf_htonl(0xe1010002)) {
+		bpf_printk("ip->daddr != 225.1.0.2\n");
+		return TC_ACT_SHOT;
+	}
+
+	struct tcphdr *tcp = (void *)ip + IP4_HLEN;
+	if ((void *)(tcp + 1) > data_end) {
+		bpf_printk("data + sizeof(*tcp) > data_end\n");
+		return TC_ACT_SHOT;
+	}
+	if (tcp->dest != bpf_htons(80)) {
+		bpf_printk("tcp->dest != 80\n");
+		return TC_ACT_SHOT;
+	}
+
+	struct tuples tuples = {};
+	tuples.five.sip.u6_addr32[2] = bpf_htonl(0xffff);
+	tuples.five.sip.u6_addr32[3] = ip->saddr;
+	tuples.five.dip.u6_addr32[2] = bpf_htonl(0xffff);
+	tuples.five.dip.u6_addr32[3] = ip->daddr;
+	tuples.five.sport = tcp->source;
+	tuples.five.dport = tcp->dest;
+	tuples.five.l4proto = ip->protocol;
+
+	struct routing_result *routing_result;
+	routing_result = bpf_map_lookup_elem(&routing_tuples_map, &tuples.five);
+	if (!routing_result) {
+		bpf_printk("routing_result == NULL\n");
+		return TC_ACT_SHOT;
+	}
+
+	if (routing_result->mark != 0) {
+		bpf_printk("routing_result->mark != 0\n");
+		return TC_ACT_SHOT;
+	}
+
+	if (routing_result->must != 0) {
+		bpf_printk("routing_result->must != 0\n");
+		return TC_ACT_SHOT;
+	}
+
+	if (routing_result->outbound != 2) {
+		bpf_printk("routing_result->outbound != 2\n");
 		return TC_ACT_SHOT;
 	}
 

--- a/control/kern/tests/bpf_test.c
+++ b/control/kern/tests/bpf_test.c
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2022-2024, daeuniverse Organization <dae@v2raya.org>
+
+//go:build exclude
+
+#define __DEBUG
+
+#include "../tproxy.c"
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 1);
+	__array(values, int());
+} entry_call_map SEC(".maps") = {
+	.values = {
+		[0] = &tproxy_dae0peer_ingress,
+	},
+};
+
+SEC("tc/pktgen/0")
+int testpktgen_0(struct __sk_buff *skb)
+{
+	// set l2 header
+	bpf_skb_change_tail(skb, 14, 0);
+	void *data = (void *)(long)skb->data;
+	void *data_end = (void *)(long)skb->data_end;
+	struct ethhdr *eth = data;
+	if ((void *)(eth + 1) > data_end) {
+		bpf_printk("data + sizeof(*eth) > data_end\n");
+		return TC_ACT_SHOT;
+	}
+	eth->h_proto = 0x0800;
+	eth->h_source[0] = 0x0a;
+	eth->h_dest[5] = 0x0b;
+	return TC_ACT_OK;
+}
+
+SEC("tc/setup/0")
+int testsetup_0(struct __sk_buff *skb)
+{
+	skb->cb[0] = TPROXY_MARK;
+	skb->cb[1] = IPPROTO_TCP;
+	bpf_tail_call(skb, &entry_call_map, 0);
+	return TC_ACT_OK;
+}
+
+SEC("tc/check/0")
+int testcheck_0(struct __sk_buff *skb)
+{
+	__u32 *status_code;
+
+	void *data = (void *)(long)skb->data;
+	void *data_end = (void *)(long)skb->data_end;
+
+	if (data + sizeof(*status_code) > data_end) {
+		bpf_printk("data + sizeof(*status_code) > data_end\n");
+		return TC_ACT_SHOT;
+	}
+
+	status_code = data;
+	if (*status_code != TC_ACT_OK) {
+		bpf_printk("status_code != TC_ACT_OK\n");
+		return TC_ACT_SHOT;
+	}
+
+	struct ethhdr *eth = data + sizeof(*status_code);
+	if ((void *)(eth + 1) > data_end) {
+		bpf_printk("data + sizeof(*eth) > data_end\n");
+		return TC_ACT_SHOT;
+	}
+	if (eth->h_proto != 0x0800) {
+		bpf_printk("eth->h_proto != 0x0800\n");
+		return TC_ACT_SHOT;
+	}
+	if (eth->h_source[0] != 0x0a) {
+		bpf_printk("eth->h_source[0] != 0x0a\n");
+		return TC_ACT_SHOT;
+	}
+	if (eth->h_dest[5] != 0x0b) {
+		bpf_printk("eth->h_dest[5] != 0x0b\n");
+		return TC_ACT_SHOT;
+	}
+
+	return TC_ACT_OK;
+}

--- a/control/kern/tests/bpf_test.go
+++ b/control/kern/tests/bpf_test.go
@@ -74,6 +74,11 @@ func collectPrograms(t *testing.T) (progset []programSet, err error) {
 		return nil, err
 	}
 
+	if err = obj.LpmArrayMap.Update(uint32(0), obj.UnusedLpmType, ebpf.UpdateAny); err != nil {
+		t.Fatalf("Failed to update LpmArrayMap: %s", err)
+		return
+	}
+
 	v := reflect.ValueOf(obj.bpftestPrograms)
 	typeOfV := v.Type()
 	for i := 0; i < v.NumField(); i++ {

--- a/control/kern/tests/bpf_test.go
+++ b/control/kern/tests/bpf_test.go
@@ -1,0 +1,151 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2024, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package tests
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/vishvananda/netlink/nl"
+)
+
+//go:generate go run -mod=mod github.com/cilium/ebpf/cmd/bpf2go -cc "$BPF_CLANG" "$BPF_STRIP_FLAG" -cflags "$BPF_CFLAGS" -target "$BPF_TARGET" bpftest ./bpf_test.c -- -I../headers -I.
+
+type programSet struct {
+	id     string
+	pktgen *ebpf.Program
+	setup  *ebpf.Program
+	check  *ebpf.Program
+}
+
+func runBpfProgram(prog *ebpf.Program, data, ctx []byte) (statusCode uint32, dataOut, ctxOut []byte, err error) {
+	dataOut = make([]byte, len(data))
+	if len(dataOut) > 0 {
+		// See comments at https://github.com/cilium/ebpf/blob/20c4d8896bdde990ce6b80d59a4262aa3ccb891d/prog.go#L563-L567
+		dataOut = make([]byte, len(data)+256+2)
+	}
+	ctxOut = make([]byte, len(ctx))
+	opts := &ebpf.RunOptions{
+		Data:       data,
+		DataOut:    dataOut,
+		Context:    ctx,
+		ContextOut: ctxOut,
+		Repeat:     1,
+	}
+	ret, err := prog.Run(opts)
+	return ret, opts.DataOut, ctxOut, err
+}
+
+func collectPrograms(t *testing.T) (progset []programSet, err error) {
+	obj := &bpftestObjects{}
+	pinPath := "/sys/fs/bpf/dae"
+	if err = os.MkdirAll(pinPath, 0755); err != nil && !os.IsExist(err) {
+		return
+	}
+
+	if err = loadBpftestObjects(obj,
+		&ebpf.CollectionOptions{
+			Maps: ebpf.MapOptions{
+				PinPath: pinPath,
+			},
+			Programs: ebpf.ProgramOptions{
+				LogSize: ebpf.DefaultVerifierLogSize * 10,
+			},
+		},
+	); err != nil {
+		var (
+			ve          *ebpf.VerifierError
+			verifierLog string
+		)
+		if errors.As(err, &ve) {
+			verifierLog = fmt.Sprintf("Verifier error: %+v\n", ve)
+		}
+
+		t.Fatalf("Failed to load objects: %s\n%+v", verifierLog, err)
+
+		return nil, err
+	}
+
+	v := reflect.ValueOf(obj.bpftestPrograms)
+	typeOfV := v.Type()
+	for i := 0; i < v.NumField(); i++ {
+		progname := typeOfV.Field(i).Name
+		if strings.HasPrefix(progname, "Testsetup") {
+			progid := strings.TrimPrefix(progname, "Testsetup")
+			progset = append(progset, programSet{
+				id:     progid,
+				pktgen: v.FieldByName("Testpktgen" + progid).Interface().(*ebpf.Program),
+				setup:  v.FieldByName("Testsetup" + progid).Interface().(*ebpf.Program),
+				check:  v.FieldByName("Testcheck" + progid).Interface().(*ebpf.Program),
+			})
+		}
+	}
+	return
+}
+
+func printBpfDebugLog(t *testing.T) {
+	file, err := os.Open("/sys/kernel/tracing/trace_pipe")
+	if err != nil {
+		t.Fatalf("Failed to open trace_pipe: %v", err)
+	}
+	defer file.Close()
+
+	buffer := make([]byte, 1024*64)
+	n, err := file.Read(buffer)
+	if err != nil {
+		t.Fatalf("Failed to read from trace_pipe: %v", err)
+	}
+
+	fmt.Print(string(buffer[:n]))
+}
+
+func Test(t *testing.T) {
+	progsets, err := collectPrograms(t)
+	if err != nil {
+		t.Fatalf("error while collecting programs: %s", err)
+	}
+
+	for _, progset := range progsets {
+		// create ctx with the max allowed size(4k - head room - tailroom)
+		data := make([]byte, 4096-256-320)
+
+		// sizeof(struct __sk_buff) < 256, let's make it 256
+		ctx := make([]byte, 256)
+
+		statusCode, data, ctx, err := runBpfProgram(progset.pktgen, data, ctx)
+		if err != nil {
+			t.Fatalf("error while running pktgen prog: %s", err)
+		}
+		if statusCode != 0 {
+			printBpfDebugLog(t)
+			t.Fatalf("error while running pktgen program: unexpected status code: %d", statusCode)
+		}
+
+		statusCode, data, ctx, err = runBpfProgram(progset.setup, data, ctx)
+		if err != nil {
+			printBpfDebugLog(t)
+			t.Fatalf("error while running setup prog: %s", err)
+		}
+
+		status := make([]byte, 4)
+		nl.NativeEndian().PutUint32(status, statusCode)
+		data = append(status, data...)
+
+		statusCode, data, ctx, err = runBpfProgram(progset.check, data, ctx)
+		if err != nil {
+			t.Fatalf("error while running check program: %+v", err)
+		}
+		if statusCode != 0 {
+			printBpfDebugLog(t)
+			t.Fatalf("error while running check program: unexpected status code: %d", statusCode)
+		}
+	}
+}

--- a/control/kern/tests/bpf_test.go
+++ b/control/kern/tests/bpf_test.go
@@ -114,6 +114,7 @@ func Test(t *testing.T) {
 	}
 
 	for _, progset := range progsets {
+		t.Logf("Running test: %s\n", progset.id)
 		// create ctx with the max allowed size(4k - head room - tailroom)
 		data := make([]byte, 4096-256-320)
 

--- a/control/kern/tests/bpf_test.go
+++ b/control/kern/tests/bpf_test.go
@@ -96,7 +96,15 @@ func collectPrograms(t *testing.T) (progset []programSet, err error) {
 	return
 }
 
+func consumeBpfDebugLog(t *testing.T) {
+	readBpfDebugLog(t)
+}
+
 func printBpfDebugLog(t *testing.T) {
+	fmt.Print(readBpfDebugLog(t))
+}
+
+func readBpfDebugLog(t *testing.T) string {
 	file, err := os.Open("/sys/kernel/tracing/trace_pipe")
 	if err != nil {
 		t.Fatalf("Failed to open trace_pipe: %v", err)
@@ -109,7 +117,7 @@ func printBpfDebugLog(t *testing.T) {
 		t.Fatalf("Failed to read from trace_pipe: %v", err)
 	}
 
-	fmt.Print(string(buffer[:n]))
+	return string(buffer[:n])
 }
 
 func Test(t *testing.T) {
@@ -153,5 +161,7 @@ func Test(t *testing.T) {
 			printBpfDebugLog(t)
 			t.Fatalf("error while running check program: unexpected status code: %d", statusCode)
 		}
+
+		consumeBpfDebugLog(t)
 	}
 }

--- a/control/kern/tests/bpf_test.h
+++ b/control/kern/tests/bpf_test.h
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (c) 2022-2024, daeuniverse Organization <dae@v2raya.org>
+
+//go:build exclude
+
+#define IP4_HLEN sizeof(struct iphdr)
+#define IP6_HLEN sizeof(struct ipv6hdr)
+#define TCP_HLEN sizeof(struct tcphdr)
+
+#define OUTBOUND_USER_DEFINED_MIN 2
+
+#define IPV4(a, b, c, d) (((a) << 24) | ((b) << 16) | ((c) << 8) | (d))
+
+static const __u32 two_key = 2;
+static const __u32 three_key = 3;
+static const __u32 four_key = 4;
+
+static __always_inline int
+set_ipv4_tcp(struct __sk_buff *skb,
+	     __u32 saddr, __u32 daddr,
+	     __u16 sport, __u16 dport)
+{
+	bpf_skb_change_tail(skb, ETH_HLEN + IP4_HLEN + TCP_HLEN, 0);
+
+	void *data = (void *)(long)skb->data;
+	void *data_end = (void *)(long)skb->data_end;
+
+	struct ethhdr *eth = data;
+	if ((void *)(eth + 1) > data_end) {
+		bpf_printk("data + sizeof(*eth) > data_end\n");
+		return TC_ACT_SHOT;
+	}
+	eth->h_dest[0] = 0x0;
+	eth->h_dest[1] = 0x1;
+	eth->h_dest[2] = 0x2;
+	eth->h_dest[3] = 0x3;
+	eth->h_dest[4] = 0x4;
+	eth->h_dest[5] = 0x5;
+	eth->h_source[0] = 0x6;
+	eth->h_source[1] = 0x7;
+	eth->h_source[2] = 0x8;
+	eth->h_source[3] = 0x9;
+	eth->h_source[4] = 0xa;
+	eth->h_source[5] = 0xb;
+	eth->h_proto = bpf_htons(ETH_P_IP);
+
+	struct iphdr *ip = data + ETH_HLEN;
+	if ((void *)(ip + 1) > data_end) {
+		bpf_printk("data + sizeof(*ip) > data_end\n");
+		return TC_ACT_SHOT;
+	}
+	ip->ihl = 5;
+	ip->version = 4;
+	ip->protocol = IPPROTO_TCP;
+	ip->saddr = bpf_htonl(saddr);
+	ip->daddr = bpf_htonl(daddr);
+	ip->tos = 4 << 2;
+
+	struct tcphdr *tcp = data + ETH_HLEN + IP4_HLEN;
+	if ((void *)(tcp + 1) > data_end) {
+		bpf_printk("data + sizeof(*tcp) > data_end\n");
+		return TC_ACT_SHOT;
+	}
+	tcp->source = bpf_htons(sport);
+	tcp->dest = bpf_htons(dport);
+	tcp->syn = 1;
+
+	return TC_ACT_OK;
+}
+
+static __always_inline int
+check_routing_ipv4_tcp(struct __sk_buff *skb,
+		    __u32 expected_status_code,
+		    __u32 saddr, __u32 daddr,
+		    __u16 sport, __u16 dport)
+{
+	__u32 *status_code;
+
+	void *data = (void *)(long)skb->data;
+	void *data_end = (void *)(long)skb->data_end;
+
+	if (data + sizeof(*status_code) > data_end) {
+		bpf_printk("data + sizeof(*status_code) > data_end\n");
+		return TC_ACT_SHOT;
+	}
+
+	status_code = data;
+	if (*status_code != expected_status_code) {
+		bpf_printk("status_code(%d) != %d\n", *status_code, expected_status_code);
+		return TC_ACT_SHOT;
+	}
+
+	if (expected_status_code == TC_ACT_REDIRECT) {
+		if (skb->cb[0] != TPROXY_MARK) {
+			bpf_printk("skb->cb[0] != TPROXY_MARK\n");
+			return TC_ACT_SHOT;
+		}
+
+		if (skb->cb[1] != IPPROTO_TCP) {
+			bpf_printk("skb->cb[1] != IPPROTO_TCP\n");
+			return TC_ACT_SHOT;
+		}
+
+	}
+
+	struct ethhdr *eth = data + sizeof(*status_code);
+	if ((void *)(eth + 1) > data_end) {
+		bpf_printk("data + sizeof(*eth) > data_end\n");
+		return TC_ACT_SHOT;
+	}
+	if (eth->h_proto != bpf_htons(ETH_P_IP)) {
+		bpf_printk("eth->h_proto != ETH_P_IP\n");
+		return TC_ACT_SHOT;
+	}
+
+	struct iphdr *ip = (void *)eth + ETH_HLEN;
+	if ((void *)(ip + 1) > data_end) {
+		bpf_printk("data + sizeof(*ip) > data_end\n");
+		return TC_ACT_SHOT;
+	}
+	if (ip->protocol != IPPROTO_TCP) {
+		bpf_printk("ip->protocol != IPPROTO_TCP\n");
+		return TC_ACT_SHOT;
+	}
+	if (ip->saddr != bpf_htonl(saddr)) {
+		bpf_printk("ip->saddr != %pI4\n", &saddr);
+		return TC_ACT_SHOT;
+	}
+	if (ip->daddr != bpf_htonl(daddr)) {
+		bpf_printk("ip->daddr != %pI4\n", &daddr);
+		return TC_ACT_SHOT;
+	}
+
+	struct tcphdr *tcp = (void *)ip + IP4_HLEN;
+	if ((void *)(tcp + 1) > data_end) {
+		bpf_printk("data + sizeof(*tcp) > data_end\n");
+		return TC_ACT_SHOT;
+	}
+	if (tcp->source != bpf_htons(sport)) {
+		bpf_printk("tcp->source != %d\n", sport);
+		return TC_ACT_SHOT;
+	}
+	if (tcp->dest != bpf_htons(dport)) {
+		bpf_printk("tcp->dest != %d\n", dport);
+		return TC_ACT_SHOT;
+	}
+
+	if (expected_status_code == TC_ACT_REDIRECT) {
+		struct tuples tuples = {};
+		tuples.five.sip.u6_addr32[2] = bpf_htonl(0xffff);
+		tuples.five.sip.u6_addr32[3] = ip->saddr;
+		tuples.five.dip.u6_addr32[2] = bpf_htonl(0xffff);
+		tuples.five.dip.u6_addr32[3] = ip->daddr;
+		tuples.five.sport = tcp->source;
+		tuples.five.dport = tcp->dest;
+		tuples.five.l4proto = ip->protocol;
+
+		struct routing_result *routing_result;
+		routing_result = bpf_map_lookup_elem(&routing_tuples_map, &tuples.five);
+		if (!routing_result) {
+			bpf_printk("routing_result == NULL\n");
+			return TC_ACT_SHOT;
+		}
+
+		if (routing_result->outbound != OUTBOUND_USER_DEFINED_MIN) {
+			bpf_printk("routing_result->outbound != OUTBOUND_USER_DEFINED_MIN\n");
+			return TC_ACT_SHOT;
+		}
+	}
+
+	return TC_ACT_OK;
+}
+
+static __always_inline void
+set_routing_fallback(__u8 outbound, bool must)
+{
+	struct match_set ms = {};
+	ms.not = false;
+	ms.type = MatchType_Fallback;
+	ms.outbound = outbound;
+	ms.must = must;
+	ms.mark = 0;
+	bpf_map_update_elem(&routing_map, &one_key, &ms, BPF_ANY);
+}


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

Add bpf test to cover bpf route logic.

This also paves the way to bpf benchmark that guides performance improvement.

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #522 

### Test Result

https://github.com/jschwinger233/dae/actions/runs/11221852069/job/31193035644?pr=23

```
=== RUN   Test
    bpf_test.go:130: Running test: AndMatch1
    bpf_test.go:130: Running test: AndMatch2
    bpf_test.go:130: Running test: AndMismatch
    bpf_test.go:130: Running test: DportMatch
    bpf_test.go:130: Running test: DportMismatch
    bpf_test.go:130: Running test: DscpMatch
    bpf_test.go:130: Running test: DscpMismatch
    bpf_test.go:130: Running test: IpsetMatch
    bpf_test.go:130: Running test: IpsetMismatch
    bpf_test.go:130: Running test: IpversionMatch
    bpf_test.go:130: Running test: IpversionMismatch
    bpf_test.go:130: Running test: L4protoMatch
    bpf_test.go:130: Running test: L4protoMismatch
    bpf_test.go:130: Running test: MacMatch
    bpf_test.go:130: Running test: MacMismatch
    bpf_test.go:130: Running test: NotMatch
    bpf_test.go:130: Running test: NotMismtach
    bpf_test.go:130: Running test: SourceIpsetMatch
    bpf_test.go:130: Running test: SourceIpsetMismatch
    bpf_test.go:130: Running test: SportMatch
    bpf_test.go:130: Running test: SportMismatch
--- PASS: Test (3.38s)
PASS
ok  	github.com/daeuniverse/dae/control/kern/tests	3.393s
```