### PR TITLE
optimize: reduce memory usage by reading kallsyms only in the trace command

### DIFF
--- a/cmd/trace.go
+++ b/cmd/trace.go
@@ -31,6 +31,9 @@ func init() {
 	traceCmd := &cobra.Command{
 		Use:   "trace",
 		Short: "To trace traffic",
+		PreRun: func(cmd *cobra.Command, args []string) {
+			trace.ReadKallsyms()
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			internal.AutoSu()
 

--- a/trace/kallsyms.go
+++ b/trace/kallsyms.go
@@ -26,11 +26,7 @@ var kallsyms []Symbol
 var kallsymsByName map[string]Symbol = make(map[string]Symbol)
 var kallsymsByAddr map[uint64]Symbol = make(map[uint64]Symbol)
 
-func init() {
-	readKallsyms()
-}
-
-func readKallsyms() {
+func ReadKallsyms() {
 	file, err := os.Open("/proc/kallsyms")
 	if err != nil {
 		logrus.Fatalf("failed to open /proc/kallsyms: %v", err)


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background
Currently, reading kallsyms during program loading causes unnecessary high memory usage, while kallsyms is only used in the trace command. Therefore, this patch changes it to initialize kallsyms before executing the trace command.
<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- read kallsyms only in the trace command

### Test Result

<!--- Attach test result here. -->
#### Configuration

```
global{ pprof_port: 12333 }
routing{}
```
Use `go tool pprof -http=:8080 http://localhost:12333/debug/pprof/heap` to generate the flame graph.

#### Screenshot

Lowers RSS usage from 194 MiB to 75 MiB.

Before:
![pprof_before](https://github.com/user-attachments/assets/35c7dca6-e725-474d-80e8-b144df0b965d)
![htop_before](https://github.com/user-attachments/assets/fa191aff-f709-4a27-9fb1-55dd0dcc1672)

After:
![pprof_after](https://github.com/user-attachments/assets/a1e07a81-78ec-4eef-9d54-7ef224198d59)
![htop_after](https://github.com/user-attachments/assets/00f9ebf5-ac33-4cc2-9d3d-15b9a246efe4)

