### PR TITLE
fix: minimal upgrade panjf2000/ants dependency to v2.0.0

### DIFF
--- a/control/udp_task_pool.go
+++ b/control/udp_task_pool.go
@@ -5,7 +5,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/panjf2000/ants"
+	ants "github.com/panjf2000/ants/v2"
 )
 
 var isTest = false

--- a/go.mod
+++ b/go.mod
@@ -9,13 +9,14 @@ require (
 	github.com/cilium/ebpf v0.15.0
 	github.com/daeuniverse/dae-config-dist/go/dae_config v0.0.0-20230604120805-1c27619b592d
 	github.com/daeuniverse/outbound v0.0.0-20241026154416-424675853298
+	github.com/daeuniverse/quic-go v0.0.0-20240413031024-943f218e0810
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/json-iterator/go v1.1.12
 	github.com/mholt/archiver/v3 v3.5.1
 	github.com/miekg/dns v1.1.61
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/okzk/sdnotify v0.0.0-20180710141335-d9becc38acbd
-	github.com/panjf2000/ants v1.3.0
+	github.com/panjf2000/ants/v2 v2.0.0
 	github.com/safchain/ethtool v0.4.1
 	github.com/shirou/gopsutil/v4 v4.24.6
 	github.com/sirupsen/logrus v1.9.3
@@ -38,7 +39,6 @@ require (
 	github.com/awnumar/memcall v0.3.0 // indirect
 	github.com/awnumar/memguard v0.22.5 // indirect
 	github.com/cloudflare/circl v1.3.9 // indirect
-	github.com/daeuniverse/quic-go v0.0.0-20240413031024-943f218e0810 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dsnet/compress v0.0.2-0.20210315054119-f66993602bf5 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,6 @@ github.com/cloudflare/circl v1.3.9/go.mod h1:PDRU+oXvdD7KCtgKxW95M5Z8BpSCJXQORiZ
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/daeuniverse/dae-config-dist/go/dae_config v0.0.0-20230604120805-1c27619b592d h1:hnC39MjR7xt5kZjrKlef7DXKFDkiX8MIcDXYC/6Jf9Q=
 github.com/daeuniverse/dae-config-dist/go/dae_config v0.0.0-20230604120805-1c27619b592d/go.mod h1:VGWGgv7pCP5WGyHGUyb9+nq/gW0yBm+i/GfCNATOJ1M=
-github.com/daeuniverse/outbound v0.0.0-20240928042419-b1e258193113 h1:m2GVle7Mdllco1bUshzvFz4RXI+2Nif1mTGaJsE91+w=
-github.com/daeuniverse/outbound v0.0.0-20240928042419-b1e258193113/go.mod h1:aR0y8VzpD7RJ5ZGD5ooe0MC6wfTzkIEYaGyxztJqG94=
 github.com/daeuniverse/outbound v0.0.0-20241026154416-424675853298 h1:MSTgM94DnFdOKO3/m0UjTwGML7Fv7EJe7c5OL4YmymI=
 github.com/daeuniverse/outbound v0.0.0-20241026154416-424675853298/go.mod h1:aR0y8VzpD7RJ5ZGD5ooe0MC6wfTzkIEYaGyxztJqG94=
 github.com/daeuniverse/quic-go v0.0.0-20240413031024-943f218e0810 h1:YtEYouFaNrg9sV9vf3UabvKShKn6sD0QaCdOxCwaF3g=
@@ -150,8 +148,8 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.33.1 h1:dsYjIxxSR755MDmKVsaFQTE22ChNBcuuTWgkUDSubOk=
 github.com/onsi/gomega v1.33.1/go.mod h1:U4R44UsT+9eLIaYRB2a5qajjtQYn0hauxvRm16AVYg0=
-github.com/panjf2000/ants v1.3.0 h1:8pQ+8leaLc9lys2viEEr8md0U4RN6uOSUCE9bOYjQ9M=
-github.com/panjf2000/ants v1.3.0/go.mod h1:AaACblRPzq35m1g3enqYcxspbbiOJJYaxU2wMpm1cXY=
+github.com/panjf2000/ants/v2 v2.0.0 h1:MvUd+EfTcLl9l8Mh6nQkMQaE4cLAewd3bv97ajOyldQ=
+github.com/panjf2000/ants/v2 v2.0.0/go.mod h1:1GFm8bV8nyCQvU5K4WvBCTG1/YBFOD2VzjffD8fV55A=
 github.com/pierrec/lz4/v4 v4.1.2/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=
 github.com/pierrec/lz4/v4 v4.1.21/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->
Dependency missing. Clear build failed.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- minimal upgrade panjf2000/ants dependency to v2.0.0
- run `go mod tidy`

### Issue Reference

Closes #701 

### Test Result

<!--- Attach test result here. -->

```
=== RUN   TestUdpTaskPool
    /root/repo/github.com/daeuniverse/dae/control/udp_task_pool_test.go:20: [{"cpu":"cpu-total","user":84004.3,"system":36651.2,"idle":28526534.9,"nice":163.4,"iowait":402.9,"irq":0.0,"softirq":1131.2,"steal":0.0,"guest":0.0,"guestNice":0.0}]
    /root/repo/github.com/daeuniverse/dae/control/udp_task_pool_test.go:30: [{"cpu":"cpu-total","user":84004.6,"system":36651.3,"idle":28526616.2,"nice":163.4,"iowait":402.9,"irq":0.0,"softirq":1131.2,"steal":0.0,"guest":0.0,"guestNice":0.0}]
--- PASS: TestUdpTaskPool (5.11s)
PASS
coverage: 3.7% of statements in all
ok      github.com/daeuniverse/dae/control      7.099s  coverage: 3.7% of statements in all

```
