### PR TITLE
chore(bpf): Cleanup dead bpf code

### DIFF
--- a/control/bpf_utils.go
+++ b/control/bpf_utils.go
@@ -182,6 +182,13 @@ func detectCgroupPath() (string, error) {
 	return "", errors.New("cgroup2 not mounted")
 }
 
+type bpfIfParams struct {
+	RxCksmOffload                  bool
+	TxL4CksmIp4Offload             bool
+	TxL4CksmIp6Offload             bool
+	UseNonstandardOffloadAlgorithm bool
+}
+
 func (p bpfIfParams) CheckVersionRequirement(version *internal.Version) (err error) {
 	if !p.TxL4CksmIp4Offload ||
 		!p.TxL4CksmIp6Offload {

--- a/control/control_plane_core.go
+++ b/control/control_plane_core.go
@@ -262,9 +262,6 @@ func (c *controlPlaneCore) _bindLan(ifname string) error {
 	if err = ifParams.CheckVersionRequirement(c.kernelVersion); err != nil {
 		return err
 	}
-	if err := c.bpf.IfindexParamsMap.Update(uint32(link.Attrs().Index), ifParams, ebpf.UpdateAny); err != nil {
-		return fmt.Errorf("update IfindexIpsMap: %w", err)
-	}
 
 	// Insert filters.
 	filterIngress := &netlink.BpfFilter{
@@ -456,9 +453,6 @@ func (c *controlPlaneCore) _bindWan(ifname string) error {
 	}
 	if err = ifParams.CheckVersionRequirement(c.kernelVersion); err != nil {
 		return err
-	}
-	if err := c.bpf.IfindexParamsMap.Update(uint32(link.Attrs().Index), ifParams, ebpf.UpdateAny); err != nil {
-		return fmt.Errorf("update IfindexIpsMap: %w", err)
 	}
 
 	/// Set-up WAN ingress/egress TC programs.

--- a/control/kern/tproxy.c
+++ b/control/kern/tproxy.c
@@ -32,21 +32,11 @@
 #define IPV6_BYTE_LENGTH 16
 #define TASK_COMM_LEN 16
 
-#define IPV4_CSUM_OFF(link_h_len) ((link_h_len) + offsetof(struct iphdr, check))
-#define IPV4_DST_OFF(link_h_len) ((link_h_len) + offsetof(struct iphdr, daddr))
-#define IPV4_SRC_OFF(link_h_len) ((link_h_len) + offsetof(struct iphdr, saddr))
-#define IPV6_DST_OFF(link_h_len) \
-	((link_h_len) + offsetof(struct ipv6hdr, daddr))
-#define IPV6_SRC_OFF(link_h_len) \
-	((link_h_len) + offsetof(struct ipv6hdr, saddr))
-
 #define PACKET_HOST 0
 #define PACKET_OTHERHOST 3
 
 #define NOWHERE_IFINDEX 0
-#define LOOPBACK_IFINDEX 1
 
-#define MAX_PARAM_LEN 16
 #define MAX_INTERFACE_NUM 256
 #ifndef MAX_MATCH_SET_LEN
 #define MAX_MATCH_SET_LEN \
@@ -69,25 +59,11 @@
 #define OUTBOUND_LOGICAL_AND 0xFF
 #define OUTBOUND_LOGICAL_MASK 0xFE
 
-#define IS_WAN 0
-#define IS_LAN 1
-
 #define TPROXY_MARK 0x8000000
-#define RECOGNIZE 0x2017
-
-#define ESOCKTNOSUPPORT 94 /* Socket type not supported */
 
 #define TIMEOUT_UDP_CONN_STATE 3e11 /* 300s */
 
 #define NDP_REDIRECT 137
-
-enum { BPF_F_CURRENT_NETNS = -1 };
-
-enum {
-	DisableL4ChecksumPolicy_EnableL4Checksum,
-	DisableL4ChecksumPolicy_Restore,
-	DisableL4ChecksumPolicy_SetZero,
-};
 
 // Param keys:
 static const __u32 zero_key;
@@ -210,9 +186,6 @@ struct {
 	__uint(max_entries, 65535);
 } fast_sock SEC(".maps");
 
-// Link to type:
-#define LinkType_None 0
-#define LinkType_Ethernet 1
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__type(key, __u32); // ifindex
@@ -221,23 +194,6 @@ struct {
 	/// NOTICE: No persistence.
 	// __uint(pinning, LIBBPF_PIN_BY_NAME);
 } linklen_map SEC(".maps");
-
-// Interface Ips:
-struct if_params {
-	bool rx_cksm_offload;
-	bool tx_l4_cksm_ip4_offload;
-	bool tx_l4_cksm_ip6_offload;
-	bool use_nonstandard_offload_algorithm;
-};
-
-struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
-	__type(key, __u32); // ifindex
-	__type(value, struct if_params); // ip
-	__uint(max_entries, MAX_INTERFACE_NUM);
-	/// NOTICE: No persistence.
-	// __uint(pinning, LIBBPF_PIN_BY_NAME);
-} ifindex_params_map SEC(".maps");
 
 // Array of LPM tries:
 struct lpm_key {
@@ -426,14 +382,8 @@ get_tuples(const struct __sk_buff *skb, struct tuples *tuples,
 
 static __always_inline bool equal16(const __be32 x[4], const __be32 y[4])
 {
-#if __clang_major__ >= 10
 	return ((__be64 *)x)[0] == ((__be64 *)y)[0] &&
 	       ((__be64 *)x)[1] == ((__be64 *)y)[1];
-
-	// return x[0] == y[0] && x[1] == y[1] && x[2] == y[2] && x[3] == y[3];
-#else
-	return __builtin_bcmp(x, y, IPV6_BYTE_LENGTH) == 0;
-#endif
 }
 
 static __always_inline int


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

删掉了 bpf 里不再被使用的代码，无业务逻辑改动。

两点需要额外关注：
1. 删掉了 `#if __clang_major__ >= 10` ，我们最低的 clang 都是 15，不存在低于 10 的。
2. 删掉了 ifindex_params_map 和用户态的 map update，所以要手动定义一个 bpfIfParams struct 给用户态做 NIC feature check. 所以也节约了一点点点 cpu memory...

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- [Implement ...]

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
