### PR TITLE
docs: add official repository installation guide for Arch Linux

### DIFF
--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -84,7 +84,15 @@ begin; zcat /proc/config.gz || bat /boot/config "/boot/config-"(uname -r); end |
 
 ### Arch Linux / Manjaro
 
-dae has been released on [AUR](https://aur.archlinux.org/packages/dae) and [archlinuxcn](https://github.com/archlinuxcn/repo/tree/master/archlinuxcn/dae).
+You can install dae directly from the official repository.
+
+Alternatively, get the latest AVX2-optimized binary package or the latest git version from [AUR](https://aur.archlinux.org) or [archlinuxcn](https://github.com/archlinuxcn/repo).
+
+#### Official Repository
+
+```shell
+sudo pacman -S dae
+```
 
 #### AUR
 
@@ -92,12 +100,6 @@ dae has been released on [AUR](https://aur.archlinux.org/packages/dae) and [arch
 
 ```shell
 [yay/paru] -S dae-avx2-bin
-```
-
-##### Latest Release (General x86-64 or aarch64)
-
-```shell
-[yay/paru] -S dae
 ```
 
 ##### Latest Git Version
@@ -112,12 +114,6 @@ dae has been released on [AUR](https://aur.archlinux.org/packages/dae) and [arch
 
 ```shell
 sudo pacman -S dae-avx2-bin
-```
-
-##### Latest Release (General x86-64 or aarch64)
-
-```shell
-sudo pacman -S dae
 ```
 
 ##### Latest Git Version

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -80,7 +80,15 @@ begin; zcat /proc/config.gz || bat /boot/config "/boot/config-"(uname -r); end |
 
 ### Arch Linux / Manjaro
 
-dae 已发布于 [AUR](https://aur.archlinux.org/packages/dae) 和 [archlinuxcn](https://github.com/archlinuxcn/repo/tree/master/archlinuxcn/dae)，使用下述命令安装：
+直接从官方仓库安装 dae 即可。
+
+除此之外，针对 AVX2 优化的最新二进制包和最新 Git 版可从 [AUR](https://aur.archlinux.org) 或 [archlinuxcn](https://github.com/archlinuxcn/repo) 获取。
+
+#### 官方仓库
+
+```shell
+sudo pacman -S dae
+```
 
 #### AUR
 
@@ -88,12 +96,6 @@ dae 已发布于 [AUR](https://aur.archlinux.org/packages/dae) 和 [archlinuxcn]
 
 ```shell
 [yay/paru] -S dae-avx2-bin
-```
-
-##### 最新稳定版 (x86-64 或 aarch64 通用版)
-
-```shell
-[yay/paru] -S dae
 ```
 
 ##### 最新 Git 版
@@ -108,12 +110,6 @@ dae 已发布于 [AUR](https://aur.archlinux.org/packages/dae) 和 [archlinuxcn]
 
 ```shell
 sudo pacman -S dae-avx2-bin
-```
-
-##### 最新稳定版 (x86-64 或 aarch64 通用版)
-
-```shell
-sudo pacman -S dae
 ```
 
 ##### 最新 Git 版 


### PR DESCRIPTION
### Background

dae is now available in the official Arch Linux repository.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- Add an official repository installation guide for Arch Linux
- Remove the latest stable release from AUR and archlinuxcn installation

### Issue Reference

### Test Result