### PR TITLE
feat(outbound): add weighted random proxy-group selection

### DIFF
--- a/component/outbound/dialer/alive_dialer_set.go
+++ b/component/outbound/dialer/alive_dialer_set.go
@@ -7,6 +7,8 @@ package dialer
 
 import (
 	"fmt"
+	"math"
+	randv2 "math/rand/v2"
 	"sort"
 	"strings"
 	"sync"
@@ -42,6 +44,7 @@ type AliveDialerSet struct {
 	dialerGroupName string
 	CheckTyp        *NetworkType
 	tolerance       time.Duration
+	uniformWeight   bool
 
 	aliveChangeCallback func(alive bool)
 
@@ -49,6 +52,7 @@ type AliveDialerSet struct {
 	dialerToIndex         map[*Dialer]int // *Dialer -> index in aliveEntries, -Init, or -NotAlive
 	dialerToLatency       map[*Dialer]time.Duration
 	dialerToLatencyOffset map[*Dialer]time.Duration
+	dialerToWeight        map[*Dialer]int64
 
 	// aliveEntries stores all alive dialers with their precomputed sorting latency.
 	// This is the primary data structure for hot path operations (GetMinLatency, GetRandExcluded).
@@ -74,19 +78,31 @@ func NewAliveDialerSet(
 		panic(fmt.Sprintf("unmatched annotations length: %v dialers and %v annotations", len(dialers), len(dialersAnnotations)))
 	}
 	dialerToLatencyOffset := make(map[*Dialer]time.Duration)
+	dialerToWeight := make(map[*Dialer]int64)
+	uniformWeight := true
+	var firstWeight int64
 	for i := range dialers {
 		d, a := dialers[i], dialersAnnotations[i]
 		dialerToLatencyOffset[d] = a.AddLatency
+		weight := 1 + a.AddWeight
+		dialerToWeight[d] = weight
+		if i == 0 {
+			firstWeight = weight
+		} else if weight != firstWeight {
+			uniformWeight = false
+		}
 	}
 	a := &AliveDialerSet{
 		log:                   log,
 		dialerGroupName:       dialerGroupName,
 		CheckTyp:              networkType,
 		tolerance:             tolerance,
+		uniformWeight:         uniformWeight,
 		aliveChangeCallback:   aliveChangeCallback,
 		dialerToIndex:         make(map[*Dialer]int),
 		dialerToLatency:       make(map[*Dialer]time.Duration),
 		dialerToLatencyOffset: dialerToLatencyOffset,
+		dialerToWeight:        dialerToWeight,
 		aliveEntries:          make([]aliveEntry, 0, len(dialers)),
 		selectionPolicy:       selectionPolicy,
 		minLatency: minLatency{
@@ -114,10 +130,16 @@ func (a *AliveDialerSet) GetRandExcluded(excluded *Dialer) *Dialer {
 	if len(a.aliveEntries) == 0 {
 		return nil
 	}
-	if excluded == nil {
+	if a.uniformWeight && excluded == nil {
 		return a.aliveEntries[fastrand.Intn(len(a.aliveEntries))].dialer
 	}
+	if a.uniformWeight {
+		return a.getUniformRandExcludedLocked(excluded)
+	}
+	return a.getWeightedRandExcludedLocked(excluded)
+}
 
+func (a *AliveDialerSet) getUniformRandExcludedLocked(excluded *Dialer) *Dialer {
 	var chosen *Dialer
 	var candidateCount int
 	for i := range a.aliveEntries {
@@ -133,6 +155,67 @@ func (a *AliveDialerSet) GetRandExcluded(excluded *Dialer) *Dialer {
 	}
 
 	return chosen
+}
+
+func (a *AliveDialerSet) getWeightedRandExcludedLocked(excluded *Dialer) *Dialer {
+	var totalWeight uint64
+	for i := range a.aliveEntries {
+		d := a.aliveEntries[i].dialer
+		if d == excluded {
+			continue
+		}
+		weight := a.dialerToWeight[d]
+		if weight <= 0 {
+			continue
+		}
+		if totalWeight > math.MaxUint64-uint64(weight) {
+			return a.getRandExponentialRaceLocked(excluded)
+		}
+		totalWeight += uint64(weight)
+	}
+	if totalWeight == 0 {
+		return nil
+	}
+
+	ticket := randv2.Uint64N(totalWeight)
+	var cumulative uint64
+	for i := range a.aliveEntries {
+		d := a.aliveEntries[i].dialer
+		if d == excluded {
+			continue
+		}
+		weight := a.dialerToWeight[d]
+		if weight <= 0 {
+			continue
+		}
+		cumulative += uint64(weight)
+		if ticket < cumulative {
+			return d
+		}
+	}
+	return a.getRandExponentialRaceLocked(excluded)
+}
+
+func (a *AliveDialerSet) getRandExponentialRaceLocked(excluded *Dialer) *Dialer {
+	var selected *Dialer
+	bestScore := math.Inf(1)
+	for i := range a.aliveEntries {
+		d := a.aliveEntries[i].dialer
+		if d == excluded {
+			continue
+		}
+		weight := a.dialerToWeight[d]
+		if weight <= 0 {
+			continue
+		}
+		u := 1 - randv2.Float64()
+		score := -math.Log(u) / float64(weight)
+		if score < bestScore {
+			bestScore = score
+			selected = d
+		}
+	}
+	return selected
 }
 
 func (a *AliveDialerSet) Len() int {

--- a/component/outbound/dialer/alive_dialer_set_test.go
+++ b/component/outbound/dialer/alive_dialer_set_test.go
@@ -7,6 +7,7 @@ package dialer
 
 import (
 	"fmt"
+	"math"
 	"sync"
 	"testing"
 
@@ -68,5 +69,113 @@ func TestAliveDialerSet_GetRandExcludedConcurrent(t *testing.T) {
 
 	for err := range errCh {
 		t.Fatal(err)
+	}
+}
+
+func TestAliveDialerSet_GetRandExcludedWithAddWeight(t *testing.T) {
+	networkType := newTestNetworkType()
+	dialers := []*Dialer{
+		newNamedTestDialer(t, "dialer-1"),
+		newNamedTestDialer(t, "dialer-2"),
+		newNamedTestDialer(t, "dialer-3"),
+	}
+	set := NewAliveDialerSet(
+		dialers[0].Log,
+		"test-group",
+		networkType,
+		0,
+		consts.DialerSelectionPolicy_Random,
+		dialers,
+		[]*Annotation{{}, {AddWeight: 99}, {}},
+		func(bool) {},
+		true,
+	)
+
+	count := make([]int, len(dialers))
+	for range 500 {
+		selected := set.GetRandExcluded(nil)
+		if selected == nil {
+			t.Fatal("expected a dialer, got nil")
+		}
+		for i, d := range dialers {
+			if selected == d {
+				count[i]++
+				break
+			}
+		}
+	}
+	if count[1] <= count[0] || count[1] <= count[2] {
+		t.Fatalf("weighted dialer was not preferred enough: counts=%v", count)
+	}
+}
+
+func TestAliveDialerSet_GetRandExcludedWithAddWeightSkipsExcluded(t *testing.T) {
+	networkType := newTestNetworkType()
+	dialers := []*Dialer{
+		newNamedTestDialer(t, "dialer-1"),
+		newNamedTestDialer(t, "dialer-2"),
+		newNamedTestDialer(t, "dialer-3"),
+	}
+	set := NewAliveDialerSet(
+		dialers[0].Log,
+		"test-group",
+		networkType,
+		0,
+		consts.DialerSelectionPolicy_Random,
+		dialers,
+		[]*Annotation{{}, {AddWeight: 99}, {}},
+		func(bool) {},
+		true,
+	)
+
+	for range 100 {
+		selected := set.GetRandExcluded(dialers[1])
+		if selected == nil {
+			t.Fatal("expected a dialer, got nil")
+		}
+		if selected == dialers[1] {
+			t.Fatal("excluded weighted dialer should never be selected")
+		}
+	}
+}
+
+func TestAliveDialerSet_GetRandExcludedWithLargeAggregateWeights(t *testing.T) {
+	dialers := []*Dialer{{}, {}, {}}
+	annotations := []*Annotation{
+		{AddWeight: math.MaxInt64 - 1},
+		{AddWeight: math.MaxInt64 - 1},
+		{AddWeight: math.MaxInt64 - 1},
+	}
+	set := NewAliveDialerSet(
+		nil,
+		"test-group",
+		nil,
+		0,
+		consts.DialerSelectionPolicy_Random,
+		dialers,
+		annotations,
+		func(bool) {},
+		true,
+	)
+	count := make([]int, len(dialers))
+	for range 300 {
+		d := set.GetRandExcluded(nil)
+		if d == nil {
+			t.Fatal("expected a dialer, got nil")
+		}
+		for j, dd := range dialers {
+			if d == dd {
+				count[j]++
+				break
+			}
+		}
+	}
+	for i, c := range count {
+		if c == 0 {
+			t.Fatalf("dialer %d was never selected: counts=%v", i, count)
+		}
+	}
+	if got := set.dialerToWeight[dialers[0]]; got != math.MaxInt64 {
+		t.Fatalf("unexpected effective weight: %v", got)
 	}
 }

--- a/component/outbound/dialer/annotation.go
+++ b/component/outbound/dialer/annotation.go
@@ -46,10 +46,10 @@ func NewAnnotation(annotation []*config_parser.Param) (*Annotation, error) {
 				return nil, fmt.Errorf("incorrect weight format: %w", err)
 			}
 			if weight < 0 {
-				return nil, fmt.Errorf("incorrect weight value: effective weight must be positive")
+				return nil, fmt.Errorf("incorrect weight value: add_weight must be >= 0 (effective weight is 1 + add_weight, so it must be positive)")
 			}
 			if weight > maxAddWeight {
-				return nil, fmt.Errorf("incorrect weight value: effective weight overflows int64")
+				return nil, fmt.Errorf("incorrect weight value: add_weight must be <= %d (effective weight is 1 + add_weight, so larger values overflow int64)", maxAddWeight)
 			}
 			// Only the first setting is valid.
 			if !addWeightSet {

--- a/component/outbound/dialer/annotation.go
+++ b/component/outbound/dialer/annotation.go
@@ -7,6 +7,7 @@ package dialer
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/daeuniverse/dae/pkg/config_parser"
@@ -14,14 +15,19 @@ import (
 
 const (
 	AnnotationKey_AddLatency = "add_latency"
+	AnnotationKey_AddWeight  = "add_weight"
+	maxAddWeight             = int64(^uint64(0)>>1) - 1
 )
 
 type Annotation struct {
 	AddLatency time.Duration
+	AddWeight  int64
 }
 
 func NewAnnotation(annotation []*config_parser.Param) (*Annotation, error) {
 	var anno Annotation
+	var addLatencySet bool
+	var addWeightSet bool
 	for _, param := range annotation {
 		switch param.Key {
 		case AnnotationKey_AddLatency:
@@ -30,8 +36,25 @@ func NewAnnotation(annotation []*config_parser.Param) (*Annotation, error) {
 				return nil, fmt.Errorf("incorrect latency format: %w", err)
 			}
 			// Only the first setting is valid.
-			if anno.AddLatency == 0 {
+			if !addLatencySet {
 				anno.AddLatency = latency
+				addLatencySet = true
+			}
+		case AnnotationKey_AddWeight:
+			weight, err := strconv.ParseInt(param.Val, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("incorrect weight format: %w", err)
+			}
+			if weight < 0 {
+				return nil, fmt.Errorf("incorrect weight value: effective weight must be positive")
+			}
+			if weight > maxAddWeight {
+				return nil, fmt.Errorf("incorrect weight value: effective weight overflows int64")
+			}
+			// Only the first setting is valid.
+			if !addWeightSet {
+				anno.AddWeight = weight
+				addWeightSet = true
 			}
 		default:
 			return nil, fmt.Errorf("unknown filter annotation: %v", param.Key)

--- a/component/outbound/dialer/annotation_test.go
+++ b/component/outbound/dialer/annotation_test.go
@@ -1,0 +1,129 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2025, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package dialer
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/daeuniverse/dae/common/consts"
+	"github.com/daeuniverse/dae/pkg/config_parser"
+)
+
+func TestNewAnnotation_AddLatencyFirstSettingWins(t *testing.T) {
+	annotation, err := NewAnnotation([]*config_parser.Param{
+		{Key: AnnotationKey_AddLatency, Val: "5s"},
+		{Key: AnnotationKey_AddLatency, Val: "9s"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if annotation.AddLatency != 5*time.Second {
+		t.Fatalf("unexpected add_latency: %v", annotation.AddLatency)
+	}
+}
+
+func TestNewAnnotation_AddLatencyFirstSettingWinsWhenFirstIsZero(t *testing.T) {
+	annotation, err := NewAnnotation([]*config_parser.Param{
+		{Key: AnnotationKey_AddLatency, Val: "0s"},
+		{Key: AnnotationKey_AddLatency, Val: "5s"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if annotation.AddLatency != 0 {
+		t.Fatalf("unexpected add_latency: %v", annotation.AddLatency)
+	}
+}
+
+func TestNewAnnotation_AddWeight(t *testing.T) {
+	annotation, err := NewAnnotation([]*config_parser.Param{{Key: AnnotationKey_AddWeight, Val: "3"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if annotation.AddWeight != 3 {
+		t.Fatalf("unexpected add_weight: %v", annotation.AddWeight)
+	}
+}
+
+func TestNewAnnotation_AddWeightRejectsNonPositiveEffectiveWeight(t *testing.T) {
+	for _, val := range []string{"-1", "-2"} {
+		_, err := NewAnnotation([]*config_parser.Param{{Key: AnnotationKey_AddWeight, Val: val}})
+		if err == nil {
+			t.Fatalf("expected add_weight=%s to fail", val)
+		}
+	}
+}
+
+func TestNewAnnotation_AddWeightRejectsInvalidNumber(t *testing.T) {
+	_, err := NewAnnotation([]*config_parser.Param{{Key: AnnotationKey_AddWeight, Val: "abc"}})
+	if err == nil {
+		t.Fatal("expected invalid weight to fail")
+	}
+}
+
+func TestNewAnnotation_AddWeightRejectsOverflowingValue(t *testing.T) {
+	_, err := NewAnnotation([]*config_parser.Param{{Key: AnnotationKey_AddWeight, Val: "9223372036854775807"}})
+	if err == nil {
+		t.Fatal("expected overflowing weight to fail")
+	}
+}
+
+func TestNewAnnotation_AddWeightAcceptsLargestSafeValue(t *testing.T) {
+	annotation, err := NewAnnotation([]*config_parser.Param{{Key: AnnotationKey_AddWeight, Val: "9223372036854775806"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if annotation.AddWeight != math.MaxInt64-1 {
+		t.Fatalf("unexpected add_weight: %v", annotation.AddWeight)
+	}
+}
+
+func TestNewAliveDialerSet_AddWeightAcceptsLargestSafeEffectiveWeight(t *testing.T) {
+	dialers := []*Dialer{{}}
+	annotations := []*Annotation{{AddWeight: math.MaxInt64 - 1}}
+	set := NewAliveDialerSet(
+		nil,
+		"test-group",
+		nil,
+		0,
+		consts.DialerSelectionPolicy_Random,
+		dialers,
+		annotations,
+		func(bool) {},
+		false,
+	)
+	if got := set.dialerToWeight[dialers[0]]; got != math.MaxInt64 {
+		t.Fatalf("unexpected effective weight: %v", got)
+	}
+}
+
+func TestNewAnnotation_AddWeightFirstSettingWins(t *testing.T) {
+	annotation, err := NewAnnotation([]*config_parser.Param{
+		{Key: AnnotationKey_AddWeight, Val: "5"},
+		{Key: AnnotationKey_AddWeight, Val: "9"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if annotation.AddWeight != 5 {
+		t.Fatalf("unexpected add_weight: %v", annotation.AddWeight)
+	}
+}
+
+func TestNewAnnotation_AddWeightFirstSettingWinsWhenFirstIsZero(t *testing.T) {
+	annotation, err := NewAnnotation([]*config_parser.Param{
+		{Key: AnnotationKey_AddWeight, Val: "0"},
+		{Key: AnnotationKey_AddWeight, Val: "9"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if annotation.AddWeight != 0 {
+		t.Fatalf("unexpected add_weight: %v", annotation.AddWeight)
+	}
+}

--- a/component/outbound/dialer_group_test.go
+++ b/component/outbound/dialer_group_test.go
@@ -8,6 +8,7 @@ package outbound
 import (
 	"context"
 	"errors"
+	"math"
 	"reflect"
 	"testing"
 	"time"
@@ -361,6 +362,119 @@ func TestDialerGroup_SetAlive(t *testing.T) {
 	}
 	if count[zeroTarget] != 0 {
 		t.Fail()
+	}
+}
+
+func TestDialerGroup_Select_Random_WithAddWeight(t *testing.T) {
+	option := &dialer.GlobalOption{
+		Log:               log,
+		TcpCheckOptionRaw: dialer.TcpCheckOptionRaw{Raw: []string{testTcpCheckUrl}},
+		CheckDnsOptionRaw: dialer.CheckDnsOptionRaw{Raw: []string{testUdpCheckDns}},
+		CheckInterval:     15 * time.Second,
+	}
+	dialers := []*dialer.Dialer{
+		newDirectDialer(option, false),
+		newDirectDialer(option, false),
+		newDirectDialer(option, false),
+	}
+	annotations := []*dialer.Annotation{
+		{},
+		{AddWeight: 99},
+		{},
+	}
+	g := NewDialerGroup(option, "test-group", dialers, annotations,
+		DialerSelectionPolicy{
+			Policy: consts.DialerSelectionPolicy_Random,
+		}, func(alive bool, networkType *dialer.NetworkType, isInit bool) {})
+	count := make([]int, len(dialers))
+	for range 500 {
+		d, _, err := g.Select(TestNetworkType, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for j, dd := range dialers {
+			if d == dd {
+				count[j]++
+				break
+			}
+		}
+	}
+	if count[1] <= count[0] || count[1] <= count[2] {
+		t.Fatalf("weighted dialer was not preferred enough: counts=%v", count)
+	}
+}
+
+func TestDialerGroup_Select_Random_WithAddWeight_IgnoreDeadDialer(t *testing.T) {
+	option := &dialer.GlobalOption{
+		Log:               log,
+		TcpCheckOptionRaw: dialer.TcpCheckOptionRaw{Raw: []string{testTcpCheckUrl}},
+		CheckDnsOptionRaw: dialer.CheckDnsOptionRaw{Raw: []string{testUdpCheckDns}},
+		CheckInterval:     15 * time.Second,
+	}
+	dialers := []*dialer.Dialer{
+		newDirectDialer(option, false),
+		newDirectDialer(option, false),
+		newDirectDialer(option, false),
+	}
+	annotations := []*dialer.Annotation{
+		{},
+		{AddWeight: 99},
+		{},
+	}
+	g := NewDialerGroup(option, "test-group", dialers, annotations,
+		DialerSelectionPolicy{
+			Policy: consts.DialerSelectionPolicy_Random,
+		}, func(alive bool, networkType *dialer.NetworkType, isInit bool) {})
+	g.MustGetAliveDialerSet(TestNetworkType).NotifyLatencyChange(dialers[1], false)
+	for range 200 {
+		d, _, err := g.Select(TestNetworkType, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if d == dialers[1] {
+			t.Fatal("dead weighted dialer should never be selected")
+		}
+	}
+}
+
+func TestDialerGroup_Select_Random_WithLargeAddWeight(t *testing.T) {
+	option := &dialer.GlobalOption{
+		Log:               log,
+		TcpCheckOptionRaw: dialer.TcpCheckOptionRaw{Raw: []string{testTcpCheckUrl}},
+		CheckDnsOptionRaw: dialer.CheckDnsOptionRaw{Raw: []string{testUdpCheckDns}},
+		CheckInterval:     15 * time.Second,
+	}
+	dialers := []*dialer.Dialer{
+		newDirectDialer(option, false),
+		newDirectDialer(option, false),
+		newDirectDialer(option, false),
+	}
+	annotations := []*dialer.Annotation{
+		{AddWeight: math.MaxInt64 - 1},
+		{AddWeight: math.MaxInt64 - 1},
+		{AddWeight: math.MaxInt64 - 1},
+	}
+	g := NewDialerGroup(option, "test-group", dialers, annotations,
+		DialerSelectionPolicy{
+			Policy: consts.DialerSelectionPolicy_Random,
+		}, func(alive bool, networkType *dialer.NetworkType, isInit bool) {})
+	count := make([]int, len(dialers))
+	for range 300 {
+		d, _, err := g.Select(TestNetworkType, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for j, dd := range dialers {
+			if d == dd {
+				count[j]++
+				break
+			}
+		}
+	}
+	for i, c := range count {
+		if c == 0 {
+			t.Fatalf("dialer %d was never selected: counts=%v", i, count)
+		}
 	}
 }
 

--- a/config/desc.go
+++ b/config/desc.go
@@ -81,10 +81,14 @@ var GroupDesc = Desc{
 	"filter": `Filter nodes from the global node pool defined by the "subscription" and "node" sections.
 Available functions: name, subtag. Not operator is supported.
 Available keys in name function: keyword, regex. No key indicates full match.
-Available keys in subtag function: regex. No key indicates full match.`,
+Available keys in subtag function: regex. No key indicates full match.
+Filters are checked in order. For a given node, only the first matching filter line applies; annotations from later matching filter lines are ignored.
+Available annotations: add_latency, add_weight.
+add_latency: Add a latency offset for latency-based policies.
+add_weight: Add a weight offset for random policy. The default weight is 1, so add_weight: 4 means effective weight 5.`,
 	"policy": `Dialer selection policy. For each new connection, select a node as dialer from group by this policy.
 Available values: random, fixed, min, min_avg10, min_moving_avg.
-random: Select randomly.
+random: Select randomly among alive nodes. Use filter annotation add_weight to bias the selection.
 fixed: Select the fixed node. Connectivity check will be disabled.
 min: Select node by the latency of last check.
 min_avg10: Select node by the average of latencies of last 10 checks.

--- a/config/marshal.go
+++ b/config/marshal.go
@@ -208,6 +208,51 @@ func (m *Marshaller) marshalLeaf(key string, from reflect.Value, depth int) (err
 	}
 	return nil
 }
+
+func (m *Marshaller) marshalFunctions(functions []*config_parser.Function) string {
+	vals := make([]string, 0, len(functions))
+	for _, f := range functions {
+		vals = append(vals, f.String(false, true, false))
+	}
+	return strings.Join(vals, " && ")
+}
+
+func (m *Marshaller) marshalAnnotation(params []*config_parser.Param) string {
+	vals := make([]string, 0, len(params))
+	for _, p := range params {
+		vals = append(vals, p.String(false, true))
+	}
+	return strings.Join(vals, ", ")
+}
+
+func (m *Marshaller) marshalAnnotatedField(key string, from reflect.Value, annotation reflect.Value, depth int) error {
+	if from.Kind() != reflect.Slice || annotation.Kind() != reflect.Slice {
+		return fmt.Errorf("annotated field %v must be a slice", key)
+	}
+	if from.Len() != annotation.Len() {
+		return fmt.Errorf("annotated field %v has mismatched lengths: %v != %v", key, from.Len(), annotation.Len())
+	}
+	for i := 0; i < from.Len(); i++ {
+		item := from.Index(i).Interface()
+		functions, ok := item.([]*config_parser.Function)
+		if !ok {
+			return fmt.Errorf("unsupported annotated field type: %T", item)
+		}
+		line := key + ": " + m.marshalFunctions(functions)
+		if !annotation.Index(i).IsNil() {
+			params, ok := annotation.Index(i).Interface().([]*config_parser.Param)
+			if !ok {
+				return fmt.Errorf("unsupported annotation field type: %T", annotation.Index(i).Interface())
+			}
+			if len(params) > 0 {
+				line += " [" + m.marshalAnnotation(params) + "]"
+			}
+		}
+		m.writeLine(depth, line)
+	}
+	return nil
+}
+
 func (m *Marshaller) marshalParam(from reflect.Value, depth int) (err error) {
 	if from.Kind() != reflect.Struct {
 		return fmt.Errorf("marshalParam can only marshal struct")
@@ -241,6 +286,14 @@ func (m *Marshaller) marshalParam(from reflect.Value, depth int) (err error) {
 				}
 			default:
 				return fmt.Errorf("unknown reserved field: %v", structField.Name)
+			}
+			continue
+		}
+
+		annotationSF, annotatable := typ.FieldByName(structField.Name + "Annotation")
+		if annotatable && annotationSF.Tag.Get("mapstructure") == "_" {
+			if err = m.marshalAnnotatedField(key, field, from.FieldByName(annotationSF.Name), depth); err != nil {
+				return err
 			}
 			continue
 		}

--- a/docs/en/configuration/separate-config.md
+++ b/docs/en/configuration/separate-config.md
@@ -103,6 +103,14 @@ group {
         filter: name(node1, node2)
         policy: fixed(0)
     }
+
+    weighted_random {
+        # add_weight biases random selection on top of the default weight 1.
+        # Here node2 has effective weight 5 while node1 keeps weight 1.
+        filter: name(node1)
+        filter: name(node2) [add_weight: 4]
+        policy: random
+    }
 }
 ```
 

--- a/example.dae
+++ b/example.dae
@@ -323,12 +323,23 @@ group {
         #filter: name(node1, node2)
 
         # Filter nodes and give a fixed latency offset to archive latency-based failover.
+        # Filter lines are checked in order. If one node matches multiple filter lines,
+        # only the first matching line applies; later annotations are ignored.
+        # For example, if one node matches both `name(US_node) [add_latency: -500ms]`
+        # and `name(premium) [add_latency: 1000ms]`, only the first matching line applies.
         # In this example, there is bigger possibility to choose US node even if original latency of US node is higher.
         filter: name(HK_node)
         filter: name(US_node) [add_latency: -500ms]
 
         # Select the node with min average of the last 10 latencies from the group for every connection.
         policy: min_avg10
+    }
+
+    weighted_random {
+        # add_weight biases the random policy on top of the default weight 1.
+        filter: name(HK_node)
+        filter: name(US_node) [add_weight: 4]
+        policy: random
     }
 
     steam {

--- a/example.dae
+++ b/example.dae
@@ -322,7 +322,7 @@ group {
         # Filter nodes from the global node pool defined by tag.
         #filter: name(node1, node2)
 
-        # Filter nodes and give a fixed latency offset to archive latency-based failover.
+        # Filter nodes and give a fixed latency offset to achieve latency-based failover.
         # Filter lines are checked in order. If one node matches multiple filter lines,
         # only the first matching line applies; later annotations are ignored.
         # For example, if one node matches both `name(US_node) [add_latency: -500ms]`


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

This change implements weighted random selection for proxy groups, without introducing a new policy name.

Previously, `policy: random` selected uniformly from alive nodes. This made it impossible to bias random selection toward preferred nodes while keeping random behavior. This patch adds `add_weight` as a filter annotation, similar to the existing `add_latency` annotation, so users can write configurations like:

```dae
filter: name(US_node) [add_weight: 4]
policy: random
```

The effective default weight is `1`, so `add_weight: 4` makes the node's effective weight `5`.

The change also covers related edge cases:

- zero-valued first annotations such as `add_latency: 0s` and `add_weight: 0`
- overflow around `1 + add_weight`
- aggregate overflow when selecting from groups with very large effective weights
- excluded or dead dialers should not be selected even when they have higher weights

In addition, it updates config marshal round-trip behavior so annotated `filter:` lines are preserved, and documents the actual first-match filter annotation semantics in the config description, example config, and docs.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [x] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- Implement weighted random proxy-group selection via `add_weight` filter annotations
- Preserve annotated `filter:` lines during config marshal / round-trip
- Document first-match filter annotation semantics and weighted random usage in config descriptions, example config, and docs
- Fix zero-valued first-annotation handling and weight overflow edge cases
- Keep equal-weight random groups on the existing fast path
- Add regression tests for weighted random selection, dead/excluded dialers, and large aggregate weights

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

N/A

### Test Result

<!--- Attach test result here. -->

```sh
go test ./component/outbound/dialer
go test ./component/outbound
go test ./config
```

Output:

```text
ok      github.com/daeuniverse/dae/component/outbound/dialer    0.221s
ok      github.com/daeuniverse/dae/component/outbound           0.070s
ok      github.com/daeuniverse/dae/config                       0.075s
```

Full test suite note:

```sh
go test ./...
```

currently fails in existing eBPF-generated type references unrelated to this change, for example:

```text
control/control_plane_core.go:104:22: undefined: bpfObjects
control/udp_conn_state_tracker.go:12:14: undefined: bpfTuplesKey
```
