### PR TITLE
test: fix CO-RE issue on kernel 6.9 and above in eBPF tests

### DIFF
--- a/control/kern/tests/bpf_test.c
+++ b/control/kern/tests/bpf_test.c
@@ -120,8 +120,9 @@ int testsetup_ipset_match(struct __sk_buff *skb)
 	ms.mark = 0;
 	bpf_map_update_elem(&routing_map, &zero_key, &ms, BPF_ANY);
 
-	struct lpm_key lpm_key = {};
-	lpm_key.trie_key.prefixlen = 112; // */16
+	struct lpm_key lpm_key = {
+		.trie_key = { .prefixlen = 112 , {} }, // */16
+	};
 	lpm_key.data[2] = bpf_ntohl(0xffff);
 	lpm_key.data[3] = bpf_ntohl(0xe0010000); // 224.1.0.0
 	__u32 lpm_value = bpf_ntohl(0x01000000);
@@ -164,8 +165,9 @@ int testsetup_ipset_mismatch(struct __sk_buff *skb)
 	ms.mark = 0;
 	bpf_map_update_elem(&routing_map, &zero_key, &ms, BPF_ANY);
 
-	struct lpm_key lpm_key = {};
-	lpm_key.trie_key.prefixlen = 112; // */16
+	struct lpm_key lpm_key = {
+		.trie_key = { .prefixlen = 112, {} }, // */16
+	};
 	lpm_key.data[2] = bpf_ntohl(0xffff);
 	lpm_key.data[3] = bpf_ntohl(0xe0010000); // 224.1.0.0
 	__u32 lpm_value = bpf_ntohl(0x01000000);
@@ -208,8 +210,9 @@ int testsetup_source_ipset_match(struct __sk_buff *skb)
 	ms.mark = 0;
 	bpf_map_update_elem(&routing_map, &zero_key, &ms, BPF_ANY);
 
-	struct lpm_key lpm_key = {};
-	lpm_key.trie_key.prefixlen = 120;
+	struct lpm_key lpm_key = {
+		.trie_key = { .prefixlen = 120, {} },
+	};
 	lpm_key.data[2] = bpf_ntohl(0xffff);
 	lpm_key.data[3] = bpf_ntohl(0xc0a83200); // 192.168.50.0
 	__u32 lpm_value = bpf_ntohl(0x01000000);
@@ -252,8 +255,9 @@ int testsetup_source_ipset_mismatch(struct __sk_buff *skb)
 	ms.mark = 0;
 	bpf_map_update_elem(&routing_map, &zero_key, &ms, BPF_ANY);
 
-	struct lpm_key lpm_key = {};
-	lpm_key.trie_key.prefixlen = 120;
+	struct lpm_key lpm_key = {
+		.trie_key = { .prefixlen = 120, {} },
+	};
 	lpm_key.data[2] = bpf_ntohl(0xffff);
 	lpm_key.data[3] = bpf_ntohl(0xc0a83200); // 192.168.50.0
 	__u32 lpm_value = bpf_ntohl(0x01000000);
@@ -526,8 +530,9 @@ int testsetup_mac_match(struct __sk_buff *skb)
 	ms.mark = 0;
 	bpf_map_update_elem(&routing_map, &zero_key, &ms, BPF_ANY);
 
-	struct lpm_key lpm_key = {};
-	lpm_key.trie_key.prefixlen = 128;
+	struct lpm_key lpm_key = {
+		.trie_key = { .prefixlen = 128, {} },
+	};
 	__u8 *data = (__u8 *)&lpm_key.data;
 	data[10] = 0x6;
 	data[11] = 0x7;
