### PR TITLE
chore: log node status and latencies in debug level

### DIFF
--- a/component/outbound/dialer/alive_dialer_set.go
+++ b/component/outbound/dialer/alive_dialer_set.go
@@ -137,7 +137,7 @@ func (a *AliveDialerSet) printLatencies() {
 	for i, dl := range alive {
 		builder.WriteString(fmt.Sprintf("%4d. [%v] %v: %v\n", i+1, dl.d.property.SubscriptionTag, dl.d.property.Name, latencyString(dl.l, dl.o)))
 	}
-	a.log.Infoln(strings.TrimSuffix(builder.String(), "\n"))
+	a.log.Debugln(strings.TrimSuffix(builder.String(), "\n"))
 }
 
 // NotifyLatencyChange should be invoked when dialer every time latency and alive state changes.
@@ -174,7 +174,7 @@ func (a *AliveDialerSet) NotifyLatencyChange(dialer *Dialer, alive bool) {
 				a.log.WithFields(logrus.Fields{
 					"dialer": dialer.property.Name,
 					"group":  a.dialerGroupName,
-				}).Infof("[NOT ALIVE --%v-> ALIVE]", a.CheckTyp.String())
+				}).Debugf("[NOT ALIVE --%v-> ALIVE]", a.CheckTyp.String())
 			}
 			a.dialerToIndex[dialer] = len(a.inorderedAliveDialerSet)
 			a.inorderedAliveDialerSet = append(a.inorderedAliveDialerSet, dialer)
@@ -186,7 +186,7 @@ func (a *AliveDialerSet) NotifyLatencyChange(dialer *Dialer, alive bool) {
 			a.log.WithFields(logrus.Fields{
 				"dialer": dialer.property.Name,
 				"group":  a.dialerGroupName,
-			}).Infof("[ALIVE --%v-> NOT ALIVE]", a.CheckTyp.String())
+			}).Debugf("[ALIVE --%v-> NOT ALIVE]", a.CheckTyp.String())
 			// Remove the dialer from inorderedAliveDialerSet.
 			if index >= len(a.inorderedAliveDialerSet) {
 				a.log.Panicf("index:%v >= len(a.inorderedAliveDialerSet):%v", index, len(a.inorderedAliveDialerSet))
@@ -251,7 +251,7 @@ func (a *AliveDialerSet) NotifyLatencyChange(dialer *Dialer, alive bool) {
 					"_old_dialer":             oldDialerName,
 					"group":                   a.dialerGroupName,
 					"network":                 a.CheckTyp.String(),
-				}).Infof("Group %vselects dialer", re)
+				}).Debugf("Group %vselects dialer", re)
 
 				a.printLatencies()
 			} else {
@@ -260,7 +260,7 @@ func (a *AliveDialerSet) NotifyLatencyChange(dialer *Dialer, alive bool) {
 				a.log.WithFields(logrus.Fields{
 					"group":   a.dialerGroupName,
 					"network": a.CheckTyp.String(),
-				}).Infof("Group has no dialer alive")
+				}).Debugf("Group has no dialer alive")
 			}
 		}
 	} else {

--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -1,5 +1,7 @@
 # Troubleshooting
 
+Before troubleshooting networking issues, you may wish to set the log level to 'debug' or 'trace' to obtain detailed information about connectivity and latencies.
+
 ## No network after `dae suspend`
 
 Do not set dae as the DNS in DHCP setting. For example, you can set `223.5.5.5` as DNS in your DHCP setting.


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

有的时候我想在 journal 里面看每个连接的分流情况，但是大鹅一直在刷节点测速日志以及存活状态，使得我基本上看不到有价值的信息。

没有在项目里见到 CONTRIBUTING.md, 因此如果有做的不对的地方烦请指出, 谢谢!

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
  It's not a new version so I didn't change that.
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae
  It's integrated into this PR. if this is inappropirate, I'll submit another PR later.

### Full Changelogs

- 更改了 `alive_dialer_set.go` 中打印延迟及节点列表时使用的 log level.

### Issue Reference

I haven't seen any.

### Test Result

It works on my machine.