### PR TITLE
fix(docker): update Go version to 1.26 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-bookworm AS builder
+FROM golang:1.26-bookworm AS builder
 RUN apt-get update && apt-get install -y llvm-15 clang-15 git make
 ENV CLANG=clang-15
 WORKDIR /build/


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- Update dockerfile builder stage base image to go-1.26

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

Closes #988 

### Test Result

<!--- Attach test result here. -->
