### PR TITLE
ci: build for GORISCV64 variants

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -37,6 +37,17 @@ jobs:
             goarch: amd64
             goamd64: v3
           # END Linux AMD64 v1 v2 v3
+          # BEGIN Linux RISCV64 rva20u64 rva22u64 rva23u64
+          - goos: linux
+            goarch: riscv64
+            goriscv64: rva20u64
+          - goos: linux
+            goarch: riscv64
+            goriscv64: rva22u64
+          - goos: linux
+            goarch: riscv64
+            goriscv64: rva23u64
+          # END Linux RISCV64 rva20u64 rva22u64 rva23u64
       fail-fast: false
 
     runs-on: ubuntu-22.04
@@ -45,6 +56,7 @@ jobs:
       GOARCH: ${{ matrix.goarch }}
       GOARM: ${{ matrix.goarm }}
       GOAMD64: ${{ matrix.goamd64 }}
+      GORISCV64: ${{ matrix.goriscv64 }}
       CGO_ENABLED: 0
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,17 @@ jobs:
             goarch: amd64
             goamd64: v3
           # END Linux AMD64 v1 v2 v3
+          # BEGIN Linux RISCV64 rva20u64 rva22u64 rva23u64
+          - goos: linux
+            goarch: riscv64
+            goriscv64: rva20u64
+          - goos: linux
+            goarch: riscv64
+            goriscv64: rva22u64
+          - goos: linux
+            goarch: riscv64
+            goriscv64: rva23u64
+          # END Linux RISCV64 rva20u64 rva22u64 rva23u64
       fail-fast: false
 
     runs-on: ubuntu-22.04
@@ -45,6 +56,7 @@ jobs:
       GOARCH: ${{ matrix.goarch }}
       GOARM: ${{ matrix.goarm }}
       GOAMD64: ${{ matrix.goamd64 }}
+      GORISCV64: ${{ matrix.goriscv64 }}
       CGO_ENABLED: 0
 
     steps:

--- a/.github/workflows/seed-build.yml
+++ b/.github/workflows/seed-build.yml
@@ -54,6 +54,17 @@ jobs:
             goarch: amd64
             goamd64: v3
           # END Linux AMD64 v1 v2 v3
+          # BEGIN Linux RISCV64 rva20u64 rva22u64 rva23u64
+          - goos: linux
+            goarch: riscv64
+            goriscv64: rva20u64
+          - goos: linux
+            goarch: riscv64
+            goriscv64: rva22u64
+          - goos: linux
+            goarch: riscv64
+            goriscv64: rva23u64
+          # END Linux RISCV64 rva20u64 rva22u64 rva23u64
       fail-fast: false
 
     runs-on: ubuntu-22.04
@@ -62,6 +73,7 @@ jobs:
       GOARCH: ${{ matrix.goarch }}
       GOARM: ${{ matrix.goarm }}
       GOAMD64: ${{ matrix.goamd64 }}
+      GORISCV64: ${{ matrix.goriscv64 }}
       CGO_ENABLED: 0
 
     steps:


### PR DESCRIPTION
<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->

### Background

<!--- Why is this change required? What problem does it solve? -->

Build for different GORISCV64 variants, like what has been done for GOARM and GOAMD64.

Ref:
[1] https://github.com/golang/go/issues/61476
[2] https://github.com/golang/go/blob/e929fb78e47dc191a402d34ca949d2e0c67e31b8/src/internal/buildcfg/cfg.go#L316-L323

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
    - I'm not sure if this needs a CHANGELOG entry. If so, please tell me and I will add it. Thanks!
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- build for GORISCV64 variants

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->

N/A

### Test Result

<!--- Attach test result here. -->

Let CI test itself :P
