### PR TITLE
fix(control): preserve DNS state for group override options

### DIFF
--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -585,10 +585,9 @@ func newControlPlaneWithContextOptions(
 				log.Debugln("\t<Empty>")
 			}
 		}
-		groupOption, err := ParseGroupOverrideOption(group, *global, log)
+		groupOption, err := ParseGroupOverrideOption(group, *global, log, option)
 		finalOption := option
 		if err == nil && groupOption != nil {
-			groupOption.TransportCacheNamespace = option.TransportCacheNamespace
 			newDialers := make([]*dialer.Dialer, 0)
 			for _, d := range dialers {
 				newDialer := d.CloneWithGlobalOptionContext(context.Background(), groupOption)
@@ -837,7 +836,7 @@ func ParseFixedDomainTtl(ks []config.KeyableString) (map[string]int, error) {
 	return m, nil
 }
 
-func ParseGroupOverrideOption(group config.Group, global config.Global, log *logrus.Logger) (*dialer.GlobalOption, error) {
+func ParseGroupOverrideOption(group config.Group, global config.Global, log *logrus.Logger, baseOption *dialer.GlobalOption) (*dialer.GlobalOption, error) {
 	result := global
 	changed := false
 	if group.TcpCheckUrl != nil {
@@ -862,6 +861,10 @@ func ParseGroupOverrideOption(group config.Group, global config.Global, log *log
 	}
 	if changed {
 		option := dialer.NewGlobalOption(&result, log)
+		if baseOption != nil {
+			option.DaeDNS = baseOption.DaeDNS
+			option.TransportCacheNamespace = baseOption.TransportCacheNamespace
+		}
 		return option, nil
 	}
 	return nil, nil

--- a/control/group_override_test.go
+++ b/control/group_override_test.go
@@ -1,0 +1,42 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2025, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package control
+
+import (
+	"testing"
+	"time"
+
+	"github.com/daeuniverse/dae/component/daedns"
+	componentdialer "github.com/daeuniverse/dae/component/outbound/dialer"
+	"github.com/daeuniverse/dae/config"
+)
+
+func TestParseGroupOverrideOptionPreservesRuntimeDialerState(t *testing.T) {
+	router := &daedns.Router{}
+	baseOption := &componentdialer.GlobalOption{
+		DaeDNS:                  router,
+		TransportCacheNamespace: "generation-1",
+	}
+
+	option, err := ParseGroupOverrideOption(config.Group{
+		CheckInterval: time.Minute,
+	}, config.Global{}, nil, baseOption)
+	if err != nil {
+		t.Fatalf("ParseGroupOverrideOption() error = %v", err)
+	}
+	if option == nil {
+		t.Fatal("ParseGroupOverrideOption() = nil, want override option")
+	}
+	if option.CheckInterval != time.Minute {
+		t.Fatalf("CheckInterval = %v, want %v", option.CheckInterval, time.Minute)
+	}
+	if option.DaeDNS != router {
+		t.Fatal("DaeDNS router was not preserved from the base option")
+	}
+	if option.TransportCacheNamespace != baseOption.TransportCacheNamespace {
+		t.Fatalf("TransportCacheNamespace = %q, want %q", option.TransportCacheNamespace, baseOption.TransportCacheNamespace)
+	}
+}


### PR DESCRIPTION
## What this PR does

When a group overrides health-check options, dae rebuilds a `GlobalOption` for cloned dialers. That rebuilt option preserved the transport cache namespace at the call site, but it did not preserve runtime state injected into the base option, especially `DaeDNS`.

As a result, cloned dialers in groups with `tcp_check_url`, `udp_check_dns`, `check_interval`, or `check_tolerance` overrides could skip `DaeDNS.WrapNodeDialer(...)` and fall back to the default resolver for node hostnames.

This patch passes the base option into `ParseGroupOverrideOption` and preserves the runtime fields needed by cloned dialers.

## Tests

- `go test -tags dae_stub_ebpf ./control -run TestParseGroupOverrideOptionPreservesRuntimeDialerState -count=1`
- `go test -tags dae_stub_ebpf ./control -count=1`