### PR TITLE
feat(config): wildcard interface name support & refactor lazybind

### DIFF
--- a/component/interface_manager.go
+++ b/component/interface_manager.go
@@ -1,0 +1,151 @@
+package component
+
+import (
+	"context"
+	"path"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+)
+
+type callbackSet struct {
+	pattern     string
+	newCallback func(netlink.Link)
+	delCallback func(netlink.Link)
+}
+
+type InterfaceManager struct {
+	log       *logrus.Logger
+	closed    context.Context
+	close     context.CancelFunc
+	mu        sync.Mutex
+	callbacks []callbackSet
+	upLinks   map[string]bool
+}
+
+func NewInterfaceManager(log *logrus.Logger) *InterfaceManager {
+	closed, toClose := context.WithCancel(context.Background())
+	mgr := &InterfaceManager{
+		log:       log,
+		callbacks: make([]callbackSet, 0),
+		closed:    closed,
+		close:     toClose,
+		upLinks:   make(map[string]bool),
+	}
+
+	ch := make(chan netlink.LinkUpdate)
+	done := make(chan struct{})
+	if e := netlink.LinkSubscribeWithOptions(ch, done, netlink.LinkSubscribeOptions{
+		ErrorCallback: func(err error) {
+			log.Debug("LinkSubscribe:", err)
+		},
+		ListExisting: true,
+	}); e != nil {
+		log.Errorf("Failed to subscribe to link updates: %v", e)
+	}
+
+	go mgr.monitor(ch, done)
+	return mgr
+}
+
+func (m *InterfaceManager) monitor(ch <-chan netlink.LinkUpdate, done chan struct{}) {
+	for {
+		select {
+		case <-m.closed.Done():
+			close(done)
+			return
+		case update := <-ch:
+			ifName := update.Link.Attrs().Name
+
+			switch update.Header.Type {
+			case unix.RTM_NEWLINK:
+				m.mu.Lock()
+				_, exists := m.upLinks[ifName]
+				if exists {
+					m.mu.Unlock()
+					continue
+				}
+				m.upLinks[ifName] = true
+				for _, callback := range m.callbacks {
+					matched, err := path.Match(callback.pattern, ifName)
+					if err != nil || !matched {
+						continue
+					}
+					if callback.newCallback != nil {
+						callback.newCallback(update.Link)
+					}
+				}
+				m.mu.Unlock()
+
+			case unix.RTM_DELLINK:
+				m.mu.Lock()
+				delete(m.upLinks, ifName)
+				for _, callback := range m.callbacks {
+					matched, err := path.Match(callback.pattern, ifName)
+					if err != nil || !matched {
+						continue
+					}
+					if callback.delCallback != nil {
+						callback.delCallback(update.Link)
+					}
+				}
+				m.mu.Unlock()
+			}
+		}
+	}
+}
+
+func (m *InterfaceManager) RegisterWithPattern(pattern string, initCallback func(netlink.Link), newCallback func(netlink.Link), delCallback func(netlink.Link)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	links, err := netlink.LinkList()
+	if err == nil {
+		for _, link := range links {
+			ifname := link.Attrs().Name
+			if matched, err := path.Match(pattern, ifname); err == nil && matched {
+				m.upLinks[ifname] = true
+
+				if initCallback != nil {
+					initCallback(link)
+				}
+			}
+		}
+	} else {
+		m.log.Errorf("Failed to get link list: %v", err)
+	}
+
+	m.callbacks = append(m.callbacks, callbackSet{
+		pattern:     pattern,
+		newCallback: newCallback,
+		delCallback: delCallback,
+	})
+}
+
+func (m *InterfaceManager) Register(ifname string, initCallback func(netlink.Link), newCallback func(netlink.Link), delCallback func(netlink.Link)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	link, err := netlink.LinkByName(ifname)
+	if err == nil {
+		m.upLinks[ifname] = true
+
+		if initCallback != nil {
+			initCallback(link)
+		}
+	}
+
+	m.callbacks = append(m.callbacks, callbackSet{
+		pattern:     ifname,
+		newCallback: newCallback,
+		delCallback: delCallback,
+	})
+}
+
+// Close cancels the context to stop the monitor goroutine
+func (m *InterfaceManager) Close() error {
+	m.close()
+	return nil
+}

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -220,9 +220,7 @@ func NewControlPlane(
 		}
 		global.LanInterface = common.Deduplicate(global.LanInterface)
 		for _, ifname := range global.LanInterface {
-			if err = core.bindLan(ifname, global.AutoConfigKernelParameter); err != nil {
-				return nil, fmt.Errorf("bindLan: %v: %w", ifname, err)
-			}
+			core.bindLan(ifname, global.AutoConfigKernelParameter)
 		}
 	}
 	// Bind to WAN
@@ -249,9 +247,7 @@ func NewControlPlane(
 					}
 				}
 			}
-			if err = core.bindWan(ifname, global.AutoConfigKernelParameter); err != nil {
-				return nil, fmt.Errorf("bindWan: %v: %w", ifname, err)
-			}
+			core.bindWan(ifname, global.AutoConfigKernelParameter)
 		}
 	}
 	// Bind to dae0 and dae0peer


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background
https://github.com/daeuniverse/dae/issues/724
该PR抽象了lazybind的能力以便后续其他功能使用（主要是后续在routing中过滤interface需要）
该PR实现的功能与 #729 类似
此外，为wan也加入了lazybind

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has been fully tested
- [x] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- interface name now support wildcard
- wan interface now support lazybind

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #724
Closes #729

### Test Result

<!--- Attach test result here. -->