@@ -548,8 +553,9 @@ int testsetup_mac_match(struct __sk_buff *skb)
 SEC("tc/check/mac_match")
 int testcheck_mac_match(struct __sk_buff *skb)
 {
-	struct lpm_key lpm_key = {};
-	lpm_key.trie_key.prefixlen = 128;
+	struct lpm_key lpm_key = {
+		.trie_key = { .prefixlen = 128 , {} },
+	};
 	__u8 *data = (__u8 *)&lpm_key.data;
 	data[10] = 0x6;
 	data[11] = 0x7;
@@ -586,8 +592,9 @@ int testsetup_mac_mismatch(struct __sk_buff *skb)
 	ms.mark = 0;
 	bpf_map_update_elem(&routing_map, &zero_key, &ms, BPF_ANY);
 
-	struct lpm_key lpm_key = {};
-	lpm_key.trie_key.prefixlen = 128;
+	struct lpm_key lpm_key = {
+		.trie_key = { .prefixlen = 128, {} },
+	};
 	__u8 *data = (__u8 *)&lpm_key.data;
 	data[10] = 0x0;
 	data[11] = 0x1;
@@ -711,8 +718,9 @@ int testsetup_and_match_1(struct __sk_buff *skb)
 	ms.mark = 0;
 	bpf_map_update_elem(&routing_map, &zero_key, &ms, BPF_ANY);
 
-	struct lpm_key lpm_key = {};
-	lpm_key.trie_key.prefixlen = 112; // */16
+	struct lpm_key lpm_key = {
+		.trie_key = { .prefixlen = 112 , {} }, // */16
+	};
 	lpm_key.data[2] = bpf_ntohl(0xffff);
 	lpm_key.data[3] = bpf_ntohl(0x01010000); // 1.1.0.0
 	__u32 lpm_value = bpf_ntohl(0x01000000);
@@ -790,8 +798,9 @@ int testsetup_and_match_2(struct __sk_buff *skb)
 	ms.mark = 0;
 	bpf_map_update_elem(&routing_map, &zero_key, &ms, BPF_ANY);
 
-	struct lpm_key lpm_key = {};
-	lpm_key.trie_key.prefixlen = 112; // */16
+	struct lpm_key lpm_key = {
+		.trie_key = { .prefixlen = 112 , {} }, // */16
+	};
 	lpm_key.data[2] = bpf_ntohl(0xffff);
 	lpm_key.data[3] = bpf_ntohl(0x01010000); // 1.1.0.0
 	__u32 lpm_value = bpf_ntohl(0x01000000);
@@ -869,8 +878,9 @@ int testsetup_and_mismatch(struct __sk_buff *skb)
 	ms.mark = 0;
 	bpf_map_update_elem(&routing_map, &zero_key, &ms, BPF_ANY);
 
-	struct lpm_key lpm_key = {};
-	lpm_key.trie_key.prefixlen = 112; // */16
+	struct lpm_key lpm_key = {
+		.trie_key = { .prefixlen = 112 , {} }, // */16
+	};
 	lpm_key.data[2] = bpf_ntohl(0xffff);
 	lpm_key.data[3] = bpf_ntohl(0x01010000); // 1.1.0.0
 	__u32 lpm_value = bpf_ntohl(0x01000000);


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

- Pull request #483 only fixes the CO-RE issue in production code. eBPF tests still failed when running on kernel 6.9 and above.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- Fix CO-RE issue on kernel 6.9 and above in eBPF tests

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

Before:

```
=== RUN   Test
    bpf_test.go:72: Failed to load objects: Verifier error: load program: bad CO-RE relocation:
                0: R1=ctx() R10=fp0
                ; int testcheck_mac_match(struct __sk_buff *skb) @ bpf_test.c:549
                0: (bf) r6 = r1                       ; R1=ctx() R6_w=ctx()
                1: (b7) r1 = 0                        ; R1_w=0
                ; struct lpm_key lpm_key = {}; @ bpf_test.c:551
                2: (7b) *(u64 *)(r10 -72) = r1        ; R1_w=0 R10=fp0 fp-72_w=0
                3: (7b) *(u64 *)(r10 -80) = r1        ; R1_w=0 R10=fp0 fp-80_w=0
                4: (bf) r2 = r10                      ; R2_w=fp0 R10=fp0
                ;  @ bpf_test.c:0
                5: (07) r2 += -80                     ; R2_w=fp-80
                6: (b7) r1 = 128                      ; R1_w=128
                ; instruction poisoned by CO-RE @ :0
                7: (85) call unknown#195896080
                invalid func unknown#195896080
                processed 8 insns (limit 1000000) max_states_per_insn 0 total_states 0 peak_states 0 mark_read 0
        
        field TestcheckMacMatch: program testcheck_mac_match: load program: bad CO-RE relocation: invalid func unknown#195896080 (14 line(s) omitted)
--- FAIL: Test (0.18s)
FAIL
FAIL    github.com/daeuniverse/dae/control/kern/tests   0.186s
FAIL
make: *** [Makefile:110: ebpf-test] Error 1

```

After:

```
=== RUN   Test
    bpf_test.go:130: Running test: AndMatch1
    bpf_test.go:130: Running test: AndMatch2
    bpf_test.go:130: Running test: AndMismatch
    bpf_test.go:130: Running test: DportMatch
    bpf_test.go:130: Running test: DportMismatch
    bpf_test.go:130: Running test: DscpMatch
    bpf_test.go:130: Running test: DscpMismatch
    bpf_test.go:130: Running test: IpsetMatch
    bpf_test.go:130: Running test: IpsetMismatch
    bpf_test.go:130: Running test: IpversionMatch
    bpf_test.go:130: Running test: IpversionMismatch
    bpf_test.go:130: Running test: L4protoMatch
    bpf_test.go:130: Running test: L4protoMismatch
    bpf_test.go:130: Running test: MacMatch
    bpf_test.go:130: Running test: MacMismatch
    bpf_test.go:130: Running test: NotMatch
    bpf_test.go:130: Running test: NotMismtach
    bpf_test.go:130: Running test: SourceIpsetMatch
    bpf_test.go:130: Running test: SourceIpsetMismatch
    bpf_test.go:130: Running test: SportMatch
    bpf_test.go:130: Running test: SportMismatch
--- PASS: Test (1.45s)
PASS
ok      github.com/daeuniverse/dae/control/kern/tests   1.459s
```

Test Environment: Arch Linux, 6.12.4-arch1-1
