### PR TITLE
feat(outbound): add weighted random proxy-group selection

### DIFF
--- a/component/outbound/dialer/alive_dialer_set.go
+++ b/component/outbound/dialer/alive_dialer_set.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/daeuniverse/dae/common/consts"
+	"github.com/daeuniverse/outbound/pkg/fastrand"
 	"github.com/sirupsen/logrus"
 )
 
@@ -36,6 +37,7 @@ type AliveDialerSet struct {
 	dialerGroupName string
 	CheckTyp        *NetworkType
 	tolerance       time.Duration
+	uniformWeight   bool
 
 	aliveChangeCallback func(alive bool)
 
@@ -66,16 +68,25 @@ func NewAliveDialerSet(
 	}
 	dialerToLatencyOffset := make(map[*Dialer]time.Duration)
 	dialerToWeight := make(map[*Dialer]int64)
+	uniformWeight := true
+	var firstWeight int64
 	for i := range dialers {
 		d, a := dialers[i], dialersAnnotations[i]
 		dialerToLatencyOffset[d] = a.AddLatency
-		dialerToWeight[d] = 1 + a.AddWeight
+		weight := 1 + a.AddWeight
+		dialerToWeight[d] = weight
+		if i == 0 {
+			firstWeight = weight
+		} else if weight != firstWeight {
+			uniformWeight = false
+		}
 	}
 	a := &AliveDialerSet{
 		log:                     log,
 		dialerGroupName:         dialerGroupName,
 		CheckTyp:                networkType,
 		tolerance:               tolerance,
+		uniformWeight:           uniformWeight,
 		aliveChangeCallback:     aliveChangeCallback,
 		dialerToIndex:           make(map[*Dialer]int),
 		dialerToLatency:         make(map[*Dialer]time.Duration),
@@ -103,6 +114,40 @@ func (a *AliveDialerSet) GetRand() *Dialer {
 	if len(a.inorderedAliveDialerSet) == 0 {
 		return nil
 	}
+	if a.uniformWeight {
+		ind := fastrand.Intn(len(a.inorderedAliveDialerSet))
+		return a.inorderedAliveDialerSet[ind]
+	}
+	var totalWeight uint64
+	for _, d := range a.inorderedAliveDialerSet {
+		weight := a.dialerToWeight[d]
+		if weight <= 0 {
+			continue
+		}
+		if totalWeight > math.MaxUint64-uint64(weight) {
+			return a.getRandExponentialRaceLocked()
+		}
+		totalWeight += uint64(weight)
+	}
+	if totalWeight == 0 {
+		return nil
+	}
+	ticket := randv2.Uint64N(totalWeight)
+	var cumulative uint64
+	for _, d := range a.inorderedAliveDialerSet {
+		weight := a.dialerToWeight[d]
+		if weight <= 0 {
+			continue
+		}
+		cumulative += uint64(weight)
+		if ticket < cumulative {
+			return d
+		}
+	}
+	return a.getRandExponentialRaceLocked()
+}
+
+func (a *AliveDialerSet) getRandExponentialRaceLocked() *Dialer {
 	var selected *Dialer
 	bestScore := math.Inf(1)
 	for _, d := range a.inorderedAliveDialerSet {

--- a/component/outbound/dialer/alive_dialer_set.go
+++ b/component/outbound/dialer/alive_dialer_set.go
@@ -7,13 +7,14 @@ package dialer
 
 import (
 	"fmt"
+	"math"
+	randv2 "math/rand/v2"
 	"sort"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/daeuniverse/dae/common/consts"
-	"github.com/daeuniverse/outbound/pkg/fastrand"
 	"github.com/sirupsen/logrus"
 )
 
@@ -42,6 +43,7 @@ type AliveDialerSet struct {
 	dialerToIndex           map[*Dialer]int // *Dialer -> index of inorderedAliveDialerSet
 	dialerToLatency         map[*Dialer]time.Duration
 	dialerToLatencyOffset   map[*Dialer]time.Duration
+	dialerToWeight          map[*Dialer]int64
 	inorderedAliveDialerSet []*Dialer
 
 	selectionPolicy consts.DialerSelectionPolicy
@@ -63,9 +65,11 @@ func NewAliveDialerSet(
 		panic(fmt.Sprintf("unmatched annotations length: %v dialers and %v annotations", len(dialers), len(dialersAnnotations)))
 	}
 	dialerToLatencyOffset := make(map[*Dialer]time.Duration)
+	dialerToWeight := make(map[*Dialer]int64)
 	for i := range dialers {
 		d, a := dialers[i], dialersAnnotations[i]
 		dialerToLatencyOffset[d] = a.AddLatency
+		dialerToWeight[d] = 1 + a.AddWeight
 	}
 	a := &AliveDialerSet{
 		log:                     log,
@@ -76,6 +80,7 @@ func NewAliveDialerSet(
 		dialerToIndex:           make(map[*Dialer]int),
 		dialerToLatency:         make(map[*Dialer]time.Duration),
 		dialerToLatencyOffset:   dialerToLatencyOffset,
+		dialerToWeight:          dialerToWeight,
 		inorderedAliveDialerSet: make([]*Dialer, 0, len(dialers)),
 		selectionPolicy:         selectionPolicy,
 		minLatency: minLatency{
@@ -98,8 +103,21 @@ func (a *AliveDialerSet) GetRand() *Dialer {
 	if len(a.inorderedAliveDialerSet) == 0 {
 		return nil
 	}
-	ind := fastrand.Intn(len(a.inorderedAliveDialerSet))
-	return a.inorderedAliveDialerSet[ind]
+	var selected *Dialer
+	bestScore := math.Inf(1)
+	for _, d := range a.inorderedAliveDialerSet {
+		weight := a.dialerToWeight[d]
+		if weight <= 0 {
+			continue
+		}
+		u := 1 - randv2.Float64()
+		score := -math.Log(u) / float64(weight)
+		if score < bestScore {
+			bestScore = score
+			selected = d
+		}
+	}
+	return selected
 }
 
 func (a *AliveDialerSet) SortingLatency(d *Dialer) time.Duration {

--- a/component/outbound/dialer/alive_dialer_set_bench_test.go
+++ b/component/outbound/dialer/alive_dialer_set_bench_test.go
@@ -1,0 +1,81 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2025, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package dialer
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/daeuniverse/dae/common/consts"
+	"github.com/daeuniverse/outbound/pkg/fastrand"
+)
+
+var benchmarkSelectedDialer *Dialer
+
+func benchmarkAliveDialerSet(size int, weighted bool) *AliveDialerSet {
+	dialers := make([]*Dialer, size)
+	annotations := make([]*Annotation, size)
+	for i := range size {
+		dialers[i] = &Dialer{}
+		annotation := &Annotation{}
+		if weighted && i%10 == 0 {
+			annotation.AddWeight = 9
+		}
+		annotations[i] = annotation
+	}
+	return NewAliveDialerSet(
+		nil,
+		"benchmark-group",
+		nil,
+		0,
+		consts.DialerSelectionPolicy_Random,
+		dialers,
+		annotations,
+		func(bool) {},
+		true,
+	)
+}
+
+func benchmarkGetRandFast(set *AliveDialerSet) *Dialer {
+	set.mu.Lock()
+	defer set.mu.Unlock()
+	if len(set.inorderedAliveDialerSet) == 0 {
+		return nil
+	}
+	ind := fastrand.Intn(len(set.inorderedAliveDialerSet))
+	return set.inorderedAliveDialerSet[ind]
+}
+
+func BenchmarkAliveDialerSet_GetRand(b *testing.B) {
+	for _, scenario := range []struct {
+		name     string
+		weighted bool
+	}{
+		{name: "default_weights", weighted: false},
+		{name: "partial_add_weight", weighted: true},
+	} {
+		b.Run(scenario.name, func(b *testing.B) {
+			for _, size := range []int{10, 100, 1000, 10000, 100000} {
+				b.Run(fmt.Sprintf("weighted/%d", size), func(b *testing.B) {
+					set := benchmarkAliveDialerSet(size, scenario.weighted)
+					b.ReportAllocs()
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						benchmarkSelectedDialer = set.GetRand()
+					}
+				})
+				b.Run(fmt.Sprintf("fastrand/%d", size), func(b *testing.B) {
+					set := benchmarkAliveDialerSet(size, scenario.weighted)
+					b.ReportAllocs()
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						benchmarkSelectedDialer = benchmarkGetRandFast(set)
+					}
+				})
+			}
+		})
+	}
+}

--- a/component/outbound/dialer/alive_dialer_set_test.go
+++ b/component/outbound/dialer/alive_dialer_set_test.go
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2025, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package dialer
+
+import (
+	"math"
+	"testing"
+
+	"github.com/daeuniverse/dae/common/consts"
+)
+
+func TestAliveDialerSet_GetRand_WithLargeAggregateWeights(t *testing.T) {
+	dialers := []*Dialer{{}, {}, {}}
+	annotations := []*Annotation{
+		{AddWeight: math.MaxInt64 - 1},
+		{AddWeight: math.MaxInt64 - 1},
+		{AddWeight: math.MaxInt64 - 1},
+	}
+	set := NewAliveDialerSet(
+		nil,
+		"test-group",
+		nil,
+		0,
+		consts.DialerSelectionPolicy_Random,
+		dialers,
+		annotations,
+		func(bool) {},
+		true,
+	)
+	count := make([]int, len(dialers))
+	for i := 0; i < 300; i++ {
+		d := set.GetRand()
+		if d == nil {
+			t.Fatal("expected a dialer, got nil")
+		}
+		for j, dd := range dialers {
+			if d == dd {
+				count[j]++
+				break
+			}
+		}
+	}
+	for i, c := range count {
+		if c == 0 {
+			t.Fatalf("dialer %d was never selected: counts=%v", i, count)
+		}
+	}
+	if got := set.dialerToWeight[dialers[0]]; got != math.MaxInt64 {
+		t.Fatalf("unexpected effective weight: %v", got)
+	}
+}

--- a/component/outbound/dialer/annotation.go
+++ b/component/outbound/dialer/annotation.go
@@ -7,6 +7,7 @@ package dialer
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/daeuniverse/dae/pkg/config_parser"
@@ -14,14 +15,19 @@ import (
 
 const (
 	AnnotationKey_AddLatency = "add_latency"
+	AnnotationKey_AddWeight  = "add_weight"
+	maxAddWeight             = int64(^uint64(0)>>1) - 1
 )
 
 type Annotation struct {
 	AddLatency time.Duration
+	AddWeight  int64
 }
 
 func NewAnnotation(annotation []*config_parser.Param) (*Annotation, error) {
 	var anno Annotation
+	var addLatencySet bool
+	var addWeightSet bool
 	for _, param := range annotation {
 		switch param.Key {
 		case AnnotationKey_AddLatency:
@@ -30,8 +36,25 @@ func NewAnnotation(annotation []*config_parser.Param) (*Annotation, error) {
 				return nil, fmt.Errorf("incorrect latency format: %w", err)
 			}
 			// Only the first setting is valid.
-			if anno.AddLatency == 0 {
+			if !addLatencySet {
 				anno.AddLatency = latency
+				addLatencySet = true
+			}
+		case AnnotationKey_AddWeight:
+			weight, err := strconv.ParseInt(param.Val, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("incorrect weight format: %w", err)
+			}
+			if weight < 0 {
+				return nil, fmt.Errorf("incorrect weight value: effective weight must be positive")
+			}
+			if weight > maxAddWeight {
+				return nil, fmt.Errorf("incorrect weight value: effective weight overflows int64")
+			}
+			// Only the first setting is valid.
+			if !addWeightSet {
+				anno.AddWeight = weight
+				addWeightSet = true
 			}
 		default:
 			return nil, fmt.Errorf("unknown filter annotation: %v", param.Key)

--- a/component/outbound/dialer/annotation_test.go
+++ b/component/outbound/dialer/annotation_test.go
@@ -1,0 +1,130 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2025, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package dialer
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/daeuniverse/dae/common/consts"
+	"github.com/daeuniverse/dae/pkg/config_parser"
+)
+
+func TestNewAnnotation_AddLatencyFirstSettingWins(t *testing.T) {
+	annotation, err := NewAnnotation([]*config_parser.Param{
+		{Key: AnnotationKey_AddLatency, Val: "5s"},
+		{Key: AnnotationKey_AddLatency, Val: "9s"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if annotation.AddLatency != 5*time.Second {
+		t.Fatalf("unexpected add_latency: %v", annotation.AddLatency)
+	}
+}
+
+func TestNewAnnotation_AddLatencyFirstSettingWinsWhenFirstIsZero(t *testing.T) {
+	annotation, err := NewAnnotation([]*config_parser.Param{
+		{Key: AnnotationKey_AddLatency, Val: "0s"},
+		{Key: AnnotationKey_AddLatency, Val: "5s"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if annotation.AddLatency != 0 {
+		t.Fatalf("unexpected add_latency: %v", annotation.AddLatency)
+	}
+}
+
+func TestNewAnnotation_AddWeight(t *testing.T) {
+	annotation, err := NewAnnotation([]*config_parser.Param{{Key: AnnotationKey_AddWeight, Val: "3"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if annotation.AddWeight != 3 {
+		t.Fatalf("unexpected add_weight: %v", annotation.AddWeight)
+	}
+}
+
+func TestNewAnnotation_AddWeightRejectsNonPositiveEffectiveWeight(t *testing.T) {
+	for _, val := range []string{"-1", "-2"} {
+		_, err := NewAnnotation([]*config_parser.Param{{Key: AnnotationKey_AddWeight, Val: val}})
+		if err == nil {
+			t.Fatalf("expected add_weight=%s to fail", val)
+		}
+	}
+}
+
+func TestNewAnnotation_AddWeightRejectsInvalidNumber(t *testing.T) {
+	_, err := NewAnnotation([]*config_parser.Param{{Key: AnnotationKey_AddWeight, Val: "abc"}})
+	if err == nil {
+		t.Fatal("expected invalid weight to fail")
+	}
+}
+
+func TestNewAnnotation_AddWeightRejectsOverflowingValue(t *testing.T) {
+	_, err := NewAnnotation([]*config_parser.Param{{Key: AnnotationKey_AddWeight, Val: "9223372036854775807"}})
+	if err == nil {
+		t.Fatal("expected overflowing weight to fail")
+	}
+}
+
+func TestNewAnnotation_AddWeightAcceptsLargestSafeValue(t *testing.T) {
+	annotation, err := NewAnnotation([]*config_parser.Param{{Key: AnnotationKey_AddWeight, Val: "9223372036854775806"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if annotation.AddWeight != math.MaxInt64-1 {
+		t.Fatalf("unexpected add_weight: %v", annotation.AddWeight)
+	}
+}
+
+func TestNewAliveDialerSet_AddWeightAcceptsLargestSafeEffectiveWeight(t *testing.T) {
+	option := &GlobalOption{}
+	dialers := []*Dialer{{}}
+	annotations := []*Annotation{{AddWeight: math.MaxInt64 - 1}}
+	set := NewAliveDialerSet(
+		nil,
+		"test-group",
+		nil,
+		option.CheckTolerance,
+		consts.DialerSelectionPolicy_Random,
+		dialers,
+		annotations,
+		func(bool) {},
+		false,
+	)
+	if got := set.dialerToWeight[dialers[0]]; got != math.MaxInt64 {
+		t.Fatalf("unexpected effective weight: %v", got)
+	}
+}
+
+func TestNewAnnotation_AddWeightFirstSettingWins(t *testing.T) {
+	annotation, err := NewAnnotation([]*config_parser.Param{
+		{Key: AnnotationKey_AddWeight, Val: "5"},
+		{Key: AnnotationKey_AddWeight, Val: "9"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if annotation.AddWeight != 5 {
+		t.Fatalf("unexpected add_weight: %v", annotation.AddWeight)
+	}
+}
+
+func TestNewAnnotation_AddWeightFirstSettingWinsWhenFirstIsZero(t *testing.T) {
+	annotation, err := NewAnnotation([]*config_parser.Param{
+		{Key: AnnotationKey_AddWeight, Val: "0"},
+		{Key: AnnotationKey_AddWeight, Val: "9"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if annotation.AddWeight != 0 {
+		t.Fatalf("unexpected add_weight: %v", annotation.AddWeight)
+	}
+}

--- a/component/outbound/dialer_group_test.go
+++ b/component/outbound/dialer_group_test.go
@@ -6,6 +6,7 @@
 package outbound
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -39,6 +40,14 @@ func newDirectDialer(option *dialer.GlobalOption, fullcone bool) *dialer.Dialer 
 	return d
 }
 
+func emptyAnnotations(n int) []*dialer.Annotation {
+	annotations := make([]*dialer.Annotation, n)
+	for i := range annotations {
+		annotations[i] = &dialer.Annotation{}
+	}
+	return annotations
+}
+
 func TestDialerGroup_Select_Fixed(t *testing.T) {
 	option := &dialer.GlobalOption{
 		Log:               log,
@@ -53,7 +62,7 @@ func TestDialerGroup_Select_Fixed(t *testing.T) {
 		newDirectDialer(option, false),
 	}
 	fixedIndex := 1
-	g := NewDialerGroup(option, "test-group", dialers, []*dialer.Annotation{{}},
+	g := NewDialerGroup(option, "test-group", dialers, emptyAnnotations(len(dialers)),
 		DialerSelectionPolicy{
 			Policy:     consts.DialerSelectionPolicy_Fixed,
 			FixedIndex: fixedIndex,
@@ -101,7 +110,7 @@ func TestDialerGroup_Select_MinLastLatency(t *testing.T) {
 		newDirectDialer(option, false),
 		newDirectDialer(option, false),
 	}
-	g := NewDialerGroup(option, "test-group", dialers, []*dialer.Annotation{{}},
+	g := NewDialerGroup(option, "test-group", dialers, emptyAnnotations(len(dialers)),
 		DialerSelectionPolicy{
 			Policy: consts.DialerSelectionPolicy_MinLastLatency,
 		}, func(alive bool, networkType *dialer.NetworkType, isInit bool) {})
@@ -166,7 +175,7 @@ func TestDialerGroup_Select_Random(t *testing.T) {
 		newDirectDialer(option, false),
 		newDirectDialer(option, false),
 	}
-	g := NewDialerGroup(option, "test-group", dialers, []*dialer.Annotation{{}},
+	g := NewDialerGroup(option, "test-group", dialers, emptyAnnotations(len(dialers)),
 		DialerSelectionPolicy{
 			Policy: consts.DialerSelectionPolicy_Random,
 		}, func(alive bool, networkType *dialer.NetworkType, isInit bool) {})
@@ -206,7 +215,7 @@ func TestDialerGroup_SetAlive(t *testing.T) {
 		newDirectDialer(option, false),
 		newDirectDialer(option, false),
 	}
-	g := NewDialerGroup(option, "test-group", dialers, []*dialer.Annotation{{}},
+	g := NewDialerGroup(option, "test-group", dialers, emptyAnnotations(len(dialers)),
 		DialerSelectionPolicy{
 			Policy: consts.DialerSelectionPolicy_Random,
 		}, func(alive bool, networkType *dialer.NetworkType, isInit bool) {})
@@ -233,5 +242,118 @@ func TestDialerGroup_SetAlive(t *testing.T) {
 	}
 	if count[zeroTarget] != 0 {
 		t.Fail()
+	}
+}
+
+func TestDialerGroup_Select_Random_WithAddWeight(t *testing.T) {
+	option := &dialer.GlobalOption{
+		Log:               log,
+		TcpCheckOptionRaw: dialer.TcpCheckOptionRaw{Raw: []string{testTcpCheckUrl}},
+		CheckDnsOptionRaw: dialer.CheckDnsOptionRaw{Raw: []string{testUdpCheckDns}},
+		CheckInterval:     15 * time.Second,
+	}
+	dialers := []*dialer.Dialer{
+		newDirectDialer(option, false),
+		newDirectDialer(option, false),
+		newDirectDialer(option, false),
+	}
+	annotations := []*dialer.Annotation{
+		{},
+		{AddWeight: 9},
+		{},
+	}
+	g := NewDialerGroup(option, "test-group", dialers, annotations,
+		DialerSelectionPolicy{
+			Policy: consts.DialerSelectionPolicy_Random,
+		}, func(alive bool, networkType *dialer.NetworkType, isInit bool) {})
+	count := make([]int, len(dialers))
+	for i := 0; i < 1200; i++ {
+		d, _, err := g.Select(TestNetworkType, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for j, dd := range dialers {
+			if d == dd {
+				count[j]++
+				break
+			}
+		}
+	}
+	if count[1] <= count[0] || count[1] <= count[2] {
+		t.Fatalf("weighted dialer was not preferred enough: counts=%v", count)
+	}
+}
+
+func TestDialerGroup_Select_Random_WithAddWeight_IgnoreDeadDialer(t *testing.T) {
+	option := &dialer.GlobalOption{
+		Log:               log,
+		TcpCheckOptionRaw: dialer.TcpCheckOptionRaw{Raw: []string{testTcpCheckUrl}},
+		CheckDnsOptionRaw: dialer.CheckDnsOptionRaw{Raw: []string{testUdpCheckDns}},
+		CheckInterval:     15 * time.Second,
+	}
+	dialers := []*dialer.Dialer{
+		newDirectDialer(option, false),
+		newDirectDialer(option, false),
+		newDirectDialer(option, false),
+	}
+	annotations := []*dialer.Annotation{
+		{},
+		{AddWeight: 20},
+		{},
+	}
+	g := NewDialerGroup(option, "test-group", dialers, annotations,
+		DialerSelectionPolicy{
+			Policy: consts.DialerSelectionPolicy_Random,
+		}, func(alive bool, networkType *dialer.NetworkType, isInit bool) {})
+	g.MustGetAliveDialerSet(TestNetworkType).NotifyLatencyChange(dialers[1], false)
+	for i := 0; i < 300; i++ {
+		d, _, err := g.Select(TestNetworkType, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if d == dialers[1] {
+			t.Fatal("dead weighted dialer should never be selected")
+		}
+	}
+}
+
+func TestDialerGroup_Select_Random_WithLargeAddWeight(t *testing.T) {
+	option := &dialer.GlobalOption{
+		Log:               log,
+		TcpCheckOptionRaw: dialer.TcpCheckOptionRaw{Raw: []string{testTcpCheckUrl}},
+		CheckDnsOptionRaw: dialer.CheckDnsOptionRaw{Raw: []string{testUdpCheckDns}},
+		CheckInterval:     15 * time.Second,
+	}
+	dialers := []*dialer.Dialer{
+		newDirectDialer(option, false),
+		newDirectDialer(option, false),
+		newDirectDialer(option, false),
+	}
+	annotations := []*dialer.Annotation{
+		{AddWeight: math.MaxInt64 - 1},
+		{AddWeight: math.MaxInt64 - 1},
+		{AddWeight: math.MaxInt64 - 1},
+	}
+	g := NewDialerGroup(option, "test-group", dialers, annotations,
+		DialerSelectionPolicy{
+			Policy: consts.DialerSelectionPolicy_Random,
+		}, func(alive bool, networkType *dialer.NetworkType, isInit bool) {})
+	count := make([]int, len(dialers))
+	for i := 0; i < 300; i++ {
+		d, _, err := g.Select(TestNetworkType, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for j, dd := range dialers {
+			if d == dd {
+				count[j]++
+				break
+			}
+		}
+	}
+	for i, c := range count {
+		if c == 0 {
+			t.Fatalf("dialer %d was never selected: counts=%v", i, count)
+		}
 	}
 }

--- a/config/desc.go
+++ b/config/desc.go
@@ -76,10 +76,14 @@ var GroupDesc = Desc{
 	"filter": `Filter nodes from the global node pool defined by the "subscription" and "node" sections.
 Available functions: name, subtag. Not operator is supported.
 Available keys in name function: keyword, regex. No key indicates full match.
-Available keys in subtag function: regex. No key indicates full match.`,
+Available keys in subtag function: regex. No key indicates full match.
+Filters are checked in order. For a given node, only the first matching filter line applies; annotations from later matching filter lines are ignored.
+Available annotations: add_latency, add_weight.
+add_latency: Add a latency offset for latency-based policies.
+add_weight: Add a weight offset for random policy. The default weight is 1, so add_weight: 4 means effective weight 5.`,
 	"policy": `Dialer selection policy. For each new connection, select a node as dialer from group by this policy.
 Available values: random, fixed, min, min_avg10, min_moving_avg.
-random: Select randomly.
+random: Select randomly among alive nodes. Use filter annotation add_weight to bias the selection.
 fixed: Select the fixed node. Connectivity check will be disabled.
 min: Select node by the latency of last check.
 min_avg10: Select node by the average of latencies of last 10 checks.

--- a/config/marshal.go
+++ b/config/marshal.go
@@ -150,8 +150,8 @@ func (m *Marshaller) marshalLeaf(key string, from reflect.Value, depth int) (err
 		}
 		switch from.Index(0).Interface().(type) {
 		case fmt.Stringer, string,
-			uint8, uint16, uint32, uint64,
-			int8, int16, int32, int64,
+			uint, uint8, uint16, uint32, uint64,
+			int, int8, int16, int32, int64,
 			float32, float64,
 			bool:
 			var vals []string
@@ -178,8 +178,8 @@ func (m *Marshaller) marshalLeaf(key string, from reflect.Value, depth int) (err
 	default:
 		switch val := from.Interface().(type) {
 		case fmt.Stringer, string,
-			uint8, uint16, uint32, uint64,
-			int8, int16, int32, int64,
+			uint, uint8, uint16, uint32, uint64,
+			int, int8, int16, int32, int64,
 			float32, float64,
 			bool:
 			m.writeLine(depth, key+":"+strconv.Quote(fmt.Sprintf("%v", val)))
@@ -191,6 +191,51 @@ func (m *Marshaller) marshalLeaf(key string, from reflect.Value, depth int) (err
 	}
 	return nil
 }
+
+func (m *Marshaller) marshalFunctions(functions []*config_parser.Function) string {
+	var vals []string
+	for _, f := range functions {
+		vals = append(vals, f.String(false, true, false))
+	}
+	return strings.Join(vals, " && ")
+}
+
+func (m *Marshaller) marshalAnnotation(params []*config_parser.Param) string {
+	var vals []string
+	for _, p := range params {
+		vals = append(vals, p.String(false, true))
+	}
+	return strings.Join(vals, ", ")
+}
+
+func (m *Marshaller) marshalAnnotatedField(key string, from reflect.Value, annotation reflect.Value, depth int) error {
+	if from.Kind() != reflect.Slice || annotation.Kind() != reflect.Slice {
+		return fmt.Errorf("annotated field %v must be a slice", key)
+	}
+	if from.Len() != annotation.Len() {
+		return fmt.Errorf("annotated field %v has mismatched lengths: %v != %v", key, from.Len(), annotation.Len())
+	}
+	for i := 0; i < from.Len(); i++ {
+		item := from.Index(i).Interface()
+		functions, ok := item.([]*config_parser.Function)
+		if !ok {
+			return fmt.Errorf("unsupported annotated field type: %T", item)
+		}
+		line := key + ": " + m.marshalFunctions(functions)
+		if !annotation.Index(i).IsNil() {
+			params, ok := annotation.Index(i).Interface().([]*config_parser.Param)
+			if !ok {
+				return fmt.Errorf("unsupported annotation field type: %T", annotation.Index(i).Interface())
+			}
+			if len(params) > 0 {
+				line += " [" + m.marshalAnnotation(params) + "]"
+			}
+		}
+		m.writeLine(depth, line)
+	}
+	return nil
+}
+
 func (m *Marshaller) marshalParam(from reflect.Value, depth int) (err error) {
 	if from.Kind() != reflect.Struct {
 		return fmt.Errorf("marshalParam can only marshal struct")
@@ -206,21 +251,30 @@ func (m *Marshaller) marshalParam(from reflect.Value, depth int) (err error) {
 		if !ok {
 			return fmt.Errorf("tag mapstructure is required")
 		}
+		if field.Type() == reflect.TypeOf([]*config_parser.RoutingRule{}) {
+			rules := field.Interface().([]*config_parser.RoutingRule)
+			for _, r := range rules {
+				m.writeLine(depth, r.String(false, true, true))
+			}
+			continue
+		}
 		// Reserved field.
 		if key == "_" {
 			switch structField.Name {
 			case "Name":
-			case "Rules":
-				// Expand.
-				rules, ok := field.Interface().([]*config_parser.RoutingRule)
-				if !ok {
-					return fmt.Errorf("unexpected Rules type: %v", field.Type())
-				}
-				for _, r := range rules {
-					m.writeLine(depth, r.String(false, true, true))
-				}
+			case "FilterAnnotation":
+			case "PolicyAnnotation":
+				// Ignore companion/reserved fields.
 			default:
 				return fmt.Errorf("unknown reserved field: %v", structField.Name)
+			}
+			continue
+		}
+
+		annotationSF, annotatable := typ.FieldByName(structField.Name + "Annotation")
+		if annotatable && annotationSF.Tag.Get("mapstructure") == "_" {
+			if err = m.marshalAnnotatedField(key, field, from.FieldByName(annotationSF.Name), depth); err != nil {
+				return err
 			}
 			continue
 		}

--- a/example.dae
+++ b/example.dae
@@ -270,12 +270,23 @@ group {
         #filter: name(node1, node2)
 
         # Filter nodes and give a fixed latency offset to archive latency-based failover.
+        # Filter lines are checked in order. If one node matches multiple filter lines,
+        # only the first matching line applies; later annotations are ignored.
+        # For example, if one node matches both `name(US_node) [add_latency: -500ms]`
+        # and `name(premium) [add_latency: 1000ms]`, only the first matching line applies.
         # In this example, there is bigger possibility to choose US node even if original latency of US node is higher.
         filter: name(HK_node)
         filter: name(US_node) [add_latency: -500ms]
 
         # Select the node with min average of the last 10 latencies from the group for every connection.
         policy: min_avg10
+    }
+
+    weighted_random {
+        # add_weight biases the random policy on top of the default weight 1.
+        filter: name(HK_node)
+        filter: name(US_node) [add_weight: 4]
+        policy: random
     }
 
     steam {


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

This change adds weighted random selection to proxy groups without introducing a new policy name.

Previously, `policy: random` always selected uniformly from alive nodes. This made it impossible to bias random selection toward preferred nodes while still keeping random behavior. This patch adds `add_weight` as a filter annotation, similar to the existing `add_latency` annotation, so users can write configurations like:

```dae
filter: name(US_node) [add_weight: 4]
policy: random
```

The change also fixes related edge cases discovered during implementation and review:

- zero-valued first annotations such as `add_latency: 0s` and `add_weight: 0`
- overflow around `1 + add_weight`
- aggregate overflow when selecting from groups with very large effective weights

In addition, it updates config marshal round-trip behavior so annotated `filter:` lines are preserved, and documents the actual first-match filter annotation semantics in the config description and example config.

Finally, it optimizes the weighted-random runtime path:

- equal-weight groups now use an O(1) fast path again
- normal weighted groups use integer roulette selection when safe
- only extreme overflow cases fall back to the exponential-race path

### Checklist

- [x] The Pull Request has been fully tested
- [x] There's an entry in the CHANGELOGS
- [x] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- Implement weighted random proxy-group selection via `add_weight` filter annotations
- Preserve annotated `filter:` lines during config marshal / round-trip
- Document first-match filter annotation semantics and weighted random usage in config docs and example config
- Fix zero-valued first-annotation handling and weight overflow edge cases
- Optimize weighted random selection with equal-weight fast path and safe integer weighted selection
- Add regression tests and performance benchmarks for weighted random selection

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->
N/A

### Test Result

```bash
go test ./component/outbound/dialer -run 'TestNewAnnotation_|TestNewAliveDialerSet_AddWeightAcceptsLargestSafeEffectiveWeight|TestAliveDialerSet_GetRand_WithLargeAggregateWeights'

go test ./component/outbound -run 'TestDialerGroup_Select_Random|TestDialerGroup_SetAlive|TestDialerGroup_Select_Random_WithAddWeight|TestDialerGroup_Select_Random_WithAddWeight_IgnoreDeadDialer|TestDialerGroup_Select_Random_WithLargeAddWeight'

go test ./config -run 'TestMarshal'
```

Output:
```
ok      github.com/daeuniverse/dae/component/outbound/dialer    (cached)
ok      github.com/daeuniverse/dae/component/outbound   (cached)
ok      github.com/daeuniverse/dae/config       (cached)
```

Benchmark coverage added:

```bash
go test -run '^$' -bench '^BenchmarkAliveDialerSet_GetRand$' -benchmem -cpu=1 ./component/outbound/dialer
perf stat -e cycles -- /tmp/alive_dialer_bench.test ...
```

Measured scenarios include:

- `default_weights`
- `partial_add_weight`
- sizes: `10 / 100 / 1000 / 10000 / 100000`
- comparison against old `fastrand`-style uniform selection baseline

<!--- Attach test result here. -->

Output:
```
goos: linux
goarch: amd64
pkg: github.com/daeuniverse/dae/component/outbound/dialer
cpu: AMD Ryzen 7 7840HS w/ Radeon 780M Graphics
BenchmarkAliveDialerSet_GetRand/default_weights/weighted/10             100000000               10.84 ns/op            0 B/op          0 allocs/op
BenchmarkAliveDialerSet_GetRand/default_weights/fastrand/10             100000000               10.38 ns/op            0 B/op          0 allocs/op
BenchmarkAliveDialerSet_GetRand/default_weights/weighted/100            100000000               10.30 ns/op            0 B/op          0 allocs/op
BenchmarkAliveDialerSet_GetRand/default_weights/fastrand/100            100000000               10.45 ns/op            0 B/op          0 allocs/op
BenchmarkAliveDialerSet_GetRand/default_weights/weighted/1000           100000000               10.29 ns/op            0 B/op          0 allocs/op
BenchmarkAliveDialerSet_GetRand/default_weights/fastrand/1000           100000000               10.32 ns/op            0 B/op          0 allocs/op
BenchmarkAliveDialerSet_GetRand/default_weights/weighted/10000          112218357               10.88 ns/op            0 B/op          0 allocs/op
BenchmarkAliveDialerSet_GetRand/default_weights/fastrand/10000          108281468               10.77 ns/op            0 B/op          0 allocs/op
BenchmarkAliveDialerSet_GetRand/default_weights/weighted/100000         100000000               10.93 ns/op            0 B/op          0 allocs/op
BenchmarkAliveDialerSet_GetRand/default_weights/fastrand/100000         100000000               10.96 ns/op            0 B/op          0 allocs/op
BenchmarkAliveDialerSet_GetRand/partial_add_weight/weighted/10          11104996               106.4 ns/op             0 B/op          0 allocs/op
BenchmarkAliveDialerSet_GetRand/partial_add_weight/fastrand/10          100000000               10.35 ns/op            0 B/op          0 allocs/op
BenchmarkAliveDialerSet_GetRand/partial_add_weight/weighted/100          1260328               946.1 ns/op             0 B/op          0 allocs/op
BenchmarkAliveDialerSet_GetRand/partial_add_weight/fastrand/100         100000000               10.45 ns/op            0 B/op          0 allocs/op
BenchmarkAliveDialerSet_GetRand/partial_add_weight/weighted/1000          116056             10180 ns/op               0 B/op          0 allocs/op
BenchmarkAliveDialerSet_GetRand/partial_add_weight/fastrand/1000        100000000               10.37 ns/op            0 B/op          0 allocs/op
BenchmarkAliveDialerSet_GetRand/partial_add_weight/weighted/10000          10000            109467 ns/op               0 B/op          0 allocs/op
BenchmarkAliveDialerSet_GetRand/partial_add_weight/fastrand/10000       111713031               10.61 ns/op            0 B/op          0 allocs/op
BenchmarkAliveDialerSet_GetRand/partial_add_weight/weighted/100000           780           1593360 ns/op               0 B/op          0 allocs/op
BenchmarkAliveDialerSet_GetRand/partial_add_weight/fastrand/100000      100000000               11.16 ns/op            0 B/op          0 allocs/op
PASS
ok      github.com/daeuniverse/dae/component/outbound/dialer    26.385s
PASS

 Performance counter stats for '/tmp/alive_dialer_bench.test ../..':

         7,493,714      cycles

       0.002839727 seconds time elapsed

       0.001719000 seconds user
       0.001741000 seconds sys
```

Under the original configuration, there was no performance degradation. Under the weighted random configuration, the corresponding group's node selection time for establishing new inbound connections degraded from O(1) to O(n). However, for a scale of no more than a few thousand nodes with dozens of inbound connections per second, the performance impact was not significant.