### PR TITLE
feat(control): add runtime traffic metrics and node latency probing

### DIFF
--- a/component/outbound/dialer/block.go
+++ b/component/outbound/dialer/block.go
@@ -15,5 +15,6 @@ func NewBlockDialer(option *GlobalOption, dialCallback func()) (netproxy.Dialer,
 	return d, &Property{
 		Property:        *_p,
 		SubscriptionTag: "",
+		Link:            "",
 	}
 }

--- a/component/outbound/dialer/dialer.go
+++ b/component/outbound/dialer/dialer.go
@@ -59,6 +59,7 @@ type InstanceOption struct {
 type Property struct {
 	D.Property
 	SubscriptionTag string
+	Link            string
 }
 
 type AliveDialerSetSet map[*AliveDialerSet]int

--- a/component/outbound/dialer/direct.go
+++ b/component/outbound/dialer/direct.go
@@ -15,5 +15,6 @@ func NewDirectDialer(option *GlobalOption, fullcone bool) (netproxy.Dialer, *Pro
 	return d, &Property{
 		Property:        *_p,
 		SubscriptionTag: "",
+		Link:            "",
 	}
 }

--- a/component/outbound/dialer/latency_probe.go
+++ b/component/outbound/dialer/latency_probe.go
@@ -1,0 +1,131 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2025, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package dialer
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/daeuniverse/dae/common/consts"
+	"github.com/daeuniverse/outbound/netproxy"
+)
+
+type LatencyProbeResult struct {
+	Alive     bool
+	Latency   time.Duration
+	Message   string
+	CheckedAt time.Time
+}
+
+func (d *Dialer) ProbeLatency() (*LatencyProbeResult, error) {
+	checkOptions := d.latencyProbeCheckOptions()
+	var (
+		bestLatency time.Duration
+		hasLatency  bool
+		lastErr     error
+	)
+
+	for _, opt := range checkOptions {
+		ok, err := d.Check(opt)
+		if err != nil {
+			lastErr = err
+		}
+		if !ok {
+			continue
+		}
+
+		latency, hasLastLatency := d.MustGetLatencies10(opt.networkType).LastLatency()
+		if !hasLastLatency {
+			continue
+		}
+		if !hasLatency || latency < bestLatency {
+			bestLatency = latency
+			hasLatency = true
+		}
+	}
+
+	result := &LatencyProbeResult{
+		Alive:     hasLatency,
+		CheckedAt: time.Now(),
+	}
+	if hasLatency {
+		result.Latency = bestLatency
+		return result, nil
+	}
+
+	if lastErr != nil {
+		result.Message = lastErr.Error()
+		return result, nil
+	}
+
+	result.Message = "no latency result"
+	return result, nil
+}
+
+func (d *Dialer) latencyProbeCheckOptions() []*CheckOption {
+	return []*CheckOption{
+		{
+			networkType: &NetworkType{
+				L4Proto:   consts.L4ProtoStr_TCP,
+				IpVersion: consts.IpVersionStr_4,
+				IsDns:     false,
+			},
+			CheckFunc: func(ctx context.Context, _ *NetworkType) (bool, error) {
+				opt, err := d.TcpCheckOptionRaw.Option()
+				if err != nil {
+					return false, err
+				}
+				if !opt.Ip4.IsValid() {
+					return false, nil
+				}
+				var tcpSomark uint32
+				var mptcp bool
+				if network, err := netproxy.ParseMagicNetwork(d.TcpCheckOptionRaw.ResolverNetwork); err == nil {
+					tcpSomark = network.Mark
+					mptcp = network.Mptcp
+				}
+				return d.HttpCheck(ctx, opt.Url, opt.Ip4, opt.Method, tcpSomark, mptcp)
+			},
+		},
+		{
+			networkType: &NetworkType{
+				L4Proto:   consts.L4ProtoStr_TCP,
+				IpVersion: consts.IpVersionStr_6,
+				IsDns:     false,
+			},
+			CheckFunc: func(ctx context.Context, _ *NetworkType) (bool, error) {
+				opt, err := d.TcpCheckOptionRaw.Option()
+				if err != nil {
+					return false, err
+				}
+				if !opt.Ip6.IsValid() {
+					return false, nil
+				}
+				var tcpSomark uint32
+				var mptcp bool
+				if network, err := netproxy.ParseMagicNetwork(d.TcpCheckOptionRaw.ResolverNetwork); err == nil {
+					tcpSomark = network.Mark
+					mptcp = network.Mptcp
+				}
+				return d.HttpCheck(ctx, opt.Url, opt.Ip6, opt.Method, tcpSomark, mptcp)
+			},
+		},
+	}
+}
+
+func FormatLatencyMessage(result *LatencyProbeResult) string {
+	if result == nil {
+		return "unknown"
+	}
+	if result.Alive {
+		return fmt.Sprintf("%dms", result.Latency.Milliseconds())
+	}
+	if result.Message != "" {
+		return result.Message
+	}
+	return "unavailable"
+}

