### PR TITLE
ci(workflows/kernel-test): add latest mainline kernel

### DIFF
--- a/.github/workflows/kernel-test.yml
+++ b/.github/workflows/kernel-test.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kernel: [ '6.1-20240305.092417', '6.6-20240305.092417' ]
+        kernel: [ '6.1-20240305.092417', '6.6-20240305.092417', 'bpf-next-main' ]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

Sometimes upstream API changes can trigger CO-RE failure in mainline kernel, such as issue #482. Therefore, it is recommended to add latest mainline kernel to tests.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- Add latest mainline kernel to tests

### Issue Reference

#482

### Test Result

<!--- Attach test result here. -->
