### PR TITLE
fix(dns): fix dns bind issue when reload

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -259,6 +259,11 @@ loop:
 				// Only keep dns cache when ip version preference not change.
 				dnsCache = c.CloneDnsCache()
 			}
+			// Stop old DNS listener before creating new one to avoid port conflicts
+			if err := c.StopDNSListener(); err != nil {
+				log.Warnf("[Reload] Failed to stop old DNS listener: %v", err)
+			}
+			
 			log.Warnln("[Reload] Load new control plane")
 			newC, err := newControlPlane(log, obj, dnsCache, newConf, externGeoDataDirs)
 			if err != nil {

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -473,6 +473,8 @@ func NewControlPlane(
 			log.Errorf("Failed to start DNS listener: %v", err)
 		} else {
 			log.Infof("DNS listener started on %s", dnsConfig.Bind)
+			// Add DNS listener stop to defer functions
+			deferFuncs = append(deferFuncs, plane.dnsListener.Stop)
 		}
 	}
 	// Refresh domain routing cache with new routing.
@@ -1017,4 +1019,12 @@ func (c *ControlPlane) Close() (err error) {
 	}
 	c.cancel()
 	return c.core.Close()
+}
+
+// StopDNSListener stops the DNS listener if it's running
+func (c *ControlPlane) StopDNSListener() error {
+	if c.dnsListener != nil {
+		return c.dnsListener.Stop()
+	}
+	return nil
 }


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background
dns port failed to unbind when doing `dae reload`
<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has been fully tested
- [x] There's an entry in the CHANGELOGS
- [x] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- fix(dns): fix dns bind issue when reload


### Test Result
<img width="920" height="390" alt="image" src="https://github.com/user-attachments/assets/4f15f397-af61-4183-89fc-82e6ae644a50" />

<!--- Attach test result here. -->
