### PR TITLE
fix(config): correct the truncation of process name(comm name)

### DIFF
--- a/component/routing/function_parser.go
+++ b/component/routing/function_parser.go
@@ -112,8 +112,8 @@ func ProcessNameParserFactory(callback func(f *config_parser.Function, procNames
 	return func(log *logrus.Logger, f *config_parser.Function, key string, paramValueGroup []string, overrideOutbound *Outbound) (err error) {
 		var procNames [][consts.TaskCommLen]byte
 		for _, v := range paramValueGroup {
-			if len([]byte(v)) > consts.TaskCommLen {
-				log.Infof(`pname routing: trim "%v" to "%v" because it is too long.`, v, string([]byte(v)[:consts.TaskCommLen]))
+			if len([]byte(v)) > consts.TaskCommLen - 1 {
+				log.Infof(`pname routing: trim "%v" to "%v" because it is too long.`, v, string([]byte(v)[:consts.TaskCommLen-1]))
 			}
 			procNames = append(procNames, toProcessName(v))
 		}
@@ -138,7 +138,7 @@ func parsePrefixes(values []string) (cidrs []netip.Prefix, err error) {
 
 func toProcessName(processName string) (procName [consts.TaskCommLen]byte) {
 	n := []byte(processName)
-	copy(procName[:], n)
+	copy(procName[:consts.TaskCommLen-1], n)
 	return procName
 }
 


### PR DESCRIPTION
Previously dae truncate the process names in pname configs to 16 bytes Now we truncate the name to 15 bytes because the length of the comm name of processes in linux is 15 bytes.

This makes
`pname(systemd-resolved)`
works the same as
`pname(systemd-resolve)`

Closes #736, #474

### Background

#736 

### Checklist

- [ ] The Pull Request has been fully tested
- [x] There's an entry in the CHANGELOGS
- [x] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- truncate the process name to 15 characters(previously 16)
- issue the truncation info log whenever the process name is longer than 15 characters(previously 16)

### Issue Reference

#736 
#474 

Closes #_[736]_

### Test Result

add pname(systemd-resolved) -> must_direct
then all the dns traffic through systemd-resolved goes out directly
but before the PR, it doesn't.
