### PR TITLE
fix(bpf): Match pname as long as 16 bytes

### DIFF
--- a/.github/workflows/bpf-test.yml
+++ b/.github/workflows/bpf-test.yml
@@ -21,8 +21,14 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y clang-15 llvm-15
+
       - name: Run BPF tests
         run: |
           git submodule update --init
-          sudo make ebpf-test || (echo "Run 'make ebpf-test' locally to investigate failures"; exit 1)
+          sudo CLANG=clang-15 make ebpf-test || (echo "Run 'make ebpf-test' locally to investigate failures"; exit 1)
 

--- a/component/routing/function_parser.go
+++ b/component/routing/function_parser.go
@@ -112,8 +112,8 @@ func ProcessNameParserFactory(callback func(f *config_parser.Function, procNames
 	return func(log *logrus.Logger, f *config_parser.Function, key string, paramValueGroup []string, overrideOutbound *Outbound) (err error) {
 		var procNames [][consts.TaskCommLen]byte
 		for _, v := range paramValueGroup {
-			if len([]byte(v)) > consts.TaskCommLen - 1 {
-				log.Infof(`pname routing: trim "%v" to "%v" because it is too long.`, v, string([]byte(v)[:consts.TaskCommLen-1]))
+			if len([]byte(v)) > consts.TaskCommLen {
+				log.Infof(`pname routing: trim "%v" to "%v" because it is too long.`, v, string([]byte(v)[:consts.TaskCommLen]))
 			}
 			procNames = append(procNames, toProcessName(v))
 		}
@@ -138,7 +138,7 @@ func parsePrefixes(values []string) (cidrs []netip.Prefix, err error) {
 
 func toProcessName(processName string) (procName [consts.TaskCommLen]byte) {
 	n := []byte(processName)
-	copy(procName[:consts.TaskCommLen-1], n)
+	copy(procName[:], n)
 	return procName
 }
 

--- a/control/kern/tproxy.c
+++ b/control/kern/tproxy.c
@@ -1771,14 +1771,13 @@ static __always_inline int get_pid_pname(struct pid_pname *pid_pname)
 	if (unlikely(ret < 0))
 		return ret;
 
-	unsigned int offset = ctx.l; // Copy it to pass CO-RE
-
-	ret = bpf_core_read_str(pid_pname->pname, sizeof(pid_pname->pname),
-				arg_buf + offset);
-	if (unlikely(ret < 0)) {
-		bpf_printk("failed to read process name: bpf_core_read_str: %d",
-			   ret);
-		return ret;
+	for (int i = 0; i < TASK_COMM_LEN; i++) {
+		if (ctx.l + i < MAX_ARG_LEN && arg_buf[ctx.l + i] != '\0') {
+			pid_pname->pname[i] = arg_buf[ctx.l + i];
+		} else {
+			pid_pname->pname[i] = '\0';
+			break;
+		}
 	}
 
 	// Pupulate tgid


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

之前为了修复 #736, #738 相当于把 dae pname 缩减到 15 字节了，但稍作修改也可让 dae 正确匹配 16 字节 pname。

核心 bug 出在 bpf_core_read_str (bpf_probe_read_user_str)，内核的实现是强行在最后一个字节设为 \0：

```c
long strncpy_from_user_nofault(char *dst, const void __user *unsafe_addr,
			      long count)
{
	long ret;

	if (unlikely(count <= 0))
		return 0;

	pagefault_disable();
	ret = strncpy_from_user(dst, unsafe_addr, count);
	pagefault_enable();

	if (ret >= count) {
		ret = count;
		dst[ret - 1] = '\0';
	} else if (ret > 0) {
		ret++;
	}

	return ret;
}
```
https://elixir.bootlin.com/linux/v6.6/source/mm/maccess.c#L177

解决办法就是不用 bpf_probe_read_user_str，两处内存都在 bpf 内核态栈里，手动拷贝一下就行了。不能直接用 __builtin_memcpy 是因为 verifier 要安全检查，手动 for 循环里加上 `if (ctx.l + i < MAX_ARG_LEN)` ~~糊弄一下~~ 即可。

（性能也应该更快一点点点）

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
