### PR TITLE
docs: fix stale contribution instructions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- NOTE: Please read the CONTRIBUTING.md guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/master/CONTRIBUTING.md -->
+<!-- NOTE: Please read the contribution guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/main/docs/en/development/contribute.md -->
 
 ### Background
 

--- a/docs/en/development/contribute.md
+++ b/docs/en/development/contribute.md
@@ -31,15 +31,15 @@ pre-commit install
 - Clone the fork on your local machine. Your remote repo on GitHub is called `origin`.
 - Add the original repository as a remote called `upstream`.
 - If you created your fork a while ago be sure to pull upstream changes into your local repository.
-- Create a new branch to work on! Branch from `develop` if it exists, else from `master`.
+- Create a new branch to work on! Branch from `main`.
 - Implement/fix your feature, comment your code.
 - Follow the code style of the project, including indentation.
-- If the project has tests run them!
+- If the project has tests run them! For routine unit tests, use `go test -tags dae_stub_ebpf ./...`. For eBPF tests, use `make ebpf-test`.
 - Write or adapt tests as needed.
 - Add or change the documentation as needed.
 - Squash your commits into a single commit with Git's [interactive rebase](https://help.github.com/articles/interactive-rebase). Create a new branch if necessary.
 - Push your branch to your fork on GitHub, the remote `origin`.
-- From your fork open a pull request in the correct branch. Target the project's `develop` branch if there is one, else go for `master`!
+- From your fork open a pull request in the correct branch. Target the project's `main` branch.
 - Once the pull request is approved and merged you can pull the changes from `upstream` to your local repo and delete
   your extra branch(es).
 


### PR DESCRIPTION
Small contributor footgun fix.

What changed
- point the PR template at the real contribution doc on `main`
- replace stale `master` and `develop` guidance with `main`
- document the unit test command CI already uses, plus the eBPF test target

How to repro
1. Open the PR template link to `CONTRIBUTING.md`. It goes to `.../blob/master/CONTRIBUTING.md`, but that file doesnt exist in this repo.
2. On a fresh checkout, run `go test ./...`.
3. Build blows up in `control` with missing generated BPF types like `bpfObjects`.
4. Run `go test -tags dae_stub_ebpf ./...` instead. That passes, and it matches CI.

Tests
- `go test -tags dae_stub_ebpf ./...`

Tiny docs fix, but it saves some head scratching
