### PR TITLE
docs: disable Encrypted ClientHello to avoid affecting traffic split

### DIFF
--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -201,6 +201,7 @@ dns {
   }
   routing {
     request {
+      qtype(https) -> reject
       fallback: alidns
     }
     response {

--- a/docs/en/configuration/dns.md
+++ b/docs/en/configuration/dns.md
@@ -121,7 +121,8 @@ dns {
             # DNS request type
             qtype(a, aaaa) -> alidns
             qtype(cname) -> googledns
-
+            # disable ECH to avoid affecting traffic split
+            qtype(https) -> reject
             # If no match, fallback to this upstream.
             fallback: asis
         }

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -195,6 +195,7 @@ dns {
   }
   routing {
     request {
+      qtype(https) -> reject
       fallback: alidns
     }
     response {

--- a/docs/zh/configuration/dns.md
+++ b/docs/zh/configuration/dns.md
@@ -120,7 +120,8 @@ dns {
             # DNS 查询类型
             qtype(a, aaaa) -> alidns
             qtype(cname) -> googledns
-
+            # 禁用 ECH 避免影响分流
+            qtype(https) -> reject
             # fallback 意为 default。
             # 如果上面的都不匹配，使用这个 upstream。
             fallback: asis


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

Recently cloudflare started to enable Encrypted Client Hello by default, which affects traffic split due to the inability to sniff domains.

I think it is necessary to add `qtype(https) -> reject` to docs

### Checklist

- [X] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [X] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- Add `qtype(https) -> reject` to the configuration files in `README.md` and `dns.md`.

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
