### PR TITLE
fix(tproxy): re-apply fwmark on non-SYN TCP packets in LAN ingress

### DIFF
--- a/control/kern/tproxy.c
+++ b/control/kern/tproxy.c
@@ -1128,6 +1128,13 @@ new_connection:;
 		if (!(tcph.syn && !tcph.ack)) {
 			// Not a new TCP connection.
 			// Perhaps single-arm.
+			// Re-apply fwmark so that non-SYN packets of a direct(mark:N)
+			// flow still follow fwmark-based policy routing.
+			struct routing_result *routing_result =
+				bpf_map_lookup_elem(&routing_tuples_map,
+						    &tuples.five);
+			if (routing_result)
+				skb->mark = routing_result->mark;
 			return TC_ACT_OK;
 		}
 		params.l4hdr = &tcph;


### PR DESCRIPTION

### Background

When using direct(mark: N) with fwmark-based policy routing on LAN ingress, only the TCP SYN packet receives the fwmark. Subsequent packets (ACK, PSH, FIN) pass through without any mark, causing them to
  bypass fwmark policy routing and follow the default route instead. This breaks TCP connections silently — the SYN reaches the intended interface (e.g., WireGuard tunnel, netns veth), but all subsequent
  packets take the wrong path.

  Root cause: the non-SYN TCP path in do_tproxy_lan_ingress (tproxy.c lines 1128–1132) returned TC_ACT_OK immediately without consulting routing_tuples_map. The map entry is correctly written during SYN
  processing (line 1194), but was never read on subsequent packets. Compare with WAN egress, which does read the map for non-SYN packets (lines 1452–1462).

  UDP is unaffected (every packet goes through route()). WAN egress TCP is unaffected (already reads the map). Only LAN ingress TCP with a non-zero mark was broken.


### Checklist

- [X] The Pull Request has been fully tested
- [X] There's an entry in the CHANGELOGS
- [X] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

  - [fix(tproxy): re-apply fwmark on non-SYN TCP packets in LAN ingress]


### Issue Reference

Closes #938 

