### PR TITLE
docs: update archlinuxcn package name & add AVX2 package to AUR

### DIFF
--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -88,7 +88,13 @@ dae has been released on [AUR](https://aur.archlinux.org/packages/dae) and [arch
 
 #### AUR
 
-##### Latest Release
+##### Latest Release (Optimized Binary for x86-64 v3 / AVX2)
+
+```shell
+[yay/paru] -S dae-avx2-bin
+```
+
+##### Latest Release (General x86-64 or aarch64)
 
 ```shell
 [yay/paru] -S dae
@@ -102,10 +108,10 @@ dae has been released on [AUR](https://aur.archlinux.org/packages/dae) and [arch
 
 #### archlinuxcn
 
-##### Latest Release (Optimized for x86-64 v3)
+##### Latest Release (Optimized Binary for x86-64 v3 / AVX2)
 
 ```shell
-sudo pacman -S dae-bin-x64-v3
+sudo pacman -S dae-avx2-bin
 ```
 
 ##### Latest Release (General x86-64 or aarch64)

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -84,7 +84,13 @@ dae 已发布于 [AUR](https://aur.archlinux.org/packages/dae) 和 [archlinuxcn]
 
 #### AUR
 
-##### 最新稳定版
+##### 最新稳定版 (针对 x86-64 v3 / AVX2 优化)
+
+```shell
+[yay/paru] -S dae-avx2-bin
+```
+
+##### 最新稳定版 (x86-64 或 aarch64 通用版)
 
 ```shell
 [yay/paru] -S dae
@@ -98,10 +104,10 @@ dae 已发布于 [AUR](https://aur.archlinux.org/packages/dae) 和 [archlinuxcn]
 
 #### archlinuxcn
 
-##### 最新稳定版 (针对 x86-64 v3 优化)
+##### 最新稳定版 (针对 x86-64 v3 / AVX2 优化)
 
 ```shell
-sudo pacman -S dae-bin-x64-v3
+sudo pacman -S dae-avx2-bin
 ```
 
 ##### 最新稳定版 (x86-64 或 aarch64 通用版)


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

The original package name `dae-bin-x64-v3` is ill-formed, which makes it removed from AUR. Therefore, it has been renamed to `dae-avx2-bin`.

Related commit: https://github.com/archlinuxcn/repo/commit/b272d171daa6b6bba845b6bf46c373c39e52e6d4

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- Update package name of the AVX2-optimized binary package in archlinuxcn section of installation guide
- Add AVX2-optimized binary package to AUR section in installation guide

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
