### PR TITLE
fix(routing): Fix MergeAndSortRulesOptimizer

### DIFF
--- a/component/routing/optimizer.go
+++ b/component/routing/optimizer.go
@@ -7,15 +7,16 @@ package routing
 
 import (
 	"fmt"
+	"net/netip"
+	"sort"
+	"strings"
+
 	"github.com/daeuniverse/dae/common/assets"
 	"github.com/daeuniverse/dae/common/consts"
 	"github.com/daeuniverse/dae/pkg/config_parser"
 	"github.com/daeuniverse/dae/pkg/geodata"
 	"github.com/mohae/deepcopy"
 	"github.com/sirupsen/logrus"
-	"net/netip"
-	"sort"
-	"strings"
 )
 
 type RulesOptimizer interface {
@@ -87,6 +88,7 @@ func (o *MergeAndSortRulesOptimizer) Optimize(rules []*config_parser.RoutingRule
 		if len(mergingRule.AndFunctions) == 1 &&
 			len(rules[i].AndFunctions) == 1 &&
 			mergingRule.AndFunctions[0].Name == rules[i].AndFunctions[0].Name &&
+			mergingRule.AndFunctions[0].Not == rules[i].AndFunctions[0].Not &&
 			rules[i].Outbound.String(true, false, true) == mergingRule.Outbound.String(true, false, true) {
 			mergingRule.AndFunctions[0].Params = append(mergingRule.AndFunctions[0].Params, rules[i].AndFunctions[0].Params...)
 		} else {


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

Without this patch, `mac('2c:9e:00:7a:26:38') -> proxy` followed by `!mac('2c:9e:00:7a:26:38') -> proxy` will be wrongly merged to `mac('2c:9e:00:7a:26:38') -> proxy`. 

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #339 

### Test Result

<!--- Attach test result here. -->