### Test Result
#### Before
```
18:50:04.566024 ens224 In  IP 10.130.8.10.51688 > 1.1.1.1.80: Flags [S], seq 3858715365, win 64240, options [mss 1460,sackOK,TS val
  3754601034 ecr 0,nop,wscale 7], length 0
  18:50:04.566100 veth-host Out IP 10.130.8.253.51688 > 1.1.1.1.80: Flags [S], seq 3858715365, win 64240, options [mss 1460,sackOK,TS val 3754601034 ecr 0,nop,wscale 7], length 0
  18:50:04.566161 veth-host In  IP 1.1.1.1.80 > 10.130.8.253.51688: Flags [S.], seq 3431646964, ack 3858715366, win 65535, options [mss 1460,sackOK,TS val 1637316516 ecr 3754601034,nop,wscale 8],
  length 0
  18:50:04.566189 ens192 Out IP 1.1.1.1.80 > 10.130.8.10.51688: Flags [S.], seq 3431646964, ack 3858715366, win 65535, options [mss 1460,sackOK,TS val 1637316516 ecr 3754601034,nop,wscale 8], length 0
  18:50:04.566387 ens224 In  IP 10.130.8.10.51688 > 1.1.1.1.80: Flags [.], ack 1, win 502, options [nop,nop,TS val 3754601035 ecr 1637316516], length 0
  18:50:04.566425 ens224 Out IP 10.130.8.253.51688 > 1.1.1.1.80: Flags [.], ack 1, win 502, options [nop,nop,TS val 3754601035 ecr 1637316516], length 0
  18:50:04.566544 ens224 In  IP 10.130.8.10.51688 > 1.1.1.1.80: Flags [P.], seq 1:72, ack 1, win 502, options [nop,nop,TS val 3754601035 ecr 1637316516], length 71: HTTP: GET / HTTP/1.1
  18:50:04.566580 ens224 Out IP 10.130.8.253.51688 > 1.1.1.1.80: Flags [P.], seq 1:72, ack 1, win 502, options [nop,nop,TS val 3754601035 ecr 1637316516], length 71: HTTP: GET / HTTP/1.1
  18:50:04.644589 ens192 In  IP 1.1.1.1.80 > 10.130.8.253.51688: Flags [R], seq 3431646965, win 0, length 0
  18:50:04.644634 ens192 Out IP 1.1.1.1.80 > 10.130.8.10.51688: Flags [R], seq 3431646965, win 0, length 0
  18:50:05.590577 veth-host In  IP 1.1.1.1.80 > 10.130.8.253.51688: Flags [S.], seq 3431646964, ack 3858715366, win 65535, options [mss 1460,sackOK,TS val 1637317541 ecr 3754601034,nop,wscale 8],
  length 0
  18:50:05.590615 ens192 Out IP 1.1.1.1.80 > 10.130.8.10.51688: Flags [S.], seq 3431646964, ack 3858715366, win 65535, options [mss 1460,sackOK,TS val 1637317541 ecr 3754601034,nop,wscale 8], length 0
  18:50:05.590894 ens224 In  IP 10.130.8.10.51688 > 1.1.1.1.80: Flags [R], seq 3858715366, win 0, length 0
  18:50:05.590935 ens224 Out IP 10.130.8.253.51688 > 1.1.1.1.80: Flags [R], seq 3858715366, win 0, length 0
  18:50:07.606575 veth-host In  IP 1.1.1.1.80 > 10.130.8.253.51688: Flags [S.], seq 3431646964, ack 3858715366, win 65535, options [mss 1460,sackOK,TS val 1637319557 ecr 3754601034,nop,wscale 8],
  length 0
  18:50:07.606609 ens192 Out IP 1.1.1.1.80 > 10.130.8.10.51688: Flags [S.], seq 3431646964, ack 3858715366, win 65535, options [mss 1460,sackOK,TS val 1637319557 ecr 3754601034,nop,wscale 8], length 0
  18:50:07.606944 ens224 In  IP 10.130.8.10.51688 > 1.1.1.1.80: Flags [R], seq 3858715366, win 0, length 0
  18:50:07.606982 ens224 Out IP 10.130.8.253.51688 > 1.1.1.1.80: Flags [R], seq 3858715366, win 0, length 0
  18:50:11.830621 veth-host In  IP 1.1.1.1.80 > 10.130.8.253.51688: Flags [S.], seq 3431646964, ack 3858715366, win 65535, options [mss 1460,sackOK,TS val 1637323781 ecr 3754601034,nop,wscale 8],
  length 0
  18:50:11.830656 ens192 Out IP 1.1.1.1.80 > 10.130.8.10.51688: Flags [S.], seq 3431646964, ack 3858715366, win 65535, options [mss 1460,sackOK,TS val 1637323781 ecr 3754601034,nop,wscale 8], length 0
  18:50:11.831025 ens224 In  IP 10.130.8.10.51688 > 1.1.1.1.80: Flags [R], seq 3858715366, win 0, length 0
  18:50:11.831064 ens224 Out IP 10.130.8.253.51688 > 1.1.1.1.80: Flags [R], seq 3858715366, win 0, length 0
  18:50:20.022597 veth-host In  IP 1.1.1.1.80 > 10.130.8.253.51688: Flags [S.], seq 3431646964, ack 3858715366, win 65535, options [mss 1460,sackOK,TS val 1637331973 ecr 3754601034,nop,wscale 8],
  length 0

```

