### PR TITLE
docs(user-guide): fix missing `chmod`  after downloaded the sample config file and fix the link of release page

### DIFF
--- a/docs/en/user-guide/run-as-daemon.md
+++ b/docs/en/user-guide/run-as-daemon.md
@@ -29,11 +29,12 @@ Download the sample config file:
 ```bash
 mkdir -p /etc/dae
 curl -L -o /etc/dae/config.dae https://github.com/daeuniverse/dae/raw/main/example.dae
+chmod 600 /etc/dae/config.dae
 ```
 
 ## Download pre-compiled binaries
 
-Releases are available in <https://github.com/daeuniverse/daed/releases>
+Releases are available in <https://github.com/daeuniverse/dae/releases>
 
 > **Note**: If you would like to get a taste of new features, there are nightly (latest) builds available. Most of the time, newly proposed changes will be included in `PRs` and will be exported as cross-platform executable binaries in builds (GitHub Action Workflow Build). Noted that newly introduced features are sometimes buggy, do it at your own risk. However, we still highly encourage you to check out our latest builds as it may help us further analyze features stability and resolve potential bugs accordingly.
 


### PR DESCRIPTION

<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->


* fix "permissions 0644 for '/etc/dae/config.dae' are too open"
* fix wrong release page link.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

-  docs(user-guide): fix missing `chmod` after downloaded the sample config file and fix the link of release page

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #_[issue number]_

### Test Result

<!--- Attach test result here. -->
