### PR TITLE
fix(bpf): Make bpf code compatible with clang-12 to clang-19

### DIFF
--- a/control/kern/tproxy.c
+++ b/control/kern/tproxy.c
@@ -1748,7 +1748,7 @@ int tproxy_dae0_ingress(struct __sk_buff *skb)
 
 struct get_real_comm_ctx {
 	char *arg_buf;
-	unsigned int l;
+	u8 l;
 };
 
 static int __noinline get_real_comm_loop_cb(__u32 index, void *data)
@@ -1782,7 +1782,7 @@ static __always_inline int get_pid_pname(struct pid_pname *pid_pname)
 
 	// Read args to buffer.
 	char arg_buf[MAX_ARG_LEN]; // Allocate it out of ctx to pass CO-RE
-	struct get_real_comm_ctx ctx = { 0 };
+	struct get_real_comm_ctx ctx = {};
 
 	ctx.arg_buf = arg_buf;
 	ret = bpf_core_read_user_str(arg_buf, MAX_ARG_LEN, args);
@@ -1798,9 +1798,11 @@ static __always_inline int get_pid_pname(struct pid_pname *pid_pname)
 	if (unlikely(ret < 0))
 		return ret;
 
-	for (int i = 0; i < TASK_COMM_LEN; i++) {
-		if (ctx.l + i < MAX_ARG_LEN && arg_buf[ctx.l + i] != '\0') {
-			pid_pname->pname[i] = arg_buf[ctx.l + i];
+	u8 offset = ctx.l;
+
+	for (u8 i = 0; i < TASK_COMM_LEN; i++) {
+		if (offset + i < MAX_ARG_LEN && arg_buf[offset + i] != '\0') {
+			pid_pname->pname[i] = arg_buf[offset + i];
 		} else {
 			pid_pname->pname[i] = '\0';
 			break;


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

clang-18+ 会导致 verifier 挂掉 #769, 这个 PR 把 `get_real_comm_ctx.l` 的长度从 u32 缩减为 u8 解决了这个问题。业务逻辑上看，get_real_comm_ctx.l 最多存储的 offset 不超过 MAX_ARG_LEN=128，所以 u8 max=256 足够了。

虽然缩减了结构体字段大小，但是内存对齐的原因让结构体整体实际大小没有变化，依然是 16 字节，产生了空洞，但是问题不大，用 `struct get_real_comm_ctx ctx = {}` 保证空洞也被零值化就行了。

测试：

```shell
for v in 12 13 14 15 16 17 18 19; do sudo CLANG=clang-$v make ebpf-test; done
```

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