#### After
```
0:12:49.402838 ens224 In  IP 10.130.8.10.38928 > 1.1.1.1.80: Flags [S], seq 1268912444, win 64240, options [mss 1460,sackOK,TS val 3759565871 ecr 0,nop,wscale 7], length 0
20:12:49.402910 veth-host Out IP 10.130.8.253.38928 > 1.1.1.1.80: Flags [S], seq 1268912444, win 64240, options [mss 1460,sackOK,TS val 3759565871 ecr 0,nop,wscale 7], length 0
20:12:49.402968 veth-host In  IP 1.1.1.1.80 > 10.130.8.253.38928: Flags [S.], seq 2632588796, ack 1268912445, win 65535, options [mss 1460,sackOK,TS val 1642281353 ecr 3759565871,nop,wscale 8], length 0
20:12:49.402994 ens192 Out IP 1.1.1.1.80 > 10.130.8.10.38928: Flags [S.], seq 2632588796, ack 1268912445, win 65535, options [mss 1460,sackOK,TS val 1642281353 ecr 3759565871,nop,wscale 8], length 0
20:12:49.403234 ens224 In  IP 10.130.8.10.38928 > 1.1.1.1.80: Flags [.], ack 1, win 502, options [nop,nop,TS val 3759565872 ecr 1642281353], length 0
20:12:49.403266 veth-host Out IP 10.130.8.253.38928 > 1.1.1.1.80: Flags [.], ack 1, win 502, options [nop,nop,TS val 3759565872 ecr 1642281353], length 0
20:12:49.403341 ens224 In  IP 10.130.8.10.38928 > 1.1.1.1.80: Flags [P.], seq 1:72, ack 1, win 502, options [nop,nop,TS val 3759565872 ecr 1642281353], length 71: HTTP: GET / HTTP/1.1
20:12:49.403371 veth-host Out IP 10.130.8.253.38928 > 1.1.1.1.80: Flags [P.], seq 1:72, ack 1, win 502, options [nop,nop,TS val 3759565872 ecr 1642281353], length 71: HTTP: GET / HTTP/1.1
20:12:49.403403 veth-host In  IP 1.1.1.1.80 > 10.130.8.253.38928: Flags [.], ack 72, win 509, options [nop,nop,TS val 1642281353 ecr 3759565872], length 0
20:12:49.403427 ens192 Out IP 1.1.1.1.80 > 10.130.8.10.38928: Flags [.], ack 72, win 509, options [nop,nop,TS val 1642281353 ecr 3759565872], length 0
20:12:49.467840 veth-host In  IP 1.1.1.1.80 > 10.130.8.253.38928: Flags [P.], seq 1:387, ack 72, win 509, options [nop,nop,TS val 1642281418 ecr 3759565872], length 386: HTTP: HTTP/1.1 301 Moved Permanently
20:12:49.467876 ens192 Out IP 1.1.1.1.80 > 10.130.8.10.38928: Flags [P.], seq 1:387, ack 72, win 509, options [nop,nop,TS val 1642281418 ecr 3759565872], length 386: HTTP: HTTP/1.1 301 Moved Permanently
20:12:49.468079 ens224 In  IP 10.130.8.10.38928 > 1.1.1.1.80: Flags [.], ack 387, win 501, options [nop,nop,TS val 3759565936 ecr 1642281418], length 0
20:12:49.468115 veth-host Out IP 10.130.8.253.38928 > 1.1.1.1.80: Flags [.], ack 387, win 501, options [nop,nop,TS val 3759565936 ecr 1642281418], length 0
20:12:49.468465 ens224 In  IP 10.130.8.10.38928 > 1.1.1.1.80: Flags [F.], seq 72, ack 387, win 501, options [nop,nop,TS val 3759565937 ecr 1642281418], length 0
20:12:49.468497 veth-host Out IP 10.130.8.253.38928 > 1.1.1.1.80: Flags [F.], seq 72, ack 387, win 501, options [nop,nop,TS val 3759565937 ecr 1642281418], length 0
20:12:49.468851 veth-host In  IP 1.1.1.1.80 > 10.130.8.253.38928: Flags [F.], seq 387, ack 73, win 509, options [nop,nop,TS val 1642281419 ecr 3759565937], length 0
20:12:49.468882 ens192 Out IP 1.1.1.1.80 > 10.130.8.10.38928: Flags [F.], seq 387, ack 73, win 509, options [nop,nop,TS val 1642281419 ecr 3759565937], length 0
20:12:49.469048 ens224 In  IP 10.130.8.10.38928 > 1.1.1.1.80: Flags [.], ack 388, win 501, options [nop,nop,TS val 3759565937 ecr 1642281419], length 0
20:12:49.469085 veth-host Out IP 10.130.8.253.38928 > 1.1.1.1.80: Flags [.], ack 388, win 501, options [nop,nop,TS val 3759565937 ecr 1642281419], length 0

```