### PR TITLE
fix(ebpf): fix "bad CO-RE relocation" on GCC 15 by disabling unnecessary UAPI CO-RE

### DIFF
--- a/control/kern/tproxy.c
+++ b/control/kern/tproxy.c
@@ -2,6 +2,10 @@
 // Copyright (c) 2022-2025, daeuniverse Organization <dae@v2raya.org>
 
 // +build ignore
+
+// Disable implicit CO-RE from vmlinux.h to bypass bad relocation caused by GCC 15 DTE stripping UAPI structs.
+#define BPF_NO_PRESERVE_ACCESS_INDEX 1
+
 #include "headers/errno-base.h"
 #include "headers/if_ether_defs.h"
 #include "headers/pkt_cls_defs.h"


### PR DESCRIPTION
### Background

Modern GCC 15's aggressive Dead Type Elimination (DTE) completely strips unused UAPI structs (like `__sk_buff`) from the `.debug_info`. Consequently, `pahole` omits them from the target `vmlinux` BTF.

Because dae imports `vmlinux.h` (which applies a global `preserve_access_index` attribute), the `cilium/ebpf` loader is forced to seek these non-existent UAPI structs in the BTF, leading to a fatal relocation failure (`unknown#195896080` / BAD RELO).

A review of `tproxy.c` confirms that the code exclusively uses UAPI abstractions and standard RFC network headers. Because UAPI offsets are ABI-stable and natively rewritten by the BPF verifier at load time, CO-RE is functionally unnecessary for this entire compilation unit.

By defining `BPF_NO_PRESERVE_ACCESS_INDEX` before including `vmlinux.h`, instruct Clang to emit raw offsets. This perfectly bypasses the GCC 15 DWARF omission blindspot while fully preserving cross-kernel compatibility.

### Checklist

- [x] The Pull Request has been fully tested
- [x] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- [Fix] fix "bad CO-RE relocation" loading failure on modern GCC 15 / Linux 6.19+ kernels.

### Issue Reference

Closes #969

### Test Result

To rigorously prove that this fix bypasses the GCC 15 DTE bug without breaking eBPF's CO-RE capability, I performed a cross-kernel verification using the exact same compiled binary (`md5: 62900327a61e5e1166af37ec875d0620`).

<details>
<summary><b>1. Compilation & Run Env (CentOS 7 + Custom Kernel 6.19 + GCC 15) - SUCCESS</b></summary>

``` shell
[kongbin@localhost test]$ md5sum ./dae
62900327a61e5e1166af37ec875d0620  ./dae

[kongbin@localhost test]$ uname -a
Linux localhost.localdomain 6.19.0 #2 SMP PREEMPT_DYNAMIC Wed Feb 25 13:59:54 CST 2026 x86_64 x86_64 x86_64 GNU/Linux

[kongbin@localhost test]$ sudo ./dae run -c ./config.dae
...
[Apr 28 11:21:20]  INFO Building control plane and routing rules...
[Apr 28 11:21:20] TRACE setting up dae netns
[Apr 28 11:21:20]  INFO Kernel v6.19 supports Netkit, attempting to create Netkit device pair
...
``` 

</details>

<details>
<summary><b>2. Test Env (Ubuntu 24.04.1 LTS + Kernel 6.11.0-21-generic #21~24.04.1-Ubuntu) - SUCCESS</b></summary>

``` shell
test@test-VMware-Virtual-Platform:~/test$ md5sum ./dae
62900327a61e5e1166af37ec875d0620  ./dae

test@test-VMware-Virtual-Platform:~/test$ uname -a
Linux test-VMware-Virtual-Platform 6.11.0-21-generic #21~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC Mon Feb 24 16:52:15 UTC 2 x86_64 x86_64 x86_64 GNU/Linux

test@test-VMware-Virtual-Platform:~/test$ ./run.sh 
...
[Apr 28 11:20:02]  INFO Building control plane and routing rules...
[Apr 28 11:20:02] TRACE setting up dae netns
[Apr 28 11:20:02]  INFO Kernel v6.11.11 supports Netkit, attempting to create Netkit device pair
...
[Apr 28 11:20:02]  INFO Loading eBPF programs and maps into the kernel...
[Apr 28 11:20:02]  INFO The loading process takes about 120MB free memory, which will be released after loading. Insufficient memory will cause loading failure.
[Apr 28 11:20:02]  INFO Loaded eBPF programs and maps
```

</details>