### PR TITLE
fix(bpf): fallback to bpf_get_current_comm when bpf_get_current_task is unavailable

### DIFF
--- a/control/bpf_stub.go
+++ b/control/bpf_stub.go
@@ -26,17 +26,17 @@ var errBpfObjectsUnavailable = errors.New("eBPF objects are unavailable in this 
 // Only safe with: (1) netkit device + scrub=NONE, (2) kernel >= 6.8 (CVE-2025-37959 fix).
 // When enabled, provides ~50% throughput improvement by bypassing CPU backlog.
 type bpfDaeParam struct {
-	_               structs.HostLayout
-	TproxyPort      uint32
-	ControlPlanePid uint32
-	Dae0Ifindex     uint32
-	DaeNetnsId      uint32
-	Dae0peerMac     [6]uint8
-	PaddingAfterMac [2]uint8
-	UseRedirectPeer uint8 // 0=use bpf_redirect(), 1=use bpf_redirect_peer() when safe
-	Padding1        uint8
-	Padding2        uint16
-	DaeSocketMark   uint32 // mark set on dae's own sockets to identify them in eBPF
+	_                    structs.HostLayout
+	TproxyPort           uint32
+	ControlPlanePid      uint32
+	Dae0Ifindex          uint32
+	DaeNetnsId           uint32
+	Dae0peerMac          [6]uint8
+	PaddingAfterMac      [2]uint8
+	UseRedirectPeer      uint8 // 0=use bpf_redirect(), 1=use bpf_redirect_peer() when safe
+	HasBpfGetCurrentTask uint8
+	Padding2             uint16
+	DaeSocketMark        uint32 // mark set on dae's own sockets to identify them in eBPF
 }
 
 type bpfDomainRouting struct {

--- a/control/bpf_utils.go
+++ b/control/bpf_utils.go
@@ -20,6 +20,8 @@ import (
 	"sync"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/features"
 	"github.com/daeuniverse/dae/common"
 	"github.com/daeuniverse/dae/common/consts"
 	daerrors "github.com/daeuniverse/dae/common/errors"
@@ -413,29 +415,37 @@ retryLoadBpf:
 		peerMac = [6]byte(hwAddr)
 	} // else: keep zero MAC for L3 netkit
 
+	hasBpfGetCurrentTask := uint8(0)
+	if err := features.HaveProgramHelper(ebpf.CGroupSockAddr, asm.FnGetCurrentTask); err == nil {
+		hasBpfGetCurrentTask = 1
+		log.Debugf("bpf_get_current_task is supported")
+	} else {
+		log.Warnf("Kernel does not support bpf_get_current_task helper: %v; process names may be truncated or less accurate (degraded to bpf_get_current_comm)", err)
+	}
+
 	constants := map[string]interface{}{
 		"PARAM": struct {
-			tproxyPort      uint32
-			controlPlanePid uint32
-			dae0Ifindex     uint32
-			daeNetnsId      uint32
-			dae0peerMac     [6]byte
-			paddingAfterMac [2]uint8
-			useRedirectPeer uint8
-			padding1        uint8
-			padding2        uint16
-			daeSocketMark   uint32
+			tproxyPort           uint32
+			controlPlanePid      uint32
+			dae0Ifindex          uint32
+			daeNetnsId           uint32
+			dae0peerMac          [6]byte
+			paddingAfterMac      [2]uint8
+			useRedirectPeer      uint8
+			hasBpfGetCurrentTask uint8
+			padding2             uint16
+			daeSocketMark        uint32
 		}{
-			tproxyPort:      opts.BigEndianTproxyPort,
-			controlPlanePid: uint32(os.Getpid()),
-			dae0Ifindex:     uint32(GetDaeNetns().Dae0().Attrs().Index),
-			daeNetnsId:      uint32(netnsID),
-			dae0peerMac:     peerMac,
-			paddingAfterMac: [2]uint8{0, 0},
-			useRedirectPeer: useRedirectPeer,
-			padding1:        0,
-			padding2:        0,
-			daeSocketMark:   soMarkFromDae,
+			tproxyPort:           opts.BigEndianTproxyPort,
+			controlPlanePid:      uint32(os.Getpid()),
+			dae0Ifindex:          uint32(GetDaeNetns().Dae0().Attrs().Index),
+			daeNetnsId:           uint32(netnsID),
+			dae0peerMac:          peerMac,
+			paddingAfterMac:      [2]uint8{0, 0},
+			useRedirectPeer:      useRedirectPeer,
+			hasBpfGetCurrentTask: hasBpfGetCurrentTask,
+			padding2:             0,
+			daeSocketMark:        soMarkFromDae,
 		},
 	}
 	if err = loadBpfObjectsWithConstantsAndCustomizer(

--- a/control/kern/tproxy.c
+++ b/control/kern/tproxy.c
@@ -176,7 +176,7 @@ struct dae_param {
 	__u8 dae0peer_mac[6];
 	__u8 padding_after_mac[2]; // pad to align use_redirect_peer
 	__u8 use_redirect_peer;
-	__u8 padding1;
+	__u8 has_bpf_get_current_task;
 	__u16 padding2;
 	// dae_socket_mark is set on dae's own sockets (Anyfrom pool) to identify them.
 	// When bpf_sk_lookup_* finds a socket, we check this mark to skip dae's own sockets.
@@ -3304,6 +3304,17 @@ static int __noinline get_real_comm_loop_cb(__u32 index, void *data)
 static __always_inline int get_pid_pname(struct pid_pname *pid_pname)
 {
 	int ret;
+
+	// Populate tgid and timestamp first
+	pid_pname->last_seen_ns = bpf_ktime_get_ns();
+	pid_pname->pid = bpf_get_current_pid_tgid() >> 32;
+
+	if (!PARAM.has_bpf_get_current_task) {
+		if (bpf_get_current_comm(&pid_pname->pname, sizeof(pid_pname->pname)))
+			pid_pname->pname[0] = '\0';
+		return 0;
+	}
+
 	// Get pointer to args string.
 	struct task_struct *task = (void *)bpf_get_current_task();
 	char *args = (void *)BPF_CORE_READ(task, mm, arg_start);
@@ -3337,9 +3348,6 @@ static __always_inline int get_pid_pname(struct pid_pname *pid_pname)
 		}
 	}
 
-	// Populate tgid
-	pid_pname->last_seen_ns = bpf_ktime_get_ns();
-	pid_pname->pid = bpf_get_current_pid_tgid() >> 32;
 	return 0;
 }
 


### PR DESCRIPTION
**Background**
Commit `320a9e52` introduced the usage of `bpf_get_current_task` combined with `BPF_CORE_READ(task, mm, arg_start)` to extract a more accurate process name (full command-line arguments parsing) instead of relying solely on `bpf_get_current_comm`. 

**The Problem**
While this works on kernels that support the helper in all required hook types, not all kernels allow the use of `bpf_get_current_task` (helper #35) in `CGroupSockAddr` (`BPF_PROG_TYPE_CGROUP_SOCK_ADDR`) or `CGroupSock` programs. On some environments (e.g., specific OpenWrt or older kernels), this causes a fatal verifier load error:
```text
program tproxy_wan_cg_connect4: load program: invalid argument: program of this type cannot use helper bpf_get_current_task#35
```

**The Solution**
Following maintainer feedback, this PR implements a robust load-time check and fallback mechanism without parsing the kernel BTF directly in user space:

1. **Probe**: During BPF initialization (`control/bpf_utils.go`), we use `features.HaveProgramHelper(ebpf.CGroupSockAddr, asm.FnGetCurrentTask)` to check if the current kernel supports the helper for the required program types.
2. **Inject**: The probe result is injected into the BPF `.rodata` section as a constant (`HAS_BPF_GET_CURRENT_TASK`).
3. **Branch & DCE**: In `get_pid_pname`, we branch based on this constant. If `HAS_BPF_GET_CURRENT_TASK` is `0`, the logic falls back to `bpf_get_current_comm`. The BPF verifier performs Dead Code Elimination (DCE) on the unreachable branch, safely discarding the unsupported `bpf_get_current_task` calls and its associated CO-RE relocations (which are correctly poisoned by the `cilium/ebpf` loader).
4. **Logging**: If the fallback is triggered, a `WARN` log is emitted in user space so that the user is aware that process names might be less accurate or truncated.

This ensures the proxy runs smoothly on older/restricted environments while preserving the precise process name capabilities on modern kernels.

**Testing**
- Evaluated against `make ebpf && go test ./...` successfully.
- Updated `bpf_stub.go` and verified successful compilation with `dae_stub_ebpf` build tags.
- Verified that the BPF verifier successfully prunes dead branches ensuring no `invalid argument` load errors on unsupported systems.

Close: #993 