### PR TITLE
optimize(bpf): Load separate programs for L2/L3 netdev

### DIFF
--- a/common/consts/ebpf.go
+++ b/common/consts/ebpf.go
@@ -167,8 +167,6 @@ const (
 	LoopbackIfIndex         = 1
 )
 
-type LanWanFlag uint8
-
 const (
 	LinkHdrLen_None     uint32 = 0
 	LinkHdrLen_Ethernet uint32 = 14

--- a/control/control_plane_core.go
+++ b/control/control_plane_core.go
@@ -139,10 +139,10 @@ func getIfParamsFromLink(link netlink.Link) (ifParams bpfIfParams, err error) {
 	return ifParams, nil
 }
 
-func (c *controlPlaneCore) mapLinkType(ifname string) error {
+func (c *controlPlaneCore) linkHdrLen(ifname string) (uint32, error) {
 	link, err := netlink.LinkByName(ifname)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	var linkHdrLen uint32
 	switch link.Attrs().EncapType {
@@ -151,9 +151,10 @@ func (c *controlPlaneCore) mapLinkType(ifname string) error {
 	case "ether":
 		linkHdrLen = consts.LinkHdrLen_Ethernet
 	default:
-		return nil
+		c.log.Warnf("Maybe unsupported link type %v, using default link header length", link.Attrs().EncapType)
+		linkHdrLen = consts.LinkHdrLen_Ethernet
 	}
-	return c.bpf.bpfMaps.LinklenMap.Update(uint32(link.Attrs().Index), linkHdrLen, ebpf.UpdateAny)
+	return linkHdrLen, nil
 }
 
 func (c *controlPlaneCore) addQdisc(ifname string) error {
@@ -253,7 +254,10 @@ func (c *controlPlaneCore) _bindLan(ifname string) error {
 		return err
 	}
 	_ = c.addQdisc(ifname)
-	_ = c.mapLinkType(ifname)
+	linkHdrLen, err := c.linkHdrLen(ifname)
+	if err != nil {
+		return err
+	}
 	/// Insert an elem into IfindexParamsMap.
 	ifParams, err := getIfParamsFromLink(link)
 	if err != nil {
@@ -273,9 +277,15 @@ func (c *controlPlaneCore) _bindLan(ifname string) error {
 			// Priority should be behind of WAN's
 			Priority: 2,
 		},
-		Fd:           c.bpf.bpfPrograms.TproxyLanIngress.FD(),
 		Name:         consts.AppName + "_lan_ingress",
 		DirectAction: true,
+	}
+	if linkHdrLen > 0 {
+		filterIngress.Fd = c.bpf.bpfPrograms.TproxyLanIngressL2.FD()
+		filterIngress.Name = filterIngress.Name + "_l2"
+	} else {
+		filterIngress.Fd = c.bpf.bpfPrograms.TproxyLanIngressL3.FD()
+		filterIngress.Name = filterIngress.Name + "_l3"
 	}
 	// Remove and add.
 	_ = netlink.FilterDel(filterIngress)
@@ -304,9 +314,15 @@ func (c *controlPlaneCore) _bindLan(ifname string) error {
 			// Priority should be front of WAN's
 			Priority: 1,
 		},
-		Fd:           c.bpf.bpfPrograms.TproxyLanEgress.FD(),
 		Name:         consts.AppName + "_lan_egress",
 		DirectAction: true,
+	}
+	if linkHdrLen > 0 {
+		filterEgress.Fd = c.bpf.bpfPrograms.TproxyLanEgressL2.FD()
+		filterEgress.Name = filterEgress.Name + "_l2"
+	} else {
+		filterEgress.Fd = c.bpf.bpfPrograms.TproxyLanEgressL3.FD()
+		filterEgress.Name = filterEgress.Name + "_l3"
 	}
 	// Remove and add.
 	_ = netlink.FilterDel(filterEgress)
@@ -444,7 +460,10 @@ func (c *controlPlaneCore) _bindWan(ifname string) error {
 		return fmt.Errorf("cannot bind to loopback interface")
 	}
 	_ = c.addQdisc(ifname)
-	_ = c.mapLinkType(ifname)
+	linkHdrLen, err := c.linkHdrLen(ifname)
+	if err != nil {
+		return err
+	}
 
 	/// Insert an elem into IfindexParamsMap.
 	ifParams, err := getIfParamsFromLink(link)
@@ -465,9 +484,15 @@ func (c *controlPlaneCore) _bindWan(ifname string) error {
 			Protocol:  unix.ETH_P_ALL,
 			Priority:  2,
 		},
-		Fd:           c.bpf.bpfPrograms.TproxyWanEgress.FD(),
 		Name:         consts.AppName + "_wan_egress",
 		DirectAction: true,
+	}
+	if linkHdrLen > 0 {
+		filterEgress.Fd = c.bpf.bpfPrograms.TproxyWanEgressL2.FD()
+		filterEgress.Name = filterEgress.Name + "_l2"
+	} else {
+		filterEgress.Fd = c.bpf.bpfPrograms.TproxyWanEgressL3.FD()
+		filterEgress.Name = filterEgress.Name + "_l3"
 	}
 	_ = netlink.FilterDel(filterEgress)
 	// Remove and add.
@@ -495,9 +520,15 @@ func (c *controlPlaneCore) _bindWan(ifname string) error {
 			Protocol:  unix.ETH_P_ALL,
 			Priority:  1,
 		},
-		Fd:           c.bpf.bpfPrograms.TproxyWanIngress.FD(),
 		Name:         consts.AppName + "_wan_ingress",
 		DirectAction: true,
+	}
+	if linkHdrLen > 0 {
+		filterIngress.Fd = c.bpf.bpfPrograms.TproxyWanIngressL2.FD()
+		filterIngress.Name = filterIngress.Name + "_l2"
+	} else {
+		filterIngress.Fd = c.bpf.bpfPrograms.TproxyWanIngressL3.FD()
+		filterIngress.Name = filterIngress.Name + "_l3"
 	}
 	_ = netlink.FilterDel(filterIngress)
 	// Remove and add.

--- a/control/kern/tests/bpf_test.c
+++ b/control/kern/tests/bpf_test.c
@@ -17,7 +17,7 @@ struct {
 	__array(values, int());
 } entry_call_map SEC(".maps") = {
 	.values = {
-		[0] = &tproxy_wan_egress,
+		[0] = &tproxy_wan_egress_l2,
 	},
 };
 
@@ -30,9 +30,6 @@ int testpktgen_dport_match(struct __sk_buff *skb)
 SEC("tc/setup/dport_match")
 int testsetup_dport_match(struct __sk_buff *skb)
 {
-	__u32 linklen = ETH_HLEN;
-	bpf_map_update_elem(&linklen_map, &one_key, &linklen, BPF_ANY);
-
 	/* dport(80) -> proxy */
 	struct match_set ms = {};
 	struct port_range pr = {80, 80};
@@ -69,9 +66,6 @@ int testpktgen_dport_mismatch(struct __sk_buff *skb)
 SEC("tc/setup/dport_mismatch")
 int testsetup_dport_mismatch(struct __sk_buff *skb)
 {
-	__u32 linklen = ETH_HLEN;
-	bpf_map_update_elem(&linklen_map, &one_key, &linklen, BPF_ANY);
-
 	/* dport(80) -> proxy */
 	struct match_set ms = {};
 	struct port_range pr = {80, 80};
@@ -108,9 +102,6 @@ int testpktgen_ipset_match(struct __sk_buff *skb)
 SEC("tc/setup/ipset_match")
 int testsetup_ipset_match(struct __sk_buff *skb)
 {
-	__u32 linklen = ETH_HLEN;
-	bpf_map_update_elem(&linklen_map, &one_key, &linklen, BPF_ANY);
-
 	/* dip(224.1.0.0/16) -> direct */
 	struct match_set ms = {};
 	ms.not = false;
@@ -153,9 +144,6 @@ int testpktgen_ipset_mismatch(struct __sk_buff *skb)
 SEC("tc/setup/ipset_mismatch")
 int testsetup_ipset_mismatch(struct __sk_buff *skb)
 {
-	__u32 linklen = ETH_HLEN;
-	bpf_map_update_elem(&linklen_map, &one_key, &linklen, BPF_ANY);
-
 	// dip(224.1.0.0/16) -> direct
 	struct match_set ms = {};
 	ms.not = false;
@@ -198,9 +186,6 @@ int testpktgen_source_ipset_match(struct __sk_buff *skb)
 SEC("tc/setup/source_ipset_match")
 int testsetup_source_ipset_match(struct __sk_buff *skb)
 {
-	__u32 linklen = ETH_HLEN;
-	bpf_map_update_elem(&linklen_map, &one_key, &linklen, BPF_ANY);
-
 	/* sip(192.168.50.0/24) -> direct */
 	struct match_set ms = {};
 	ms.not = false;
@@ -243,9 +228,6 @@ int testpktgen_source_ipset_mismatch(struct __sk_buff *skb)
 SEC("tc/setup/source_ipset_mismatch")
 int testsetup_source_ipset_mismatch(struct __sk_buff *skb)
 {
-	__u32 linklen = ETH_HLEN;
-	bpf_map_update_elem(&linklen_map, &one_key, &linklen, BPF_ANY);
-
 	/* sip(192.168.50.0/24) -> direct */
 	struct match_set ms = {};
 	ms.not = false;
@@ -288,9 +270,6 @@ int testpktgen_sport_match(struct __sk_buff *skb)
 SEC("tc/setup/sport_match")
 int testsetup_sport_match(struct __sk_buff *skb)
 {
-	__u32 linklen = ETH_HLEN;
-	bpf_map_update_elem(&linklen_map, &one_key, &linklen, BPF_ANY);
-
 	/* sport(19000-20000) -> proxy */
 	struct match_set ms = {};
 	struct port_range pr = {19000, 20000};
@@ -327,9 +306,6 @@ int testpktgen_sport_mismatch(struct __sk_buff *skb)
 SEC("tc/setup/sport_mismatch")
 int testsetup_sport_mismatch(struct __sk_buff *skb)
 {
-	__u32 linklen = ETH_HLEN;
-	bpf_map_update_elem(&linklen_map, &one_key, &linklen, BPF_ANY);
-
 	/* sport(19230-19232) -> proxy */
 	struct match_set ms = {};
 	struct port_range pr = {19230, 19232};
@@ -366,9 +342,6 @@ int testpktgen_l4proto_match(struct __sk_buff *skb)
 SEC("tc/setup/l4proto_match")
 int testsetup_l4proto_match(struct __sk_buff *skb)
 {
-	__u32 linklen = ETH_HLEN;
-	bpf_map_update_elem(&linklen_map, &one_key, &linklen, BPF_ANY);
-
 	/* l4proto(tcp) -> proxy */
 	struct match_set ms = {};
 	ms.l4proto_type = L4ProtoType_TCP;
@@ -404,9 +377,6 @@ int testpktgen_l4proto_mismatch(struct __sk_buff *skb)
 SEC("tc/setup/l4proto_mismatch")
 int testsetup_l4proto_mismatch(struct __sk_buff *skb)
 {
-	__u32 linklen = ETH_HLEN;
-	bpf_map_update_elem(&linklen_map, &one_key, &linklen, BPF_ANY);
-
 	/* l4proto(udp) -> proxy */
 	struct match_set ms = {};
 	ms.l4proto_type = L4ProtoType_UDP;
@@ -442,9 +412,6 @@ int testpktgen_ipversion_match(struct __sk_buff *skb)
 SEC("tc/setup/ipversion_match")
 int testsetup_ipversion_match(struct __sk_buff *skb)
 {
-	__u32 linklen = ETH_HLEN;
-	bpf_map_update_elem(&linklen_map, &one_key, &linklen, BPF_ANY);
-
 	/* ipversion(4) -> proxy */
 	struct match_set ms = {};
 	ms.ip_version = IpVersionType_4;
@@ -480,9 +447,6 @@ int testpktgen_ipversion_mismatch(struct __sk_buff *skb)
 SEC("tc/setup/ipversion_mismatch")
 int testsetup_ipversion_mismatch(struct __sk_buff *skb)
 {
-	__u32 linklen = ETH_HLEN;
-	bpf_map_update_elem(&linklen_map, &one_key, &linklen, BPF_ANY);
-
 	/* ipversion(6) -> proxy */
 	struct match_set ms = {};
 	ms.ip_version = IpVersionType_6;
@@ -518,9 +482,6 @@ int testpktgen_mac_match(struct __sk_buff *skb)
 SEC("tc/setup/mac_match")
 int testsetup_mac_match(struct __sk_buff *skb)
 {
-	__u32 linklen = ETH_HLEN;
-	bpf_map_update_elem(&linklen_map, &one_key, &linklen, BPF_ANY);
-
 	/* mac('06:07:08:09:0a:0b') -> proxy */
 	struct match_set ms = {};
 	ms.not = false;
@@ -580,9 +541,6 @@ int testpktgen_mac_mismatch(struct __sk_buff *skb)
 SEC("tc/setup/mac_mismatch")
 int testsetup_mac_mismatch(struct __sk_buff *skb)
 {
-	__u32 linklen = ETH_HLEN;
-	bpf_map_update_elem(&linklen_map, &one_key, &linklen, BPF_ANY);
-
 	/* mac('00:01:02:03:04:05') -> proxy */
 	struct match_set ms = {};
 	ms.not = false;
@@ -630,9 +588,6 @@ int testpktgen_dscp_match(struct __sk_buff *skb)
 SEC("tc/setup/dscp_match")
 int testsetup_dscp_match(struct __sk_buff *skb)
 {
-	__u32 linklen = ETH_HLEN;
-	bpf_map_update_elem(&linklen_map, &one_key, &linklen, BPF_ANY);
-
 	/* dscp(4) -> proxy */
 	struct match_set ms = {};
 	ms.dscp = 4;
@@ -668,9 +623,6 @@ int testpktgen_dscp_mismatch(struct __sk_buff *skb)
 SEC("tc/setup/dscp_mismatch")
 int testsetup_dscp_mismatch(struct __sk_buff *skb)
 {
-	__u32 linklen = ETH_HLEN;
-	bpf_map_update_elem(&linklen_map, &one_key, &linklen, BPF_ANY);
-
 	/* dscp(5) -> proxy */
 	struct match_set ms = {};
 	ms.dscp = 5;
@@ -706,9 +658,6 @@ int testpktgen_and_match_1(struct __sk_buff *skb)
 SEC("tc/setup/and_match_1")
 int testsetup_and_match_1(struct __sk_buff *skb)
 {
-	__u32 linklen = ETH_HLEN;
-	bpf_map_update_elem(&linklen_map, &one_key, &linklen, BPF_ANY);
-
 	/* dip(1.1.0.0/16) && l4proto(tcp) && dport(1-1023, 8443) -> proxy */
 	struct match_set ms = {};
 	ms.not = false;
@@ -786,9 +735,6 @@ int testpktgen_and_match_2(struct __sk_buff *skb)
 SEC("tc/setup/and_match_2")
 int testsetup_and_match_2(struct __sk_buff *skb)
 {
-	__u32 linklen = ETH_HLEN;
-	bpf_map_update_elem(&linklen_map, &one_key, &linklen, BPF_ANY);
-
 	/* dip(1.1.0.0/16) && l4proto(tcp) && dport(1-1023, 8443) -> proxy */
 	struct match_set ms = {};
 	ms.not = false;
@@ -866,9 +812,6 @@ int testpktgen_and_mismatch(struct __sk_buff *skb)
 SEC("tc/setup/and_mismatch")
 int testsetup_and_mismatch(struct __sk_buff *skb)
 {
-	__u32 linklen = ETH_HLEN;
-	bpf_map_update_elem(&linklen_map, &one_key, &linklen, BPF_ANY);
-
 	/* dip(1.1.0.0/16) && l4proto(tcp) && dport(1-1023, 8443) -> proxy */
 	struct match_set ms = {};
 	ms.not = false;
@@ -946,9 +889,6 @@ int testpktgen_not_match(struct __sk_buff *skb)
 SEC("tc/setup/not_match")
 int testsetup_not_match(struct __sk_buff *skb)
 {
-	__u32 linklen = ETH_HLEN;
-	bpf_map_update_elem(&linklen_map, &one_key, &linklen, BPF_ANY);
-
 	/* !dport(80) -> proxy */
 	struct match_set ms = {};
 	struct port_range pr = {80, 80};
@@ -985,9 +925,6 @@ int testpktgen_not_mismtach(struct __sk_buff *skb)
 SEC("tc/setup/not_mismtach")
 int testsetup_not_mismtach(struct __sk_buff *skb)
 {
-	__u32 linklen = ETH_HLEN;
-	bpf_map_update_elem(&linklen_map, &one_key, &linklen, BPF_ANY);
-
 	/* !dport(80) -> proxy */
 	struct match_set ms = {};
 	struct port_range pr = {80, 80};


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

这样可以干掉 linklen_map，降低四个 tc hooks 的指令数，节省每个 skb 处理所需的 cpu。

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
