### PR TITLE
fix(bpf): restore cmdline parsing for accurate process name

### DIFF
--- a/control/kern/tproxy.c
+++ b/control/kern/tproxy.c
@@ -3274,15 +3274,72 @@ int tproxy_dae0_ingress(struct __sk_buff *skb)
 	return bpf_redirect(redirect_entry->ifindex, flags);
 }
 
+struct get_real_comm_ctx {
+	char *arg_buf;
+	u8 l;
+};
+
+static int __noinline get_real_comm_loop_cb(__u32 index, void *data)
+{
+	/*
+	* For string like: /usr/lib/sddm/sddm-helper --socket /tmp/sddm-auth1
+	* We extract "sddm-helper" from it.
+	*/
+	struct get_real_comm_ctx *ctx = (struct get_real_comm_ctx *)data;
+
+	if (index >= MAX_ARG_LEN) // always false, just to make verifier happy
+		return 1;
+	if (unlikely(ctx->arg_buf[index] == '/'))
+		ctx->l = index + 1;
+	if (unlikely(ctx->arg_buf[index] == ' ' ||
+		     ctx->arg_buf[index] == '\0')) {
+		// Write to dst.
+		ctx->arg_buf[index] = '\0';
+		return 1;
+	}
+	return 0;
+}
+
 /// Parse command line arguments to get the real command name and tgid.
 static __always_inline int get_pid_pname(struct pid_pname *pid_pname)
 {
-	__u64 pid_tgid = bpf_get_current_pid_tgid();
+	int ret;
+	// Get pointer to args string.
+	struct task_struct *task = (void *)bpf_get_current_task();
+	char *args = (void *)BPF_CORE_READ(task, mm, arg_start);
 
+	// Read args to buffer.
+	char arg_buf[MAX_ARG_LEN]; // Allocate it out of ctx to pass CO-RE
+	struct get_real_comm_ctx ctx = {};
+
+	ctx.arg_buf = arg_buf;
+	ret = bpf_core_read_user_str(arg_buf, MAX_ARG_LEN, args);
+	if (unlikely(ret < 0)) {
+		bpf_printk(
+			"failed to read process name: bpf_core_read_user_str: %d",
+			ret);
+		return ret;
+	}
+
+	// Find range of command name.
+	ret = bpf_loop(MAX_ARG_LEN, get_real_comm_loop_cb, &ctx, 0);
+	if (unlikely(ret < 0))
+		return ret;
+
+	u8 offset = ctx.l;
+
+	for (u8 i = 0; i < TASK_COMM_LEN; i++) {
+		if (offset + i < MAX_ARG_LEN && arg_buf[offset + i] != '\0') {
+			pid_pname->pname[i] = arg_buf[offset + i];
+		} else {
+			pid_pname->pname[i] = '\0';
+			break;
+		}
+	}
+
+	// Populate tgid
 	pid_pname->last_seen_ns = bpf_ktime_get_ns();
-	pid_pname->pid = pid_tgid >> 32;
-	if (bpf_get_current_comm(&pid_pname->pname, sizeof(pid_pname->pname)))
-		pid_pname->pname[0] = '\0';
+	pid_pname->pid = bpf_get_current_pid_tgid() >> 32;
 	return 0;
 }
 


### PR DESCRIPTION
### Background

Commit 9731e66 simplified process name retrieval by switching from cmdline parsing to bpf_get_current_comm(). However, bpf_get_current_comm() returns the thread name (task_struct->comm), not the process name.
For multi-threaded programs like those using tokio, this results in names like:
- tokio-rt-worker
- tokio-rt-worker-0
Instead of the actual process name (e.g., myapp).
This PR reverts to the original implementation that parses command line arguments from mm->arg_start to extract the real executable name.

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- Restore cmdline parsing from mm->arg_start for accurate process name
- Revert the simplification from commit 9731e66 that used bpf_get_current_comm()

### Test Result

Process names can be correctly obtained on X86 Debian 13, while other architectures still require testing

Before

```
May 03 13:06:07 debian dae[206669]: level=info msg="192.168.2.10:38364 <-> 91.108.56.104:443" dialer=DE dscp=0 ip="91.108.56.104:443" mac="98:fa:9b:0b:46:61" network=tcp4 outbound=DE pname=tokio-rt-worker policy=min_avg10 sniffed=
May 03 13:18:13 debian dae[206669]: level=info msg="192.168.2.10:34842 <-> 91.108.56.104:443" dialer=DE dscp=0 ip="91.108.56.104:443" mac="98:fa:9b:0b:46:61" network=tcp4 outbound=DE pname=tokio-rt-worker policy=min_avg10 sniffed=
May 03 13:18:16 debian dae[206669]: level=info msg="192.168.2.10:57828 <-> 91.108.56.104:443" dialer=DE dscp=0 ip="91.108.56.104:443" mac="98:fa:9b:0b:46:61" network=tcp4 outbound=DE pname=tokio-rt-worker policy=min_avg10 sniffed=
```

Now

```
May 03 23:04:28 debian dae[321635]: level=info msg="192.168.2.10:55694 <-> 91.108.56.104:443" dialer=US-LA-WEE-REALITY dscp=0 ip="91.108.56.104:443" mac="98:fa:9b:0b:46:61" network=tcp4 outbound=proxy pname=UploadRecord2TG policy=min sniffed=
May 03 23:04:59 debian dae[321635]: level=info msg="192.168.2.10:33682 <-> 91.108.56.104:443" dialer=US-LA-WEE-REALITY dscp=0 ip="91.108.56.104:443" mac="98:fa:9b:0b:46:61" network=tcp4 outbound=proxy pname=UploadRecord2TG policy=min sniffed=
May 03 23:05:01 debian dae[321635]: level=info msg="192.168.2.10:33684 <-> 91.108.56.104:443" dialer=US-LA-WEE-REALITY dscp=0 ip="91.108.56.104:443" mac="98:fa:9b:0b:46:61" network=tcp4 outbound=proxy pname=UploadRecord2TG policy=min sniffed=
```