--- a/component/outbound/dialer/register.go
+++ b/component/outbound/dialer/register.go
@@ -18,6 +18,7 @@ func NewFromLink(gOption *GlobalOption, iOption InstanceOption, link string, sub
 	p := Property{
 		Property:        *_p,
 		SubscriptionTag: subscriptionTag,
+		Link:            link,
 	}
 	return NewDialer(d, gOption, iOption, &p), nil
 }

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -45,6 +45,14 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+type NodeLatencySnapshot struct {
+	Link      string
+	LatencyMs *int32
+	Alive     bool
+	Message   string
+	CheckedAt time.Time
+}
+
 type ControlPlane struct {
 	log *logrus.Logger
 
@@ -1013,6 +1021,37 @@ func (c *ControlPlane) ActiveTCPConnections() (n int) {
 	return n
 }
 
+func (c *ControlPlane) TriggerLatencyChecks() {
+	for _, group := range c.outbounds {
+		for _, d := range group.Dialers {
+			d.NotifyCheck()
+		}
+	}
+}
+
+func (c *ControlPlane) SnapshotNodeLatencies() []NodeLatencySnapshot {
+	latenciesByLink := make(map[string]NodeLatencySnapshot)
+	for _, group := range c.outbounds {
+		for _, d := range group.Dialers {
+			link := d.Property().Link
+			if link == "" {
+				continue
+			}
+
+			snapshot := bestNodeLatencySnapshotForDialer(d)
+			if existing, ok := latenciesByLink[link]; !ok || preferNodeLatencySnapshot(snapshot, existing) {
+				latenciesByLink[link] = snapshot
+			}
+		}
+	}
+
+	results := make([]NodeLatencySnapshot, 0, len(latenciesByLink))
+	for _, snapshot := range latenciesByLink {
+		results = append(results, snapshot)
+	}
+	return results
+}
+
 func (c *ControlPlane) Close() (err error) {
 	// Invoke defer funcs in reverse order.
 	for i := len(c.deferFuncs) - 1; i >= 0; i-- {
@@ -1027,6 +1066,62 @@ func (c *ControlPlane) Close() (err error) {
 	}
 	c.cancel()
 	return c.core.Close()
+}
+
+func bestNodeLatencySnapshotForDialer(d *dialer.Dialer) NodeLatencySnapshot {
+	snapshot := NodeLatencySnapshot{
+		Link:      d.Property().Link,
+		Alive:     false,
+		Message:   "no latency result",
+		CheckedAt: time.Time{},
+	}
+
+	checkTypes := []*dialer.NetworkType{
+		{
+			L4Proto:   consts.L4ProtoStr_TCP,
+			IpVersion: consts.IpVersionStr_4,
+			IsDns:     false,
+		},
+		{
+			L4Proto:   consts.L4ProtoStr_TCP,
+			IpVersion: consts.IpVersionStr_6,
+			IsDns:     false,
+		},
+	}
+
+	var bestLatency time.Duration
+	for _, networkType := range checkTypes {
+		latency, ok := d.MustGetLatencies10(networkType).LastLatency()
+		if !ok {
+			continue
+		}
+		if !snapshot.Alive || latency < bestLatency {
+			latencyMs := int32(latency.Milliseconds())
+			bestLatency = latency
+			snapshot.LatencyMs = &latencyMs
+			snapshot.Alive = d.MustGetAlive(networkType)
+			snapshot.Message = dialer.FormatLatencyMessage(&dialer.LatencyProbeResult{
+				Alive:   snapshot.Alive,
+				Latency: latency,
+			})
+			snapshot.CheckedAt = time.Now()
+		}
+	}
+
+	return snapshot
+}
+
+func preferNodeLatencySnapshot(next NodeLatencySnapshot, current NodeLatencySnapshot) bool {
+	if next.LatencyMs != nil && current.LatencyMs == nil {
+		return true
+	}
+	if next.LatencyMs == nil {
+		return false
+	}
+	if current.LatencyMs == nil {
+		return true
+	}
+	return *next.LatencyMs < *current.LatencyMs
 }
 
 // StopDNSListener stops the DNS listener if it's running

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -1005,6 +1005,14 @@ func (c *ControlPlane) AbortConnections() (err error) {
 	return errors.Join(errs...)
 }
 
+func (c *ControlPlane) ActiveTCPConnections() (n int) {
+	c.inConnections.Range(func(_, _ any) bool {
+		n++
+		return true
+	})
+	return n
+}
+
 func (c *ControlPlane) Close() (err error) {
 	// Invoke defer funcs in reverse order.
 	for i := len(c.deferFuncs) - 1; i >= 0; i-- {

--- a/control/runtime_stats.go
+++ b/control/runtime_stats.go
@@ -15,6 +15,8 @@ const (
 	maxRuntimeHistorySeconds = 60 * 60
 	defaultRuntimeWindowSec  = 30 * 60
 	defaultRuntimeMaxPoints  = 180
+	runtimeBucketDuration    = 250 * time.Millisecond
+	runtimeRateWindow        = time.Second
 )
 
 type RuntimeTrafficSample struct {
@@ -34,16 +36,23 @@ type RuntimeStatsSnapshot struct {
 	Samples           []RuntimeTrafficSample
 }
 
+type runtimeBucket struct {
+	Timestamp     time.Time
+	UploadBytes   uint64
+	DownloadBytes uint64
+	Duration      time.Duration
+}
+
 type runtimeStats struct {
 	mu sync.Mutex
 
-	currentSecond  int64
-	currentUpload  uint64
-	currentDownload uint64
+	currentBucketStart time.Time
+	currentUploadBytes uint64
+	currentDownloadBytes uint64
 
 	uploadTotal   uint64
 	downloadTotal uint64
-	history       []RuntimeTrafficSample
+	history       []runtimeBucket
 }
 
 var globalRuntimeStats = &runtimeStats{}
@@ -70,9 +79,9 @@ func (s *runtimeStats) record(upload uint64, download uint64, now time.Time) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.advanceLocked(now.Unix())
-	s.currentUpload += upload
-	s.currentDownload += download
+	s.advanceLocked(bucketStart(now))
+	s.currentUploadBytes += upload
+	s.currentDownloadBytes += download
 	s.uploadTotal += upload
 	s.downloadTotal += download
 }
@@ -88,59 +97,66 @@ func (s *runtimeStats) snapshot(activeConnections int, udpSessions int, windowSe
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	nowSec := now.Unix()
-	s.advanceLocked(nowSec)
+	nowBucketStart := bucketStart(now)
+	s.advanceLocked(nowBucketStart)
 
-	startSec := nowSec - int64(windowSec) + 1
-	if startSec < 0 {
-		startSec = 0
-	}
+	startTime := now.Add(-time.Duration(windowSec) * time.Second)
 
-	samples := make([]RuntimeTrafficSample, 0, len(s.history)+1)
-	for _, sample := range s.history {
-		if sample.Timestamp.Unix() >= startSec {
-			samples = append(samples, sample)
+	buckets := make([]runtimeBucket, 0, len(s.history)+1)
+	for _, bucket := range s.history {
+		if !bucket.Timestamp.Before(startTime) {
+			buckets = append(buckets, bucket)
 		}
 	}
-	samples = append(samples, RuntimeTrafficSample{
-		Timestamp:    time.Unix(nowSec, 0),
-		UploadRate:   s.currentUpload,
-		DownloadRate: s.currentDownload,
+
+	currentDuration := now.Sub(s.currentBucketStart)
+	if currentDuration <= 0 {
+		currentDuration = runtimeBucketDuration
+	}
+	buckets = append(buckets, runtimeBucket{
+		Timestamp:     now,
+		UploadBytes:   s.currentUploadBytes,
+		DownloadBytes: s.currentDownloadBytes,
+		Duration:      currentDuration,
 	})
+
+	uploadRate, downloadRate := ratesFromBuckets(buckets, now, runtimeRateWindow)
 
 	return RuntimeStatsSnapshot{
 		UpdatedAt:         now,
-		UploadRate:        s.currentUpload,
-		DownloadRate:      s.currentDownload,
+		UploadRate:        uploadRate,
+		DownloadRate:      downloadRate,
 		UploadTotal:       s.uploadTotal,
 		DownloadTotal:     s.downloadTotal,
 		ActiveConnections: activeConnections,
 		UDPSessions:       udpSessions,
-		Samples:           bucketizeRuntimeSamples(samples, maxPoints),
+		Samples:           bucketizeRuntimeSamples(samplesFromBuckets(buckets), maxPoints),
 	}
 }
 
-func (s *runtimeStats) advanceLocked(targetSecond int64) {
-	if s.currentSecond == 0 {
-		s.currentSecond = targetSecond
+func (s *runtimeStats) advanceLocked(targetBucketStart time.Time) {
+	if s.currentBucketStart.IsZero() {
+		s.currentBucketStart = targetBucketStart
 		return
 	}
-	if targetSecond <= s.currentSecond {
+	if !targetBucketStart.After(s.currentBucketStart) {
 		return
 	}
 
-	for s.currentSecond < targetSecond {
-		s.history = append(s.history, RuntimeTrafficSample{
-			Timestamp:    time.Unix(s.currentSecond, 0),
-			UploadRate:   s.currentUpload,
-			DownloadRate: s.currentDownload,
+	for s.currentBucketStart.Before(targetBucketStart) {
+		s.history = append(s.history, runtimeBucket{
+			Timestamp:     s.currentBucketStart.Add(runtimeBucketDuration),
+			UploadBytes:   s.currentUploadBytes,
+			DownloadBytes: s.currentDownloadBytes,
+			Duration:      runtimeBucketDuration,
 		})
-		if len(s.history) > maxRuntimeHistorySeconds {
-			s.history = append([]RuntimeTrafficSample(nil), s.history[len(s.history)-maxRuntimeHistorySeconds:]...)
+		maxHistoryBuckets := int((time.Duration(maxRuntimeHistorySeconds) * time.Second) / runtimeBucketDuration)
+		if len(s.history) > maxHistoryBuckets {
+			s.history = append([]runtimeBucket(nil), s.history[len(s.history)-maxHistoryBuckets:]...)
 		}
-		s.currentSecond++
-		s.currentUpload = 0
-		s.currentDownload = 0
+		s.currentBucketStart = s.currentBucketStart.Add(runtimeBucketDuration)
+		s.currentUploadBytes = 0
+		s.currentDownloadBytes = 0
 	}
 }
 
@@ -179,4 +195,68 @@ func bucketizeRuntimeSamples(samples []RuntimeTrafficSample, maxPoints int) []Ru
 	}
 
 	return result
+}
+
+func bucketStart(now time.Time) time.Time {
+	return now.Truncate(runtimeBucketDuration)
+}
+
+func rateFromBytes(bytes uint64, duration time.Duration) uint64 {
+	if duration <= 0 {
+		return 0
+	}
+	return uint64(float64(bytes) * float64(time.Second) / float64(duration))
+}
+
+func samplesFromBuckets(buckets []runtimeBucket) []RuntimeTrafficSample {
+	samples := make([]RuntimeTrafficSample, 0, len(buckets))
+	for _, bucket := range buckets {
+		samples = append(samples, RuntimeTrafficSample{
+			Timestamp:    bucket.Timestamp,
+			UploadRate:   rateFromBytes(bucket.UploadBytes, bucket.Duration),
+			DownloadRate: rateFromBytes(bucket.DownloadBytes, bucket.Duration),
+		})
+	}
+	return samples
+}
+
+func ratesFromBuckets(buckets []runtimeBucket, now time.Time, window time.Duration) (uploadRate uint64, downloadRate uint64) {
+	if len(buckets) == 0 {
+		return 0, 0
+	}
+
+	windowStart := now.Add(-window)
+	var (
+		totalUpload   uint64
+		totalDownload uint64
+		totalDuration time.Duration
+	)
+
+	for _, bucket := range buckets {
+		bucketEnd := bucket.Timestamp
+		bucketStart := bucketEnd.Add(-bucket.Duration)
+		if !bucketEnd.After(windowStart) {
+			continue
+		}
+
+		effectiveStart := bucketStart
+		if effectiveStart.Before(windowStart) {
+			effectiveStart = windowStart
+		}
+		effectiveDuration := bucketEnd.Sub(effectiveStart)
+		if effectiveDuration <= 0 {
+			continue
+		}
+
+		ratio := float64(effectiveDuration) / float64(bucket.Duration)
+		totalUpload += uint64(float64(bucket.UploadBytes) * ratio)
+		totalDownload += uint64(float64(bucket.DownloadBytes) * ratio)
+		totalDuration += effectiveDuration
+	}
+
+	if totalDuration <= 0 {
+		return 0, 0
+	}
+
+	return rateFromBytes(totalUpload, totalDuration), rateFromBytes(totalDownload, totalDuration)
 }

--- a/control/runtime_stats.go
+++ b/control/runtime_stats.go
@@ -1,0 +1,182 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2025, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package control
+
+import (
+	"math"
+	"sync"
+	"time"
+)
+
+const (
+	maxRuntimeHistorySeconds = 60 * 60
+	defaultRuntimeWindowSec  = 30 * 60
+	defaultRuntimeMaxPoints  = 180
+)
+
+type RuntimeTrafficSample struct {
+	Timestamp    time.Time
+	UploadRate   uint64
+	DownloadRate uint64
+}
+
+type RuntimeStatsSnapshot struct {
+	UpdatedAt         time.Time
+	UploadRate        uint64
+	DownloadRate      uint64
+	UploadTotal       uint64
+	DownloadTotal     uint64
+	ActiveConnections int
+	UDPSessions       int
+	Samples           []RuntimeTrafficSample
+}
+
+type runtimeStats struct {
+	mu sync.Mutex
+
+	currentSecond  int64
+	currentUpload  uint64
+	currentDownload uint64
+
+	uploadTotal   uint64
+	downloadTotal uint64
+	history       []RuntimeTrafficSample
+}
+
+var globalRuntimeStats = &runtimeStats{}
+
+func RecordUploadTraffic(n int64) {
+	if n <= 0 {
+		return
+	}
+	globalRuntimeStats.record(uint64(n), 0, time.Now())
+}
+
+func RecordDownloadTraffic(n int64) {
+	if n <= 0 {
+		return
+	}
+	globalRuntimeStats.record(0, uint64(n), time.Now())
+}
+
+func SnapshotRuntimeStats(activeConnections int, udpSessions int, windowSec int, maxPoints int) RuntimeStatsSnapshot {
+	return globalRuntimeStats.snapshot(activeConnections, udpSessions, windowSec, maxPoints, time.Now())
+}
+
+func (s *runtimeStats) record(upload uint64, download uint64, now time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.advanceLocked(now.Unix())
+	s.currentUpload += upload
+	s.currentDownload += download
+	s.uploadTotal += upload
+	s.downloadTotal += download
+}
+
+func (s *runtimeStats) snapshot(activeConnections int, udpSessions int, windowSec int, maxPoints int, now time.Time) RuntimeStatsSnapshot {
+	if windowSec <= 0 {
+		windowSec = defaultRuntimeWindowSec
+	}
+	if maxPoints <= 0 {
+		maxPoints = defaultRuntimeMaxPoints
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	nowSec := now.Unix()
+	s.advanceLocked(nowSec)
+
+	startSec := nowSec - int64(windowSec) + 1
+	if startSec < 0 {
+		startSec = 0
+	}
+
+	samples := make([]RuntimeTrafficSample, 0, len(s.history)+1)
+	for _, sample := range s.history {
+		if sample.Timestamp.Unix() >= startSec {
+			samples = append(samples, sample)
+		}
+	}
+	samples = append(samples, RuntimeTrafficSample{
+		Timestamp:    time.Unix(nowSec, 0),
+		UploadRate:   s.currentUpload,
+		DownloadRate: s.currentDownload,
+	})
+
+	return RuntimeStatsSnapshot{
+		UpdatedAt:         now,
+		UploadRate:        s.currentUpload,
+		DownloadRate:      s.currentDownload,
+		UploadTotal:       s.uploadTotal,
+		DownloadTotal:     s.downloadTotal,
+		ActiveConnections: activeConnections,
+		UDPSessions:       udpSessions,
+		Samples:           bucketizeRuntimeSamples(samples, maxPoints),
+	}
+}
+
+func (s *runtimeStats) advanceLocked(targetSecond int64) {
+	if s.currentSecond == 0 {
+		s.currentSecond = targetSecond
+		return
+	}
+	if targetSecond <= s.currentSecond {
+		return
+	}
+
+	for s.currentSecond < targetSecond {
+		s.history = append(s.history, RuntimeTrafficSample{
+			Timestamp:    time.Unix(s.currentSecond, 0),
+			UploadRate:   s.currentUpload,
+			DownloadRate: s.currentDownload,
+		})
+		if len(s.history) > maxRuntimeHistorySeconds {
+			s.history = append([]RuntimeTrafficSample(nil), s.history[len(s.history)-maxRuntimeHistorySeconds:]...)
+		}
+		s.currentSecond++
+		s.currentUpload = 0
+		s.currentDownload = 0
+	}
+}
+
+func bucketizeRuntimeSamples(samples []RuntimeTrafficSample, maxPoints int) []RuntimeTrafficSample {
+	if len(samples) <= maxPoints {
+		return samples
+	}
+
+	bucketSize := int(math.Ceil(float64(len(samples)) / float64(maxPoints)))
+	result := make([]RuntimeTrafficSample, 0, maxPoints)
+
+	for start := 0; start < len(samples); start += bucketSize {
+		end := start + bucketSize
+		if end > len(samples) {
+			end = len(samples)
+		}
+		bucket := samples[start:end]
+		last := bucket[len(bucket)-1]
+
+		maxUpload := last.UploadRate
+		maxDownload := last.DownloadRate
+		for _, sample := range bucket[:len(bucket)-1] {
+			if sample.UploadRate > maxUpload {
+				maxUpload = sample.UploadRate
+			}
+			if sample.DownloadRate > maxDownload {
+				maxDownload = sample.DownloadRate
+			}
+		}
+
+		result = append(result, RuntimeTrafficSample{
+			Timestamp:    last.Timestamp,
+			UploadRate:   maxUpload,
+			DownloadRate: maxDownload,
+		})
+	}
+
+	return result
+}

--- a/control/tcp.go
+++ b/control/tcp.go
@@ -171,17 +171,32 @@ type WriteCloser interface {
 	CloseWrite() error
 }
 
+type runtimeTrafficWriter struct {
+	writer netproxy.Conn
+	record func(int64)
+}
+
+func (w *runtimeTrafficWriter) Write(p []byte) (int, error) {
+	n, err := w.writer.Write(p)
+	if n > 0 {
+		w.record(int64(n))
+	}
+	return n, err
+}
+
 func RelayTCP(lConn, rConn netproxy.Conn) (err error) {
 	eCh := make(chan error, 1)
+	uploadWriter := &runtimeTrafficWriter{writer: rConn, record: RecordUploadTraffic}
+	downloadWriter := &runtimeTrafficWriter{writer: lConn, record: RecordDownloadTraffic}
 	go func() {
-		_, e := io.Copy(rConn, lConn)
+		_, e := io.Copy(uploadWriter, lConn)
 		if rConn, ok := rConn.(WriteCloser); ok {
 			rConn.CloseWrite()
 		}
 		rConn.SetReadDeadline(time.Now().Add(10 * time.Second))
 		eCh <- e
 	}()
-	_, e := io.Copy(lConn, rConn)
+	_, e := io.Copy(downloadWriter, rConn)
 	if lConn, ok := lConn.(WriteCloser); ok {
 		lConn.CloseWrite()
 	}

--- a/control/udp.go
+++ b/control/udp.go
@@ -92,6 +92,7 @@ func (c *ControlPlane) handlePkt(lConn *net.UDPConn, data []byte, src, pktDst, r
 		if err != nil {
 			return err
 		}
+		RecordUploadTraffic(int64(len(data)))
 		return nil
 	}
 
@@ -202,7 +203,11 @@ getNew:
 		// Handler handles response packets and send it to the client.
 		Handler: func(data []byte, from netip.AddrPort) (err error) {
 			// Do not return conn-unrelated err in this func.
-			return sendPkt(c.log, data, from, realSrc, src, lConn)
+			if err = sendPkt(c.log, data, from, realSrc, src, lConn); err != nil {
+				return err
+			}
+			RecordDownloadTraffic(int64(len(data)))
+			return nil
 		},
 		NatTimeout: natTimeout,
 		GetDialOption: func() (option *DialOption, err error) {
@@ -302,6 +307,7 @@ getNew:
 		retry++
 		goto getNew
 	}
+	RecordUploadTraffic(int64(len(data)))
 
 	// Print log.
 	// Only print routing for new connection to avoid the log exploded (Quic and BT).

--- a/control/udp_endpoint_pool.go
+++ b/control/udp_endpoint_pool.go
@@ -107,6 +107,14 @@ func (p *UdpEndpointPool) Get(lAddr netip.AddrPort) (udpEndpoint *UdpEndpoint, o
 	return _ue.(*UdpEndpoint), ok
 }
 
+func (p *UdpEndpointPool) Count() (n int) {
+	p.pool.Range(func(_, _ any) bool {
+		n++
+		return true
+	})
+	return n
+}
+
 func (p *UdpEndpointPool) GetOrCreate(lAddr netip.AddrPort, createOption *UdpEndpointOptions) (udpEndpoint *UdpEndpoint, isNew bool, err error) {
 	_ue, ok := p.pool.Load(lAddr)
 begin:


### PR DESCRIPTION
## Summary

This PR adds two runtime capabilities to `dae` control plane:

- runtime traffic metrics with rolling history
- node latency probing support

It also includes a responsiveness fix for runtime traffic updates.

## What changed

- add runtime traffic statistics collection in control plane
- keep rolling runtime history instead of unbounded growth
- expose upload / download rate and total traffic related snapshots for runtime consumers
- improve runtime traffic update responsiveness
- add node latency probing support in outbound dialer / control plane
- provide control-plane access to node latency probe results

## Runtime traffic metrics

This PR introduces runtime stats tracking for live traffic observation.

Highlights:

- track upload and download activity continuously during runtime
- keep recent history in a bounded rolling window
- support current-rate style snapshots as well as accumulated totals
- avoid unbounded memory growth by trimming old buckets

## Node latency probing

This PR adds control-plane support for latency probing of configured nodes.

Highlights:

- add probing logic for outbound nodes
- expose probe results through control-plane snapshot / trigger methods
- provide a foundation for higher-layer consumers such as `dae-wing` and `daed`

## Fix included

This PR also includes a responsiveness improvement for runtime traffic updates so runtime stats react faster under active traffic.

## Why

These changes are intended to support higher-level runtime dashboards and orchestration UIs that need:

- live traffic overview
- bounded recent traffic history
- node latency measurements
- explicit probe triggering and result snapshots

## Scope

This PR only adds the runtime/control-plane capability in `dae`.

Follow-up changes in upper layers are expected separately:

- `dae-wing` will consume these capabilities and expose them via API
- `daed` will consume the API for UI presentation

## Manual verification

- [ ] start dae and confirm runtime traffic stats are updated while traffic is active
- [ ] confirm traffic history remains bounded over time
- [ ] confirm runtime totals continue accumulating during process lifetime
- [ ] trigger node latency probing and confirm results are produced
- [ ] verify no obvious regression in normal runtime behavior

## Related follow-up

This PR is intended to be consumed by follow-up `dae-wing` / `daed` changes for:

- runtime traffic overview
- node latency testing / display


Tested locally.

Manual verification completed:
- verified runtime traffic metrics update while traffic is active
- verified runtime traffic history remains bounded instead of growing unbounded
- verified runtime totals continue accumulating during process lifetime
- verified node latency probing can be triggered successfully
- verified latency probe results are available from the control plane
- verified no obvious regression in basic runtime behavior during manual testing

Please add the `tested` label if needed.
