### PR TITLE
feat(dns): support tcp+udp schema for dns local bind

### DIFF
--- a/example.dae
+++ b/example.dae
@@ -168,7 +168,10 @@ dns {
     #}
 
     # Bind to local address to listen for DNS queries
-    #bind: '127.0.0.1:5353'
+    # bind: '127.0.0.1:5353'
+    # bind: 'tcp://127.0.0.1:5353'
+    # bind: 'udp://127.0.0.1:5353'
+    # bind: 'tcp+udp://127.0.0.1:5353'
 
     upstream {
         # Value can be scheme://host:port, where the scheme can be tcp/udp/tcp+udp/h3/http3/quic/https/tls.


### PR DESCRIPTION

<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

support config for dns local bind as below
```
bind: 'tcp+udp://127.0.0.1:5353'
bind: 'udp://127.0.0.1:5353'
bind: 'tcp://127.0.0.1:5353'
```

### Checklist

- [x] The Pull Request has been fully tested
- [x] There's an entry in the CHANGELOGS
- [x] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- feat(dns): support tcp+udp schema for dns local bind

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

### Test Result

<img width="1038" height="320" alt="image" src="https://github.com/user-attachments/assets/f15611dd-f3f5-4b7d-94d9-3726ebc791b7" />


