### PR TITLE
feat: rewrite fixed_fallback with background goroutine for independent retry and zero-latency switchback

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -50,3 +50,11 @@ jobs:
         run: |
           git submodule update --init --recursive
           go test -tags dae_stub_ebpf ./...
+
+      # The outbound package holds the fixed_fallback background goroutine and
+      # its alive-transition callbacks, which are concurrency-sensitive. Run it
+      # under the race detector to catch data races the plain run may miss.
+      - name: Run tests with race detector (outbound)
+        run: |
+          git submodule update --init --recursive
+          go test -race -tags dae_stub_ebpf ./component/outbound/...

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The `fixed_fallback` policy always prefers a specific node but gracefully degrad
 - **Background goroutine** independently drives the retry cycle, not dependent on traffic
 - **Health check** dead detection also starts the goroutine (via `aliveTransitionCallback`)
 - **Node recovery** is detected in next health check cycle or goroutine probe — traffic returns instantly
+- **`retries = 0`**: there is **no** background retry goroutine (the node is marked `done` immediately). Recovery from that point relies entirely on the **global health check** (`check_interval` + configured probe URLs) re-marking the node alive — it will **not** be probed by the fallback's own loop. Make sure `check_interval > 0` and a probe target is configured, otherwise a dead fixed node stays fallen back indefinitely.
 
 **Example:**
 ```

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ As a successor of [v2rayA](https://github.com/v2rayA/v2rayA), dae abandoned v2ra
 - [x] Support to split traffic by MAC address in LAN.
 - [x] Support to split traffic with invert match rules.
 - [x] Support to automatically switch nodes according to policy. That is to say, support to automatically test independent TCP/UDP/IPv4/IPv6 latencies, and then use the best nodes for corresponding traffic according to user-defined policy.
+- [x] **`fixed_fallback` policy**: Prefer a specific node with automatic retry, grace period, and latency-aware fallback on failure. Recovers automatically when the preferred node comes back online.
 - [x] Support advanced DNS resolution process.
 - [x] Support full-cone NAT for shadowsocks, trojan(-go) and socks5 (no test).
 - [x] Support various trending proxy protocols, seen in [proxy-protocols.md](./docs/en/proxy-protocols.md).
@@ -30,6 +31,66 @@ As a successor of [v2rayA](https://github.com/v2rayA/v2rayA), dae abandoned v2ra
 ## Getting Started
 
 Please refer to [Quick Start Guide](./docs/en/README.md) to start using `dae` right away!
+
+## Dialer Selection Policies
+
+dae supports several dialer (node) selection policies for `group` blocks:
+
+| Policy | Description |
+|--------|-------------|
+| `fixed(index)` | Always use the node at the given index. No fallback |
+| `min_moving_avg` | Pick the node with the lowest moving-average latency |
+| `min_avg10` | Pick the node with the lowest average latency over the last 10 probes |
+| `min_last_latency` | Pick the node with the lowest most-recent latency |
+| `random` | Pick a random alive node |
+| **`fixed_fallback(index, timeout, retries, fallback_policy)`** | **Fixed node with disaster-recovery fallback** |
+
+### `fixed_fallback` — Fixed Node with Graceful Degradation
+
+The `fixed_fallback` policy always prefers a specific node but gracefully degrades to a backup policy when that node dies, and **automatically returns** when it recovers.
+
+**Syntax:** `fixed_fallback(index, timeout, retries, fallback_policy)`
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| `index` | — (required) | Dialer index in group (0-based) |
+| `timeout` | `3s` | Retry interval. Clamped to minimum 2s with WARN log |
+| `retries` | `3` | Max retries before fallback. `0` = immediate fallback |
+| `fallback_policy` | `min_moving_avg` | Policy after retries exhausted |
+
+**How it works (two-layer architecture):**
+
+```
+                    ┌─ MustGetAlive=true  ── Use fixed node
+                    │
+  Select() ─────────┤
+                    │                              Natural Traffic
+                    │                                    ↓
+                    └─ MustGetAlive=false ── → Fallback to backup node
+                                               │
+                                               ├─ Background goroutine drives
+                                               │  retry probes independently
+                                               │  (ticker every `timeout`)
+                                               │
+                                               └─ Node recovers → auto switch back
+```
+
+- **Natural traffic** falls back **immediately** on dead node — zero timeout window wasted
+- **Background goroutine** independently drives the retry cycle, not dependent on traffic
+- **Health check** dead detection also starts the goroutine (via `aliveTransitionCallback`)
+- **Node recovery** is detected in next health check cycle or goroutine probe — traffic returns instantly
+
+**Example:**
+```
+group {
+    name 'my-group'
+    policy 'fixed_fallback(0, 3s, 3, random)'
+    node 'jp-tokyo-premium'   # index 0 — preferred
+    node 'us-west-cheap'      # index 1 — fallback candidate
+    node 'sg-singapore'       # index 2 — fallback candidate
+}
+```
+Behavior: Always use `jp-tokyo-premium`. If it dies, **immediately** use a random alive fallback. Background goroutine retries every 3s for 3 attempts. If node recovers during that time, traffic switches back immediately.
 
 ## Notes
 

--- a/common/consts/dialer.go
+++ b/common/consts/dialer.go
@@ -26,6 +26,10 @@ const (
 	DialerSelectionPolicy_Random DialerSelectionPolicy = "random"
 	// DialerSelectionPolicy_Fixed always selects the first dialer.
 	DialerSelectionPolicy_Fixed DialerSelectionPolicy = "fixed"
+	// DialerSelectionPolicy_FixedWithFallback always selects the n-th dialer when alive;
+	// falls back to min_moving_avg among other alive dialers when dead.
+	// When the fixed dialer revives, traffic will automatically return to it.
+	DialerSelectionPolicy_FixedWithFallback DialerSelectionPolicy = "fixed_fallback"
 	// DialerSelectionPolicy_MinAverage10Latencies selects the dialer with minimum average latency of last 10 checks.
 	DialerSelectionPolicy_MinAverage10Latencies DialerSelectionPolicy = "min_avg10"
 	// DialerSelectionPolicy_MinMovingAverageLatencies selects the dialer with minimum moving average latency.

--- a/component/outbound/dialer/connectivity_check.go
+++ b/component/outbound/dialer/connectivity_check.go
@@ -767,6 +767,14 @@ func (d *Dialer) aliveBackground() {
 		case <-waitDone:
 		case <-d.ctx.Done():
 			return
+		case <-time.After(cycle + 5*time.Second):
+			// Probe(s) appear stuck — log diagnostic and continue.
+			// The stuck probe will eventually resolve, but we don't block
+			// the entire check cycle waiting for it.
+			if d.Log != nil {
+				d.Log.WithField("dialer", d.Property().Name).
+					Warnln("Health check probe appears stuck; continuing cycle")
+			}
 		}
 		if checkFamily == "" {
 			// Stability-based wash white: only reset stability if a protocol family had failures
@@ -824,6 +832,12 @@ func (d *Dialer) submitCheckTasks(workerPool *ants.Pool, wg *sync.WaitGroup, opt
 	for _, opt := range opts {
 		// No need to test if there is no dialer selection policy using its latency.
 		if !d.hasAliveDialerSets(opt.networkType) {
+			if d.Log != nil && d.Log.IsLevelEnabled(logrus.DebugLevel) {
+				d.Log.WithFields(logrus.Fields{
+					"dialer":  d.Property().Name,
+					"network": opt.networkType.String(),
+				}).Debugln("Skipping probe: no AliveDialerSet for network type")
+			}
 			continue
 		}
 

--- a/component/outbound/dialer/connectivity_check.go
+++ b/component/outbound/dialer/connectivity_check.go
@@ -516,7 +516,7 @@ func (d *Dialer) aliveBackground() {
 	// If check_interval is 0 or not configured, skip connectivity check entirely
 	if d.CheckInterval == 0 {
 		d.Log.WithField("dialer", d.Property().Name).
-			Debugln("Connectivity check disabled (check_interval=0)")
+			Warnln("Connectivity check disabled (check_interval=0)")
 		return
 	}
 
@@ -644,7 +644,7 @@ func (d *Dialer) aliveBackground() {
 	// If neither TCP nor UDP checks are configured, return early
 	if len(CheckOpts) == 0 {
 		d.Log.WithField("dialer", d.Property().Name).
-			Debugln("No connectivity checks configured, skipping")
+			Warnln("No connectivity checks configured, skipping")
 		return
 	}
 

--- a/component/outbound/dialer/connectivity_check.go
+++ b/component/outbound/dialer/connectivity_check.go
@@ -1172,6 +1172,17 @@ func (d *Dialer) markAvailableTraffic(typ *NetworkType) collectionUpdate {
 	d.NotifyHealthCheckResult(typ, true, isRevival)
 	if isRevival {
 		d.notifyAliveTransition(typ, true)
+		// Log dead→alive transitions for operational visibility.
+		if d.Log != nil {
+			nodeName := ""
+			if d.property != nil {
+				nodeName = d.property.Name
+			}
+			d.Log.WithFields(logrus.Fields{
+				"dialer":  nodeName,
+				"network": typ.String(),
+			}).Infoln("Node became ALIVE (traffic)")
+		}
 	}
 	return update
 }

--- a/component/outbound/dialer/connectivity_check.go
+++ b/component/outbound/dialer/connectivity_check.go
@@ -136,26 +136,34 @@ func newCollection() *collection {
 }
 
 func (d *Dialer) mustGetCollection(typ *NetworkType) *collection {
-	idx := typ.Index()
-	// When udp_check_dns is not configured, DNS-UDP collections (IdxDnsUdp4/6)
-	// are never probed and their Alive flag stays true forever (initial value).
-	// This false-positive "alive" breaks the fixed_fallback retry state machine
-	// because DNS UDP always resets the retry timer before TCP can advance it.
-	// Solution: redirect DNS-UDP lookups to the corresponding TCP collection
-	// (same IP version) so they share the same (correct) Alive value.
-	if len(d.CheckDnsOptionRaw.Raw) == 0 {
-		switch idx {
-		case IdxDnsUdp4:
-			idx = IdxTcp4
-		case IdxDnsUdp6:
-			idx = IdxTcp6
-		}
-	}
-	return d.collections[idx]
+	return d.collections[typ.Index()]
 }
 
 func (d *Dialer) MustGetAlive(typ *NetworkType) bool {
 	return d.mustGetCollection(typ).Alive.Load()
+}
+
+// AliveForRetry reports whether the dialer should be considered alive for
+// fixed_fallback retry/fallback decisions on network type typ.
+//
+// When udp_check_dns is not configured, the DNS-UDP collection is never probed
+// by the health-check loop and its Alive flag stays at its initial value
+// (true) forever. That false-positive "alive" would make a Select() over
+// DNS-UDP reset the fixed_fallback retry counter on every DNS resolution
+// cycle, so fallback never triggers even though the node's TCP — and thus the
+// node itself — is dead.
+//
+// To fix that without coupling the DNS-UDP and TCP collections (which would
+// break UDP health-domain independence and snapshot/restore semantics, since
+// the two network types must remain independently markable), we mirror the
+// liveness decision to the same IP family's TCP collection only at this
+// retry-decision site.
+func (d *Dialer) AliveForRetry(typ *NetworkType) bool {
+	if typ != nil && typ.L4Proto == consts.L4ProtoStr_UDP && typ.IsDns && len(d.CheckDnsOptionRaw.Raw) == 0 {
+		mirrored := &NetworkType{L4Proto: consts.L4ProtoStr_TCP, IpVersion: typ.IpVersion}
+		return d.MustGetAlive(mirrored)
+	}
+	return d.MustGetAlive(typ)
 }
 
 func (d *Dialer) SnapshotLastProbe(typ *NetworkType) DialerProbeObservationSnapshot {
@@ -502,11 +510,6 @@ func shouldSkipIpFamily6(raw []string) bool {
 	}
 
 	return hasExplicitIpv4 && !hasIpv6
-}
-
-// hasUdpDnsConfig returns true if udp_check_dns is configured.
-func hasUdpDnsConfig(raw []string) bool {
-	return len(raw) > 0
 }
 
 func (d *Dialer) aliveBackground() {

--- a/component/outbound/dialer/connectivity_check.go
+++ b/component/outbound/dialer/connectivity_check.go
@@ -136,7 +136,22 @@ func newCollection() *collection {
 }
 
 func (d *Dialer) mustGetCollection(typ *NetworkType) *collection {
-	return d.collections[typ.Index()]
+	idx := typ.Index()
+	// When udp_check_dns is not configured, DNS-UDP collections (IdxDnsUdp4/6)
+	// are never probed and their Alive flag stays true forever (initial value).
+	// This false-positive "alive" breaks the fixed_fallback retry state machine
+	// because DNS UDP always resets the retry timer before TCP can advance it.
+	// Solution: redirect DNS-UDP lookups to the corresponding TCP collection
+	// (same IP version) so they share the same (correct) Alive value.
+	if len(d.CheckDnsOptionRaw.Raw) == 0 {
+		switch idx {
+		case IdxDnsUdp4:
+			idx = IdxTcp4
+		case IdxDnsUdp6:
+			idx = IdxTcp6
+		}
+	}
+	return d.collections[idx]
 }
 
 func (d *Dialer) MustGetAlive(typ *NetworkType) bool {
@@ -464,7 +479,44 @@ func getActiveDialerCount() int {
 	return poolActiveCount
 }
 
+// shouldSkipIpFamily6 returns true when raw explicitly lists only IPv4 addresses
+// (no explicit IPv6 entries). This avoids unnecessary IPv6 probes when the user's
+// network doesn't support IPv6.
+// Returns false (keep IPv6 probes) when:
+//   - Explicit IPv6 addresses are found in config
+//   - No explicit IPs are given (DNS resolution might return IPv6)
+func shouldSkipIpFamily6(raw []string) bool {
+	hasIpv6 := false
+	hasExplicitIpv4 := false
+
+	for i := 1; i < len(raw); i++ {
+		addr, err := netip.ParseAddr(raw[i])
+		if err != nil {
+			continue
+		}
+		if addr.Is6() {
+			hasIpv6 = true
+		} else {
+			hasExplicitIpv4 = true
+		}
+	}
+
+	return hasExplicitIpv4 && !hasIpv6
+}
+
+// hasUdpDnsConfig returns true if udp_check_dns is configured.
+func hasUdpDnsConfig(raw []string) bool {
+	return len(raw) > 0
+}
+
 func (d *Dialer) aliveBackground() {
+	// If check_interval is 0 or not configured, skip connectivity check entirely
+	if d.CheckInterval == 0 {
+		d.Log.WithField("dialer", d.Property().Name).
+			Debugln("Connectivity check disabled (check_interval=0)")
+		return
+	}
+
 	cycle := d.CheckInterval
 	var tcpSomark uint32
 	var mptcp bool
@@ -563,7 +615,45 @@ func (d *Dialer) aliveBackground() {
 		},
 		CheckFunc: makeDnsCheckFunc(func(o *CheckDnsOption) netip.Addr { return o.Ip6 }, &udpNetwork),
 	}
-	var CheckOpts = []*CheckOption{tcp4CheckOpt, tcp6CheckOpt, udp4CheckDnsOpt, udp6CheckDnsOpt}
+	// Build CheckOpts dynamically based on configuration:
+	//   - Only add TCP checks if tcp_check_url is configured
+	//   - Only add UDP DNS checks if udp_check_dns is configured
+	//   - Skip IPv6 probes when only IPv4 addresses are explicitly configured
+	useTcpCheck := len(d.TcpCheckOptionRaw.Raw) > 0
+	useUdpDns := len(d.CheckDnsOptionRaw.Raw) > 0
+	skipTcp6 := useTcpCheck && shouldSkipIpFamily6(d.TcpCheckOptionRaw.Raw)
+	skipUdp6 := useUdpDns && shouldSkipIpFamily6(d.CheckDnsOptionRaw.Raw)
+
+	var CheckOpts []*CheckOption
+	if useTcpCheck {
+		CheckOpts = append(CheckOpts, tcp4CheckOpt)
+		if !skipTcp6 {
+			CheckOpts = append(CheckOpts, tcp6CheckOpt)
+		}
+	}
+	if useUdpDns {
+		CheckOpts = append(CheckOpts, udp4CheckDnsOpt)
+		if !skipUdp6 {
+			CheckOpts = append(CheckOpts, udp6CheckDnsOpt)
+		}
+	}
+
+	// If neither TCP nor UDP checks are configured, return early
+	if len(CheckOpts) == 0 {
+		d.Log.WithField("dialer", d.Property().Name).
+			Debugln("No connectivity checks configured, skipping")
+		return
+	}
+
+	if d.Log.IsLevelEnabled(logrus.DebugLevel) {
+		d.Log.WithFields(logrus.Fields{
+			"dialer":   d.property.Name,
+			"tcp4":     useTcpCheck,
+			"tcp6":     useTcpCheck && !skipTcp6,
+			"udp4_dns": useUdpDns,
+			"udp6_dns": useUdpDns && !skipUdp6,
+		}).Debugln("Connectivity check probes configured")
+	}
 
 	var unusedOnce bool
 	checkUnused := func() bool {
@@ -683,7 +773,9 @@ func (d *Dialer) aliveBackground() {
 			// WITHOUT any successes in this cycle. This allows partially-working dual-stack
 			// nodes (e.g. V4 OK, V6 broken) to eventually wash white their penalty.
 			d.NotifyPeriodicCheckResult(consts.L4ProtoStr_TCP, cycleRes.tcpSuccess, cycleRes.tcpFailure && !cycleRes.tcpSuccess)
-			d.NotifyPeriodicCheckResultForType(udp4CheckDnsOpt.networkType, cycleRes.udpSuccess, cycleRes.udpFailure && !cycleRes.udpSuccess)
+			if useUdpDns {
+				d.NotifyPeriodicCheckResultForType(udp4CheckDnsOpt.networkType, cycleRes.udpSuccess, cycleRes.udpFailure && !cycleRes.udpSuccess)
+			}
 		}
 
 		// Targeted checks don't disturb the periodic timer — only full checks do.
@@ -1035,7 +1127,7 @@ func (d *Dialer) markAvailable(typ *NetworkType, latency time.Duration) (collect
 			d.Log.WithFields(logrus.Fields{
 				"dialer":  nodeName,
 				"network": typ.String(),
-				"latency":  latency.String(),
+				"latency": latency.String(),
 			}).Infoln("Node became ALIVE")
 		}
 		d.notifyAliveTransition(typ, true)

--- a/component/outbound/dialer/connectivity_check.go
+++ b/component/outbound/dialer/connectivity_check.go
@@ -959,6 +959,25 @@ func (d *Dialer) markUnavailableInternal(typ *NetworkType, force bool, isTraffic
 	wasAlive := collection.Alive.Load()
 	collection.Alive.Store(alive)
 
+	// Log alive/dead transitions for operational visibility.
+	if d.Log != nil {
+		nodeName := ""
+		if d.property != nil {
+			nodeName = d.property.Name
+		}
+		if wasAlive && !alive {
+			d.Log.WithFields(logrus.Fields{
+				"dialer":  nodeName,
+				"network": typ.String(),
+			}).Warnln("Node became DEAD")
+		} else if !wasAlive && alive {
+			d.Log.WithFields(logrus.Fields{
+				"dialer":  nodeName,
+				"network": typ.String(),
+			}).Infoln("Node became ALIVE")
+		}
+	}
+
 	update := collectionUpdate{
 		alive:             alive,
 		movingAverage:     collection.MovingAverage,
@@ -1007,6 +1026,18 @@ func (d *Dialer) markAvailable(typ *NetworkType, latency time.Duration) (collect
 	isRevival := !wasAlive
 	d.NotifyHealthCheckResult(typ, true, isRevival)
 	if isRevival {
+		// Log node revival for operational visibility.
+		if d.Log != nil {
+			nodeName := ""
+			if d.property != nil {
+				nodeName = d.property.Name
+			}
+			d.Log.WithFields(logrus.Fields{
+				"dialer":  nodeName,
+				"network": typ.String(),
+				"latency":  latency.String(),
+			}).Infoln("Node became ALIVE")
+		}
 		d.notifyAliveTransition(typ, true)
 	}
 

--- a/component/outbound/dialer/connectivity_check_test.go
+++ b/component/outbound/dialer/connectivity_check_test.go
@@ -19,6 +19,7 @@ import (
 	D "github.com/daeuniverse/outbound/dialer"
 	"github.com/daeuniverse/outbound/protocol/direct"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
 )
 
 func newTestDialer(t *testing.T) *Dialer {
@@ -557,4 +558,78 @@ func TestSetQuicDcidCacheClearFuncConcurrentNotify(t *testing.T) {
 	if calls.Load() == 0 {
 		t.Fatal("expected NotifyHealthCheckResult to invoke a configured callback")
 	}
+}
+
+// TestDialer_AliveForRetry_DnsUdpMirrorsToTcp locks in the fixed_fallback fix:
+// when udp_check_dns is NOT configured, the DNS-UDP collection is never probed
+// by the health-check loop and keeps its initial "alive" value forever. Trusting
+// it would reset the fixed_fallback retry counter on every DNS resolution cycle
+// and prevent fallback. AliveForRetry must mirror the liveness decision to the
+// same-family TCP collection instead.
+func TestDialer_AliveForRetry_DnsUdpMirrorsToTcp(t *testing.T) {
+	d := newTestDialer(t)
+
+	dnsUdp4 := &NetworkType{
+		L4Proto:   consts.L4ProtoStr_UDP,
+		IpVersion: consts.IpVersionStr_4,
+		IsDns:     true,
+	}
+	require.Equal(t, IdxDnsUdp4, dnsUdp4.Index(),
+		"DNS-UDP-4 must map to IdxDnsUdp4")
+
+	tcp4 := &NetworkType{
+		L4Proto:   consts.L4ProtoStr_TCP,
+		IpVersion: consts.IpVersionStr_4,
+	}
+
+	// Default: no udp_check_dns configured, so CheckDnsOptionRaw.Raw is empty.
+	require.Empty(t, d.CheckDnsOptionRaw.Raw,
+		"test dialer should have no udp_check_dns configured")
+
+	// Mirror path: DNS-UDP reports alive (stale initial), but the node's TCP is
+	// dead. AliveForRetry must mirror to TCP and report dead.
+	d.collections[IdxDnsUdp4].Alive.Store(true)
+	d.collections[IdxTcp4].Alive.Store(false)
+	require.False(t, d.AliveForRetry(dnsUdp4),
+		"AliveForRetry must mirror DNS-UDP liveness to TCP and report dead when TCP is dead")
+
+	// When TCP recovers, AliveForRetry must report alive again.
+	d.collections[IdxTcp4].Alive.Store(true)
+	require.True(t, d.AliveForRetry(dnsUdp4),
+		"AliveForRetry must report alive once the mirrored TCP collection is alive")
+
+	// Control: a plain TCP-4 query is read directly and unaffected by the
+	// DNS-UDP flag.
+	d.collections[IdxTcp4].Alive.Store(false)
+	require.False(t, d.AliveForRetry(tcp4),
+		"plain TCP-4 AliveForRetry must reflect the TCP collection directly")
+}
+
+// TestDialer_AliveForRetry_DnsUdpNoMirrorWhenConfigured covers the other branch:
+// when udp_check_dns IS configured, the DNS-UDP collection is genuinely probed,
+// so AliveForRetry must read it directly (no TCP mirror).
+func TestDialer_AliveForRetry_DnsUdpNoMirrorWhenConfigured(t *testing.T) {
+	d := newTestDialer(t)
+
+	dnsUdp4 := &NetworkType{
+		L4Proto:   consts.L4ProtoStr_UDP,
+		IpVersion: consts.IpVersionStr_4,
+		IsDns:     true,
+	}
+
+	// Configure udp_check_dns so the mirror branch is skipped.
+	d.CheckDnsOptionRaw.Raw = []string{"1.1.1.1"}
+
+	// DNS-UDP alive, TCP dead: must report alive (reads DNS-UDP directly,
+	// does NOT fall back to the dead TCP collection).
+	d.collections[IdxDnsUdp4].Alive.Store(true)
+	d.collections[IdxTcp4].Alive.Store(false)
+	require.True(t, d.AliveForRetry(dnsUdp4),
+		"with udp_check_dns configured, AliveForRetry must read DNS-UDP directly and ignore TCP")
+
+	// DNS-UDP dead: must report dead regardless of TCP.
+	d.collections[IdxDnsUdp4].Alive.Store(false)
+	d.collections[IdxTcp4].Alive.Store(true)
+	require.False(t, d.AliveForRetry(dnsUdp4),
+		"with udp_check_dns configured, a dead DNS-UDP collection must report dead even if TCP is alive")
 }

--- a/component/outbound/dialer/dialer.go
+++ b/component/outbound/dialer/dialer.go
@@ -248,6 +248,13 @@ func NewDialerContext(ctx context.Context, dialer netproxy.Dialer, option *Globa
 	}
 	collections[IdxDnsTcp4] = collections[IdxTcp4]
 	collections[IdxDnsTcp6] = collections[IdxTcp6]
+	// DNS-UDP collections (IdxDnsUdp4/6) stay independent from the TCP
+	// collections so UDP health-domain independence and snapshot/restore
+	// semantics are preserved. When udp_check_dns is not configured the
+	// DNS-UDP collection is never probed and stays alive forever; the
+	// fixed_fallback retry logic accounts for that via Dialer.AliveForRetry,
+	// which mirrors DNS-UDP liveness to the same IP family's TCP collection at
+	// the retry-decision site only.
 
 	ctx, cancel := context.WithCancel(ctx)
 	d := &Dialer{

--- a/component/outbound/dialer/dialer.go
+++ b/component/outbound/dialer/dialer.go
@@ -294,6 +294,14 @@ func (d *Dialer) CloneWithGlobalOption(option *GlobalOption) *Dialer {
 	return d.CloneWithGlobalOptionContext(d.ctx, option)
 }
 
+// Done returns the dialer's context Done channel. It lets callers (e.g. the
+// fixed_fallback background retry goroutine) stop waiting when the dialer is
+// torn down on shutdown or config reload. The underlying ctx field is
+// unexported, so this accessor is the only safe cross-package handle.
+func (d *Dialer) Done() <-chan struct{} {
+	return d.ctx.Done()
+}
+
 // CloneWithGlobalOptionContext returns a new dialer instance initialized with option.
 func (d *Dialer) CloneWithGlobalOptionContext(ctx context.Context, option *GlobalOption) *Dialer {
 	if d.property != nil && d.property.Link != "" {

--- a/component/outbound/dialer_group.go
+++ b/component/outbound/dialer_group.go
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: AGPL-3.0-only
- * Copyright (c) 2022-2026, daeuniverse Organization <dae@v2raya.org>
+ * Copyright (c) 2022-2025, daeuniverse Organization <dae@v2raya.org>
  */
 
 package outbound
@@ -17,7 +17,6 @@ import (
 	"github.com/daeuniverse/dae/component/outbound/dialer"
 	_ "github.com/daeuniverse/outbound/dialer"
 	"github.com/daeuniverse/outbound/netproxy"
-	"github.com/daeuniverse/outbound/pkg/fastrand"
 	"github.com/sirupsen/logrus"
 )
 
@@ -41,13 +40,19 @@ type DialerGroup struct {
 	resuscitateLastTime atomic.Int64
 	noAliveLogLastTimes [8]atomic.Int64
 
-	// fixed_fallback retry state
-	fixedFallbackDeadSince      atomic.Int64
-	fixedFallbackRetryCount     atomic.Int64
-	fixedFallbackLastRetryNano  atomic.Int64
+	// fixed_fallback retry state (protected by fixedFallbackMu)
+	fixedFallbackMu            sync.Mutex
+	fixedFallbackDeadSince     int64
+	fixedFallbackRetryCount    int64
+	fixedFallbackLastRetryNano int64
+	// Background retry goroutine for fixed_fallback.
+	// Started when the fixed node is first detected dead.
+	// Stopped when the node recovers (MustGetAlive=true).
+	fixedFallbackStopCh  chan struct{}
+	fixedFallbackRunning atomic.Bool
 
 	// fixed_fallback log rate limit
-	fixedFallbackLastLogMark atomic.Int64 // 0=alive, 1=dead_detected, 2+=retry_step, -1=fallen_back
+	fixedFallbackLastLogMark atomic.Int64
 	fixedFallbackLastLogTime atomic.Int64
 
 	cachedMinCheckInterval time.Duration
@@ -84,6 +89,29 @@ func NewDialerGroup(
 	group.registerAliveDialerSets(state.aliveDialerSets)
 	group.selectionState.Store(state)
 	group.cachedMinCheckInterval = group.MinCheckInterval()
+
+	// Register a callback on the fixed dialer so the background retry
+	// goroutine starts when the health check marks the node as dead,
+	// not only when traffic flows through Select().
+	if p.Policy == consts.DialerSelectionPolicy_FixedWithFallback &&
+		p.FixedIndex >= 0 && p.FixedIndex < len(dialers) {
+		fixed := dialers[p.FixedIndex]
+		if fixed != nil {
+			fixed.RegisterAliveTransitionCallback(func(nt *dialer.NetworkType, alive bool) {
+				if alive {
+					return
+				}
+				if group.fixedFallbackRunning.CompareAndSwap(false, true) {
+					group.fixedFallbackStopCh = make(chan struct{})
+					group.fixedFallbackMu.Lock()
+					group.fixedFallbackDeadSince = time.Now().UnixNano()
+					group.fixedFallbackRetryCount = 0
+					group.fixedFallbackMu.Unlock()
+					go group.runFixedFallbackRetry(fixed, p, nt)
+				}
+			})
+		}
+	}
 
 	for _, nt := range standardSelectionNetworkTypes() {
 		aliveChangeCallback(true, nt, true)
@@ -271,6 +299,24 @@ func (g *DialerGroup) resuscitate(networkType *dialer.NetworkType) {
 	}
 }
 
+// LogNoAliveDialer logs a warning when no alive dialer is found for selection.
+// It is rate-limited per network type to prevent log spam.
+func (g *DialerGroup) LogNoAliveDialer(
+	origNetworkType string,
+	selectionNetworkType *dialer.NetworkType,
+	src netip.AddrPort,
+	dst netip.AddrPort,
+	domain string,
+	strictIpVersion bool,
+) {
+	idx := selectionNetworkType.Index()
+	interval := max(g.cachedMinCheckInterval*5, 10*time.Second)
+
+	if g.tryDoRateLimitedAction(&g.noAliveLogLastTimes[idx], interval) {
+		g.logNoAlive(origNetworkType, selectionNetworkType, src, dst, domain, strictIpVersion, interval)
+	}
+}
+
 func (g *DialerGroup) logNoAlive(
 	origNetworkType string,
 	selectionNetworkType *dialer.NetworkType,
@@ -299,37 +345,60 @@ func (g *DialerGroup) logNoAlive(
 	}).Warn("no alive dialer for selection (rate-limited)")
 }
 
-// logFixedFallback logs fixed_fallback events in a state-aware manner.
-// mark is used to deduplicate: same mark → skipped, different mark → logged.
-// Special marks: 0=alive/recovery, 1=dead_detected, 2+N=retry_step, -1=fallen_back.
-func (g *DialerGroup) logFixedFallback(level logrus.Level, mark int64, dialerName, format string, args ...interface{}) {
-	// Deduplicate by mark: skip if we already logged this state
-	if g.fixedFallbackLastLogMark.Load() == mark {
-		return
-	}
-
-	g.fixedFallbackLastLogMark.Store(mark)
-
+// logFixedFallback records state transitions for the fixed_fallback policy.
+// Mark values: 0=alive/recovery, 1=dead_detected, >=10=retry step,
+// -1=fallen back to alternative.
+func (g *DialerGroup) logFixedFallback(state int64, fixed *dialer.Dialer, nt *dialer.NetworkType) {
 	if g.log == nil {
 		return
 	}
-	if !g.log.IsLevelEnabled(level) {
-		return
+	nodeName := ""
+	if fixed != nil && fixed.Property() != nil {
+		nodeName = fixed.Property().Name
 	}
 
-	entry := g.log.WithFields(logrus.Fields{
-		"group":  g.Name,
-		"dialer": dialerName,
-	})
-	switch level {
-	case logrus.InfoLevel:
-		entry.Infof(format, args...)
-	case logrus.WarnLevel:
-		entry.Warnf(format, args...)
-	case logrus.ErrorLevel:
-		entry.Errorf(format, args...)
-	default:
-		entry.Infof(format, args...)
+	switch {
+	case state == 0:
+		// Recovery: fixed dialer is alive again
+		old := g.fixedFallbackLastLogMark.Swap(0)
+		if old != 0 {
+			g.log.WithFields(logrus.Fields{
+				"group":   g.Name,
+				"dialer":  nodeName,
+				"network": nt.String(),
+			}).Infoln("Fixed dialer is ALIVE, traffic restored")
+		}
+	case state == 1:
+		// First time detecting dead: log and update state
+		old := g.fixedFallbackLastLogMark.Swap(1)
+		if old != 1 {
+			g.log.WithFields(logrus.Fields{
+				"group":   g.Name,
+				"dialer":  nodeName,
+				"network": nt.String(),
+			}).Warnln("Fixed dialer DEAD, starting retry")
+		}
+	case state >= 10:
+		// Retry: log the actual retry count (state - 10)
+		retryCount := state - 10
+		old := g.fixedFallbackLastLogMark.Swap(state)
+		if old != state {
+			g.log.WithFields(logrus.Fields{
+				"group":   g.Name,
+				"dialer":  nodeName,
+				"network": nt.String(),
+			}).Infoln("Fixed dialer retry", retryCount)
+		}
+	case state < 0:
+		// Fallen back to alternative
+		old := g.fixedFallbackLastLogMark.Swap(-1)
+		if old >= 0 {
+			g.log.WithFields(logrus.Fields{
+				"group":   g.Name,
+				"dialer":  nodeName,
+				"network": nt.String(),
+			}).Warnln("Fixed dialer DEAD, fallen back to alternative")
+		}
 	}
 }
 
@@ -407,117 +476,87 @@ func (g *DialerGroup) _select(networkType *dialer.NetworkType, state *dialerGrou
 		return g.Dialers[policy.FixedIndex], 0, selected, nil
 
 	case consts.DialerSelectionPolicy_FixedWithFallback:
-		// FixedWithFallback always prefers the configured dialer when alive.
-		// When the fixed dialer is backoff/dead, it will retry with configurable
-		// timeout and max retries before falling back to the configured fallback policy.
-		// When the fixed dialer revives, traffic automatically returns to it.
-		if policy.FixedIndex >= 0 && policy.FixedIndex < len(g.Dialers) {
-			fixedDialer := g.Dialers[policy.FixedIndex]
-			fixedName := ""
-			if p := fixedDialer.Property(); p != nil {
-				fixedName = p.Name
-			}
-
-			if fixedDialer.MustGetAlive(networkType) {
-				// Node is alive → reset retry state and use it
-				wasDead := g.fixedFallbackDeadSince.Swap(0) != 0
-				g.fixedFallbackRetryCount.Store(0)
-				if wasDead {
-					// Recovery log (rate-limited)
-					g.logFixedFallback(logrus.InfoLevel, 0, fixedName,
-						"fixed dialer recovered, traffic returned")
-				}
-				selected := preferAlternateSelectionNetworkType(fixedDialer, networkType)
-				return fixedDialer, 0, selected, nil
-			}
-			// Fixed dialer is dead. Apply retry logic with timeout.
-			nowUnix := time.Now().Unix()
-			deadSince := g.fixedFallbackDeadSince.Load()
-			retries := g.fixedFallbackRetryCount.Load()
-
-			if deadSince == 0 {
-				// First time detecting dead → record time
-				g.fixedFallbackDeadSince.Store(nowUnix)
-				g.logFixedFallback(logrus.WarnLevel, 1, fixedName,
-					"fixed dialer dead, starting retry (timeout=%v, max_retries=%d)",
-					policy.FixedFallbackTimeout, policy.FixedFallbackRetries)
-				// Keep using fixed node (will fail, but user explicitly configured it)
-				selected := preferAlternateSelectionNetworkType(fixedDialer, networkType)
-				return fixedDialer, 0, selected, nil
-			}
-
-			elapsed := time.Duration(nowUnix-deadSince) * time.Second
-			if elapsed < policy.FixedFallbackTimeout {
-				// Still within current timeout window → keep trying fixed node
-				selected := preferAlternateSelectionNetworkType(fixedDialer, networkType)
-				return fixedDialer, 0, selected, nil
-			}
-
-			// Timeout passed → dedup-protected retry count increment.
-			// Multiple networkTypes may trigger concurrently and share
-			// the same retry state; requiring FixedFallbackTimeout/2
-			// between increments prevents batch-advance of the counter.
-			nowNano := time.Now().UnixNano()
-			lastRetryNano := g.fixedFallbackLastRetryNano.Load()
-			shouldIncrement := nowNano-lastRetryNano > int64(policy.FixedFallbackTimeout)/2
-			if shouldIncrement {
-				newRetries := retries + 1
-				g.fixedFallbackLastRetryNano.Store(nowNano)
-				g.fixedFallbackRetryCount.Store(newRetries)
-				g.fixedFallbackDeadSince.Store(nowUnix)
-
-				// Log every retry, including the last one before fallback.
-				g.logFixedFallback(logrus.InfoLevel, 2+newRetries, fixedName,
-					"fixed dialer retry %d/%d", newRetries, policy.FixedFallbackRetries)
-
-				if int(newRetries) < policy.FixedFallbackRetries {
-					// Still have retries left → keep trying fixed node
-					selected := preferAlternateSelectionNetworkType(fixedDialer, networkType)
-					return fixedDialer, 0, selected, nil
-				}
-
-				// Fire emergency probes on the last timeout so the node gets
-				// a resuscitation chance before we fully fallback.
-				fixedDialer.NotifyCheckTcp()
-				fixedDialer.NotifyCheckDnsUdp()
-			}
-			// else: dedup blocks → fall through to fallback
-
-			// Max retries reached → fallback (but keep state so we don't
-			// reset until the node revives)
-			g.logFixedFallback(logrus.WarnLevel, -1, fixedName,
-				"fixed dialer retries exhausted (%d/%d), falling back to %v",
-				policy.FixedFallbackRetries, policy.FixedFallbackRetries, policy.FallbackPolicy)
+		if policy.FixedIndex < 0 || policy.FixedIndex >= len(g.Dialers) {
+			return nil, 0, nil, fmt.Errorf("selected dialer index is out of range")
 		}
-		// Fixed dialer is out of range or retries exhausted. Fall back to configured policy.
-		switch policy.FallbackPolicy {
-		case consts.DialerSelectionPolicy_Random:
-			// Random: collect all alive dialers and pick one at random.
-			var aliveList []*dialer.Dialer
-			for _, d := range g.Dialers {
-				if d.MustGetAlive(networkType) {
-					aliveList = append(aliveList, d)
-				}
+		fixed := g.Dialers[policy.FixedIndex]
+
+		fallbackPolicy := DialerSelectionPolicy{Policy: policy.FallbackPolicy}
+		networkTypes, count := g.selectionNetworkTypes(networkType, fallbackPolicy)
+
+		for i := range count {
+			a := state.aliveDialerSets[networkTypes[i].Index()]
+			if a == nil {
+				continue
 			}
-			if len(aliveList) > 0 {
-				chosen := aliveList[int(fastrand.Int63n(int64(len(aliveList))))]
-				selected := preferAlternateSelectionNetworkType(chosen, networkType)
-				return chosen, 0, selected, nil
-			}
-		default:
-			// min_* policies: use AliveDialerSet for latency-based selection.
-			networkTypes, count := g.selectionNetworkTypes(networkType, DialerSelectionPolicy{
-				Policy: policy.FallbackPolicy,
-			})
-			for i := range count {
-				a := state.aliveDialerSets[networkTypes[i].Index()]
-				if a == nil {
-					continue
+			nt := &networkTypes[i]
+
+			// Try fixed dialer first
+			if fixed != nil && fixed.MustGetAlive(nt) {
+				// Node is alive → reset retry state and use it
+				g.fixedFallbackMu.Lock()
+				wasDead := g.fixedFallbackDeadSince != 0
+				g.fixedFallbackDeadSince = 0
+				g.fixedFallbackRetryCount = 0
+				g.fixedFallbackMu.Unlock()
+				if wasDead {
+					g.logFixedFallback(0, fixed, nt)
 				}
-				d, latency := a.GetMinLatency(nil)
+				selected := preferAlternateSelectionNetworkType(fixed, nt)
+				return fixed, 0, selected, nil
+			}
+
+			// Fixed dialer is dead → fallback.
+			// Retries are handled by the background goroutine.
+			var (
+				nowNano       int64
+				deadSinceNano int64
+			)
+
+			g.fixedFallbackMu.Lock()
+			nowNano = time.Now().UnixNano()
+			deadSinceNano = g.fixedFallbackDeadSince
+
+			if deadSinceNano == 0 {
+				// First Select() finding this node dead.
+				// Start background retry goroutine if not already running
+				// (may have been started by aliveTransitionCallback already).
+				g.fixedFallbackDeadSince = nowNano
+				g.fixedFallbackRetryCount = 0
+				g.fixedFallbackMu.Unlock()
+				g.logFixedFallback(1, fixed, nt)
+
+				if g.fixedFallbackRunning.CompareAndSwap(false, true) {
+					g.fixedFallbackStopCh = make(chan struct{})
+					go g.runFixedFallbackRetry(fixed, policy, nt)
+				}
+
+				// Background goroutine handles retries separately.
+				// Natural traffic falls back immediately.
+				goto doFallback
+			}
+
+			// Node already known dead. Background goroutine owns retries.
+			// Fallback immediately — no retryCount/elapsed check.
+			g.fixedFallbackMu.Unlock()
+			g.logFixedFallback(-1, fixed, nt)
+			goto doFallback
+
+		doFallback:
+			switch policy.FallbackPolicy {
+			case consts.DialerSelectionPolicy_Random:
+				d := a.GetRandExcluded(excluded)
 				if d != nil {
-					selected := preferAlternateSelectionNetworkType(d, &networkTypes[i])
-					return d, latency, selected, nil
+					selected := preferAlternateSelectionNetworkType(d, nt)
+					return d, 0, selected, nil
+				}
+			case consts.DialerSelectionPolicy_MinLastLatency,
+				consts.DialerSelectionPolicy_MinAverage10Latencies,
+				consts.DialerSelectionPolicy_MinMovingAverageLatencies:
+				d, lat := a.GetMinLatency(excluded)
+				if d != nil {
+					selected := preferAlternateSelectionNetworkType(d, nt)
+					return d, lat, selected, nil
 				}
 			}
 		}
@@ -548,6 +587,7 @@ func (g *DialerGroup) selectionNetworkTypes(networkType *dialer.NetworkType, pol
 	count = 1
 
 	if policy.Policy == consts.DialerSelectionPolicy_Fixed ||
+		policy.Policy == consts.DialerSelectionPolicy_FixedWithFallback ||
 		networkType.L4Proto != consts.L4ProtoStr_UDP ||
 		networkType.EffectiveUdpHealthDomain() != dialer.UdpHealthDomainData {
 		return networkTypes, count
@@ -587,21 +627,21 @@ func (g *DialerGroup) buildSelectionState(policy DialerSelectionPolicy, setAlive
 		return state
 	}
 
+	// Determine the policy to use for AliveDialerSet creation.
+	// FixedWithFallback uses its FallbackPolicy so latency is tracked
+	// for min_moving_avg / min / random fallback selection.
+	aliveSetPolicy := policy.Policy
+	if policy.Policy == consts.DialerSelectionPolicy_FixedWithFallback {
+		aliveSetPolicy = policy.FallbackPolicy
+	}
+
 	specs := standardSelectionNetworkTypes()
 	keys := dialer.StandardHealthKeys()
 
 	for i, nt := range specs {
 		networkType := *nt
-		// For FixedWithFallback, build the AliveDialerSet using FallbackPolicy
-		// so that latency data is properly tracked for the fallback path.
-		// The main (fixed) path bypasses the set entirely, so using FallbackPolicy
-		// here has no adverse effect on fixed-node selection.
-		setPolicy := policy.Policy
-		if policy.Policy == consts.DialerSelectionPolicy_FixedWithFallback {
-			setPolicy = policy.FallbackPolicy
-		}
 		set := dialer.NewAliveDialerSet(
-			g.log, g.Name, &networkType, g.checkTolerance, setPolicy,
+			g.log, g.Name, &networkType, g.checkTolerance, aliveSetPolicy,
 			g.Dialers, g.dialersAnnotations,
 			func(networkType *dialer.NetworkType) func(alive bool) {
 				return func(alive bool) { g.aliveChangeCallback(alive, networkType, false) }
@@ -713,5 +753,71 @@ func alternateNetworkType(networkType *dialer.NetworkType) *dialer.NetworkType {
 		return &alt
 	default:
 		return nil
+	}
+}
+
+// runFixedFallbackRetry is a background goroutine that drives the
+// timeout × retries cycle for the fixed_fallback policy independently
+// of traffic. It fires probes at each FixedFallbackTimeout interval,
+// and after maxRetries, marks the node for fallback.
+func (g *DialerGroup) runFixedFallbackRetry(fixed *dialer.Dialer, policy DialerSelectionPolicy, nt *dialer.NetworkType) {
+	defer g.fixedFallbackRunning.Store(false)
+
+	actualTimeout := policy.FixedFallbackTimeout
+	if actualTimeout < 2*time.Second {
+		actualTimeout = 2 * time.Second
+		g.log.WithFields(logrus.Fields{
+			"group":        g.Name,
+			"configured":   policy.FixedFallbackTimeout.String(),
+			"actual":       actualTimeout.String(),
+			"node":         fixed.Property().Name,
+			"network_type": nt.String(),
+		}).Warnln("fixed_fallback timeout too low, clamped to minimum 2s to prevent probe storm")
+	}
+	ticker := time.NewTicker(actualTimeout)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-g.fixedFallbackStopCh:
+			return
+		case <-ticker.C:
+		}
+
+		// Check if node has recovered
+		if fixed.MustGetAlive(nt) {
+			g.fixedFallbackMu.Lock()
+			g.fixedFallbackDeadSince = 0
+			g.fixedFallbackRetryCount = 0
+			g.fixedFallbackMu.Unlock()
+			return
+		}
+
+		// Advance retry count
+		g.fixedFallbackMu.Lock()
+		g.fixedFallbackRetryCount++
+		g.fixedFallbackLastRetryNano = time.Now().UnixNano()
+
+		shouldFallback := g.fixedFallbackRetryCount >= int64(policy.FixedFallbackRetries)
+		if shouldFallback {
+			// Make deadSince far in the past so any Select() immediately
+			// sees elapsed >> timeout and falls back.
+			g.fixedFallbackDeadSince = time.Now().UnixNano() -
+				int64(policy.FixedFallbackTimeout)*int64(policy.FixedFallbackRetries) - 1
+		} else {
+			g.fixedFallbackDeadSince = time.Now().UnixNano()
+		}
+		g.fixedFallbackMu.Unlock()
+
+		// Fire probes — also gives the node a chance to be marked alive
+		// before the next tick.
+		fixed.NotifyCheckTcp()
+		fixed.NotifyCheckDnsUdp()
+
+		if shouldFallback {
+			g.logFixedFallback(-1, fixed, nt)
+			return
+		}
+		g.logFixedFallback(10+g.fixedFallbackRetryCount, fixed, nt)
 	}
 }

--- a/component/outbound/dialer_group.go
+++ b/component/outbound/dialer_group.go
@@ -17,6 +17,7 @@ import (
 	"github.com/daeuniverse/dae/component/outbound/dialer"
 	_ "github.com/daeuniverse/outbound/dialer"
 	"github.com/daeuniverse/outbound/netproxy"
+	"github.com/daeuniverse/outbound/pkg/fastrand"
 	"github.com/sirupsen/logrus"
 )
 
@@ -476,19 +477,37 @@ func (g *DialerGroup) _select(networkType *dialer.NetworkType, state *dialerGrou
 				policy.FixedFallbackRetries, policy.FixedFallbackRetries, policy.FallbackPolicy)
 		}
 		// Fixed dialer is out of range or retries exhausted. Fall back to configured policy.
-		networkTypes, count := g.selectionNetworkTypes(networkType, DialerSelectionPolicy{
-			Policy: policy.FallbackPolicy,
-		})
-		for i := range count {
-			a := state.aliveDialerSets[networkTypes[i].Index()]
-			if a == nil {
-				continue
+		switch policy.FallbackPolicy {
+		case consts.DialerSelectionPolicy_Random:
+			// Random: collect all alive dialers and pick one at random.
+			var aliveList []*dialer.Dialer
+			for _, d := range g.Dialers {
+				if d.MustGetAlive(networkType) {
+					aliveList = append(aliveList, d)
+				}
 			}
-			d, latency := a.GetMinLatency(nil)
-			if d != nil {
-				selected := preferAlternateSelectionNetworkType(d, &networkTypes[i])
-				return d, latency, selected, nil
+			if len(aliveList) > 0 {
+				chosen := aliveList[int(fastrand.Int63n(int64(len(aliveList))))]
+				selected := preferAlternateSelectionNetworkType(chosen, networkType)
+				return chosen, 0, selected, nil
 			}
+		default:
+			// min_* policies: use AliveDialerSet for latency-based selection.
+			networkTypes, count := g.selectionNetworkTypes(networkType, DialerSelectionPolicy{
+				Policy: policy.FallbackPolicy,
+			})
+			for i := range count {
+				a := state.aliveDialerSets[networkTypes[i].Index()]
+				if a == nil {
+					continue
+				}
+				d, latency := a.GetMinLatency(nil)
+				if d != nil {
+					selected := preferAlternateSelectionNetworkType(d, &networkTypes[i])
+					return d, latency, selected, nil
+				}
+			}
+		}
 		}
 		return nil, time.Hour, nil, ErrNoAliveDialer
 
@@ -560,8 +579,16 @@ func (g *DialerGroup) buildSelectionState(policy DialerSelectionPolicy, setAlive
 
 	for i, nt := range specs {
 		networkType := *nt
+		// For FixedWithFallback, build the AliveDialerSet using FallbackPolicy
+		// so that latency data is properly tracked for the fallback path.
+		// The main (fixed) path bypasses the set entirely, so using FallbackPolicy
+		// here has no adverse effect on fixed-node selection.
+		setPolicy := policy.Policy
+		if policy.Policy == consts.DialerSelectionPolicy_FixedWithFallback {
+			setPolicy = policy.FallbackPolicy
+		}
 		set := dialer.NewAliveDialerSet(
-			g.log, g.Name, &networkType, g.checkTolerance, policy.Policy,
+			g.log, g.Name, &networkType, g.checkTolerance, setPolicy,
 			g.Dialers, g.dialersAnnotations,
 			func(networkType *dialer.NetworkType) func(alive bool) {
 				return func(alive bool) { g.aliveChangeCallback(alive, networkType, false) }

--- a/component/outbound/dialer_group.go
+++ b/component/outbound/dialer_group.go
@@ -605,7 +605,6 @@ func (g *DialerGroup) _select(networkType *dialer.NetworkType, state *dialerGrou
 				}
 			}
 		}
-		}
 		return nil, time.Hour, nil, ErrNoAliveDialer
 
 	case consts.DialerSelectionPolicy_MinLastLatency,

--- a/component/outbound/dialer_group.go
+++ b/component/outbound/dialer_group.go
@@ -400,6 +400,28 @@ func (g *DialerGroup) logFixedFallback(state int64, fixed *dialer.Dialer, nt *di
 	}
 }
 
+// logFixedFallbackDetail logs the actual fallback target after selection.
+func (g *DialerGroup) logFixedFallbackDetail(fixed, fallbackDialer *dialer.Dialer, nt *dialer.NetworkType, latency time.Duration) {
+	if g.log == nil {
+		return
+	}
+	fixedName := ""
+	if fixed != nil && fixed.Property() != nil {
+		fixedName = fixed.Property().Name
+	}
+	fallbackName := ""
+	if fallbackDialer != nil && fallbackDialer.Property() != nil {
+		fallbackName = fallbackDialer.Property().Name
+	}
+	g.log.WithFields(logrus.Fields{
+		"group":    g.Name,
+		"fixed":    fixedName,
+		"fallback": fallbackName,
+		"network":  nt.String(),
+		"latency":  latency.String(),
+	}).Warnln("Fixed dialer DEAD, fallback to", fallbackName)
+}
+
 // Select is a backward-compatible wrapper for SelectWithExclusion.
 func (g *DialerGroup) Select(networkType *dialer.NetworkType, strictIpVersion bool) (d *dialer.Dialer, latency time.Duration, err error) {
 	d, latency, _, err = g.SelectWithExclusionResult(networkType, strictIpVersion, nil)
@@ -555,6 +577,7 @@ func (g *DialerGroup) _select(networkType *dialer.NetworkType, state *dialerGrou
 			case consts.DialerSelectionPolicy_Random:
 				d := a.GetRandExcluded(excluded)
 				if d != nil {
+					g.logFixedFallbackDetail(fixed, d, nt, 0)
 					selected := preferAlternateSelectionNetworkType(d, nt)
 					return d, 0, selected, nil
 				}
@@ -563,6 +586,7 @@ func (g *DialerGroup) _select(networkType *dialer.NetworkType, state *dialerGrou
 				consts.DialerSelectionPolicy_MinMovingAverageLatencies:
 				d, lat := a.GetMinLatency(excluded)
 				if d != nil {
+					g.logFixedFallbackDetail(fixed, d, nt, lat)
 					selected := preferAlternateSelectionNetworkType(d, nt)
 					return d, lat, selected, nil
 				}

--- a/component/outbound/dialer_group.go
+++ b/component/outbound/dialer_group.go
@@ -414,7 +414,7 @@ func (g *DialerGroup) _select(networkType *dialer.NetworkType, state *dialerGrou
 	case consts.DialerSelectionPolicy_FixedWithFallback:
 		// FixedWithFallback always prefers the configured dialer when alive.
 		// When the fixed dialer is backoff/dead, it will retry with configurable
-		// timeout and max retries before falling back to min_moving_avg.
+		// timeout and max retries before falling back to the configured fallback policy.
 		// When the fixed dialer revives, traffic automatically returns to it.
 		if policy.FixedIndex >= 0 && policy.FixedIndex < len(g.Dialers) {
 			fixedDialer := g.Dialers[policy.FixedIndex]
@@ -472,12 +472,12 @@ func (g *DialerGroup) _select(networkType *dialer.NetworkType, state *dialerGrou
 			// Max retries reached → fallback (but keep state so we don't
 			// reset until the node revives)
 			g.logFixedFallback(logrus.WarnLevel, -1, fixedName,
-				"fixed dialer retries exhausted (%d/%d), falling back to min_moving_avg",
-				policy.FixedFallbackRetries, policy.FixedFallbackRetries)
+				"fixed dialer retries exhausted (%d/%d), falling back to %v",
+				policy.FixedFallbackRetries, policy.FixedFallbackRetries, policy.FallbackPolicy)
 		}
-		// Fixed dialer is out of range or retries exhausted. Fall back to min_moving_avg.
+		// Fixed dialer is out of range or retries exhausted. Fall back to configured policy.
 		networkTypes, count := g.selectionNetworkTypes(networkType, DialerSelectionPolicy{
-			Policy: consts.DialerSelectionPolicy_MinMovingAverageLatencies,
+			Policy: policy.FallbackPolicy,
 		})
 		for i := range count {
 			a := state.aliveDialerSets[networkTypes[i].Index()]

--- a/component/outbound/dialer_group.go
+++ b/component/outbound/dialer_group.go
@@ -54,6 +54,9 @@ type DialerGroup struct {
 	// fixed_fallback log rate limit
 	fixedFallbackLastLogMark atomic.Int64
 
+	// fixed_fallback detail log rate limit (timestamp-based, 10s cooldown)
+	fixedFallbackDetailLog atomic.Int64
+
 	cachedMinCheckInterval time.Duration
 }
 
@@ -401,8 +404,18 @@ func (g *DialerGroup) logFixedFallback(state int64, fixed *dialer.Dialer, nt *di
 }
 
 // logFixedFallbackDetail logs the actual fallback target after selection.
+// Rate-limited to once per 10 seconds to prevent log spam under high traffic.
 func (g *DialerGroup) logFixedFallbackDetail(fixed, fallbackDialer *dialer.Dialer, nt *dialer.NetworkType, latency time.Duration) {
 	if g.log == nil {
+		return
+	}
+	// Rate limit: allow one log per 10 seconds.
+	now := time.Now().UnixNano()
+	last := g.fixedFallbackDetailLog.Load()
+	if now-last < 10*int64(time.Second) {
+		return
+	}
+	if !g.fixedFallbackDetailLog.CompareAndSwap(last, now) {
 		return
 	}
 	fixedName := ""

--- a/component/outbound/dialer_group.go
+++ b/component/outbound/dialer_group.go
@@ -362,6 +362,36 @@ func (g *DialerGroup) _select(networkType *dialer.NetworkType, state *dialerGrou
 		selected := preferAlternateSelectionNetworkType(g.Dialers[policy.FixedIndex], networkType)
 		return g.Dialers[policy.FixedIndex], 0, selected, nil
 
+	case consts.DialerSelectionPolicy_FixedWithFallback:
+		// FixedWithFallback always prefers the configured dialer when alive.
+		// When the fixed dialer is backoff/dead, it falls back to
+		// min_moving_avg selection among all alive dialers.
+		// When the fixed dialer revives (periodic health check restores it),
+		// traffic automatically returns to it.
+		if policy.FixedIndex >= 0 && policy.FixedIndex < len(g.Dialers) {
+			fixedDialer := g.Dialers[policy.FixedIndex]
+			if fixedDialer.MustGetAlive(networkType) {
+				selected := preferAlternateSelectionNetworkType(fixedDialer, networkType)
+				return fixedDialer, 0, selected, nil
+			}
+		}
+		// Fixed dialer is out of range or not alive. Fall back to min_moving_avg.
+		networkTypes, count := g.selectionNetworkTypes(networkType, DialerSelectionPolicy{
+			Policy: consts.DialerSelectionPolicy_MinMovingAverageLatencies,
+		})
+		for i := range count {
+			a := state.aliveDialerSets[networkTypes[i].Index()]
+			if a == nil {
+				continue
+			}
+			d, latency := a.GetMinLatency(nil)
+			if d != nil {
+				selected := preferAlternateSelectionNetworkType(d, &networkTypes[i])
+				return d, latency, selected, nil
+			}
+		}
+		return nil, time.Hour, nil, ErrNoAliveDialer
+
 	case consts.DialerSelectionPolicy_MinLastLatency,
 		consts.DialerSelectionPolicy_MinAverage10Latencies,
 		consts.DialerSelectionPolicy_MinMovingAverageLatencies:
@@ -476,7 +506,8 @@ func policyNeedsAliveState(policy consts.DialerSelectionPolicy) bool {
 	case consts.DialerSelectionPolicy_Random,
 		consts.DialerSelectionPolicy_MinLastLatency,
 		consts.DialerSelectionPolicy_MinAverage10Latencies,
-		consts.DialerSelectionPolicy_MinMovingAverageLatencies:
+		consts.DialerSelectionPolicy_MinMovingAverageLatencies,
+		consts.DialerSelectionPolicy_FixedWithFallback:
 		return true
 	case consts.DialerSelectionPolicy_Fixed:
 		return false

--- a/component/outbound/dialer_group.go
+++ b/component/outbound/dialer_group.go
@@ -51,6 +51,14 @@ type DialerGroup struct {
 	// Stopped when the node recovers (MustGetAlive=true).
 	fixedFallbackRunning atomic.Bool
 
+	// fixedFallbackNt is the networkType the background retry goroutine is
+	// currently probing. Set when the goroutine starts, cleared when it exits.
+	// Keyed so a select on a different networkType (partial node death, e.g.
+	// TCP alive while UDP dead) does not reset this networkType's retry state,
+	// which would otherwise cause log jitter and prevent the goroutine from
+	// settling (see M1 review).
+	fixedFallbackNt *dialer.NetworkType
+
 	// fixed_fallback log rate limit
 	fixedFallbackLastLogMark atomic.Int64
 
@@ -105,6 +113,19 @@ func NewDialerGroup(
 	// one-shot guard) will be required to avoid duplicate goroutines.
 	if p.Policy == consts.DialerSelectionPolicy_FixedWithFallback &&
 		p.FixedIndex >= 0 && p.FixedIndex < len(dialers) {
+		// H1: if health check is disabled (check_interval==0) but the policy
+		// asks for retries, the background retry probes are silently dropped
+		// (aliveBackground returns early when CheckInterval==0), so timeout/
+		// retries never take effect - the node falls back permanently on the
+		// first failure. Warn loudly at startup so the misconfiguration is
+		// visible (the generic "Health check is DISABLED" warning does not
+		// mention this policy-specific consequence).
+		if p.FixedFallbackRetries > 0 && group.cachedMinCheckInterval == 0 {
+			log.Warnf("fixed_fallback: retries=%d but check_interval=0 (health check disabled). "+
+				"Retry probes will be silently dropped; the fixed node will fallback permanently on first failure. "+
+				"Set check_interval>0 to enable retry probes, or set retries=0 to skip retry explicitly.",
+				p.FixedFallbackRetries)
+		}
 		fixed := dialers[p.FixedIndex]
 		if fixed != nil {
 			fixed.RegisterAliveTransitionCallback(func(nt *dialer.NetworkType, alive bool) {
@@ -534,17 +555,24 @@ func (g *DialerGroup) _select(networkType *dialer.NetworkType, state *dialerGrou
 
 			// Try fixed dialer first
 			if fixed != nil && fixed.AliveForRetry(nt) {
-				// Node is alive → reset retry state and use it
 				g.fixedFallbackMu.Lock()
-				wasDead := g.fixedFallbackDeadSince != 0
-				g.fixedFallbackDeadSince = 0
-				g.fixedFallbackRetryCount = 0
-				g.fixedFallbackLastRetryNano = 0
-				g.fixedFallbackDone = false
-				g.fixedFallbackMu.Unlock()
-				if wasDead {
-					g.logFixedFallback(0, fixed, nt)
+				// Only a select on the networkType the retry goroutine is
+				// tracking may clear the dead/retry state. A different
+				// networkType (e.g. TCP alive while UDP is dead) must not
+				// reset UDP's retry, otherwise partial death causes log
+				// jitter and the goroutine never settles (see M1 review).
+				if g.fixedFallbackNt == nil || nt.Index() == g.fixedFallbackNt.Index() {
+					// Node is alive -> reset retry state and use it
+					wasDead := g.fixedFallbackDeadSince != 0
+					g.fixedFallbackDeadSince = 0
+					g.fixedFallbackRetryCount = 0
+					g.fixedFallbackLastRetryNano = 0
+					g.fixedFallbackDone = false
+					if wasDead {
+						g.logFixedFallback(0, fixed, nt)
+					}
 				}
+				g.fixedFallbackMu.Unlock()
 				selected := preferAlternateSelectionNetworkType(fixed, nt)
 				return fixed, 0, selected, nil
 			}
@@ -611,6 +639,15 @@ func (g *DialerGroup) _select(networkType *dialer.NetworkType, state *dialerGrou
 					selected := preferAlternateSelectionNetworkType(d, nt)
 					return d, lat, selected, nil
 				}
+			default:
+				// M3: defensive fallback. FallbackPolicy should only ever be
+				// one of the four handled cases above (the parser rejects
+				// fixed/fixed_fallback and unknown names), but guard against a
+				// zero value or a future policy constant so a misconfigured
+				// FallbackPolicy is surfaced instead of silently returning
+				// ErrNoAliveDialer.
+				g.log.Warnf("fixed_fallback: FallbackPolicy %q is not handled by doFallback; no fallback dialer selected", policy.FallbackPolicy)
+			}
 			}
 		}
 		return nil, time.Hour, nil, ErrNoAliveDialer
@@ -824,6 +861,17 @@ func (g *DialerGroup) resetFixedFallback() {
 // and after maxRetries, marks the node for fallback.
 func (g *DialerGroup) runFixedFallbackRetry(fixed *dialer.Dialer, policy DialerSelectionPolicy, nt *dialer.NetworkType) {
 	defer g.fixedFallbackRunning.Store(false)
+	// Track which networkType this goroutine is probing so a select on a
+	// different networkType (partial node death, e.g. TCP alive / UDP dead)
+	// does not reset this networkType's retry state (see M1 review).
+	defer func() {
+		g.fixedFallbackMu.Lock()
+		g.fixedFallbackNt = nil
+		g.fixedFallbackMu.Unlock()
+	}()
+	g.fixedFallbackMu.Lock()
+	g.fixedFallbackNt = nt
+	g.fixedFallbackMu.Unlock()
 
 	// retries <= 0: give up immediately, no ticker needed.
 	// Node stays marked as done until health check recovers it.
@@ -855,7 +903,13 @@ func (g *DialerGroup) runFixedFallbackRetry(fixed *dialer.Dialer, policy DialerS
 	defer ticker.Stop()
 
 	for {
-		<-ticker.C
+		select {
+			case <-ticker.C:
+			case <-fixed.Done():
+				// dae is shutting down or the dialer was replaced by a reload;
+				// stop probing instead of blocking until retries are exhausted.
+				return
+			}
 
 		// Check if node has recovered
 		if fixed.AliveForRetry(nt) {

--- a/component/outbound/dialer_group.go
+++ b/component/outbound/dialer_group.go
@@ -40,6 +40,14 @@ type DialerGroup struct {
 	resuscitateLastTime atomic.Int64
 	noAliveLogLastTimes [8]atomic.Int64
 
+	// fixed_fallback retry state
+	fixedFallbackDeadSince  atomic.Int64
+	fixedFallbackRetryCount atomic.Int64
+
+	// fixed_fallback log rate limit
+	fixedFallbackLastLogMark atomic.Int64 // 0=alive, 1=dead_detected, 2+=retry_step, -1=fallen_back
+	fixedFallbackLastLogTime atomic.Int64
+
 	cachedMinCheckInterval time.Duration
 }
 
@@ -289,6 +297,47 @@ func (g *DialerGroup) logNoAlive(
 	}).Warn("no alive dialer for selection (rate-limited)")
 }
 
+// logFixedFallback logs fixed_fallback events in a rate-limited, state-aware manner.
+// mark is used to deduplicate: same mark → skipped, different mark → logged.
+// Special marks: 0=alive/recovery, 1=dead_detected, 2+N=retry_step, -1=fallen_back.
+func (g *DialerGroup) logFixedFallback(level logrus.Level, mark int64, dialerName, format string, args ...interface{}) {
+	const logInterval = 10 * time.Second
+
+	// Deduplicate by mark: skip if we already logged this state
+	if g.fixedFallbackLastLogMark.Load() == mark {
+		return
+	}
+
+	// Rate limit: max one log per interval
+	if !g.tryDoRateLimitedAction(&g.fixedFallbackLastLogTime, logInterval) {
+		return
+	}
+
+	g.fixedFallbackLastLogMark.Store(mark)
+
+	if g.log == nil {
+		return
+	}
+	if !g.log.IsLevelEnabled(level) {
+		return
+	}
+
+	entry := g.log.WithFields(logrus.Fields{
+		"group":  g.Name,
+		"dialer": dialerName,
+	})
+	switch level {
+	case logrus.InfoLevel:
+		entry.Infof(format, args...)
+	case logrus.WarnLevel:
+		entry.Warnf(format, args...)
+	case logrus.ErrorLevel:
+		entry.Errorf(format, args...)
+	default:
+		entry.Infof(format, args...)
+	}
+}
+
 // Select is a backward-compatible wrapper for SelectWithExclusion.
 func (g *DialerGroup) Select(networkType *dialer.NetworkType, strictIpVersion bool) (d *dialer.Dialer, latency time.Duration, err error) {
 	d, latency, _, err = g.SelectWithExclusionResult(networkType, strictIpVersion, nil)
@@ -364,18 +413,69 @@ func (g *DialerGroup) _select(networkType *dialer.NetworkType, state *dialerGrou
 
 	case consts.DialerSelectionPolicy_FixedWithFallback:
 		// FixedWithFallback always prefers the configured dialer when alive.
-		// When the fixed dialer is backoff/dead, it falls back to
-		// min_moving_avg selection among all alive dialers.
-		// When the fixed dialer revives (periodic health check restores it),
-		// traffic automatically returns to it.
+		// When the fixed dialer is backoff/dead, it will retry with configurable
+		// timeout and max retries before falling back to min_moving_avg.
+		// When the fixed dialer revives, traffic automatically returns to it.
 		if policy.FixedIndex >= 0 && policy.FixedIndex < len(g.Dialers) {
 			fixedDialer := g.Dialers[policy.FixedIndex]
+			fixedName := ""
+			if p := fixedDialer.Property(); p != nil {
+				fixedName = p.Name
+			}
+
 			if fixedDialer.MustGetAlive(networkType) {
+				// Node is alive → reset retry state and use it
+				wasDead := g.fixedFallbackDeadSince.Swap(0) != 0
+				g.fixedFallbackRetryCount.Store(0)
+				if wasDead {
+					// Recovery log (rate-limited)
+					g.logFixedFallback(logrus.InfoLevel, 0, fixedName,
+						"fixed dialer recovered, traffic returned")
+				}
 				selected := preferAlternateSelectionNetworkType(fixedDialer, networkType)
 				return fixedDialer, 0, selected, nil
 			}
+			// Fixed dialer is dead. Apply retry logic with timeout.
+			nowUnix := time.Now().Unix()
+			deadSince := g.fixedFallbackDeadSince.Load()
+			retries := g.fixedFallbackRetryCount.Load()
+
+			if deadSince == 0 {
+				// First time detecting dead → record time
+				g.fixedFallbackDeadSince.Store(nowUnix)
+				g.logFixedFallback(logrus.WarnLevel, 1, fixedName,
+					"fixed dialer dead, starting retry (timeout=%v, max_retries=%d)",
+					policy.FixedFallbackTimeout, policy.FixedFallbackRetries)
+				// Keep using fixed node (will fail, but user explicitly configured it)
+				selected := preferAlternateSelectionNetworkType(fixedDialer, networkType)
+				return fixedDialer, 0, selected, nil
+			}
+
+			elapsed := time.Duration(nowUnix-deadSince) * time.Second
+			if elapsed < policy.FixedFallbackTimeout {
+				// Still within current timeout window → keep trying fixed node
+				selected := preferAlternateSelectionNetworkType(fixedDialer, networkType)
+				return fixedDialer, 0, selected, nil
+			}
+
+			// Timeout passed → this counts as one retry
+			newRetries := retries + 1
+			if int(newRetries) < policy.FixedFallbackRetries {
+				// Still have retries left → reset timer, keep trying
+				g.fixedFallbackRetryCount.Store(newRetries)
+				g.fixedFallbackDeadSince.Store(nowUnix)
+				g.logFixedFallback(logrus.InfoLevel, 2+newRetries, fixedName,
+					"fixed dialer retry %d/%d", newRetries, policy.FixedFallbackRetries)
+				selected := preferAlternateSelectionNetworkType(fixedDialer, networkType)
+				return fixedDialer, 0, selected, nil
+			}
+			// Max retries reached → fallback (but keep state so we don't
+			// reset until the node revives)
+			g.logFixedFallback(logrus.WarnLevel, -1, fixedName,
+				"fixed dialer retries exhausted (%d/%d), falling back to min_moving_avg",
+				policy.FixedFallbackRetries, policy.FixedFallbackRetries)
 		}
-		// Fixed dialer is out of range or not alive. Fall back to min_moving_avg.
+		// Fixed dialer is out of range or retries exhausted. Fall back to min_moving_avg.
 		networkTypes, count := g.selectionNetworkTypes(networkType, DialerSelectionPolicy{
 			Policy: consts.DialerSelectionPolicy_MinMovingAverageLatencies,
 		})

--- a/component/outbound/dialer_group.go
+++ b/component/outbound/dialer_group.go
@@ -45,15 +45,14 @@ type DialerGroup struct {
 	fixedFallbackDeadSince     int64
 	fixedFallbackRetryCount    int64
 	fixedFallbackLastRetryNano int64
+	fixedFallbackDone          bool
 	// Background retry goroutine for fixed_fallback.
 	// Started when the fixed node is first detected dead.
 	// Stopped when the node recovers (MustGetAlive=true).
-	fixedFallbackStopCh  chan struct{}
 	fixedFallbackRunning atomic.Bool
 
 	// fixed_fallback log rate limit
 	fixedFallbackLastLogMark atomic.Int64
-	fixedFallbackLastLogTime atomic.Int64
 
 	cachedMinCheckInterval time.Duration
 }
@@ -102,8 +101,7 @@ func NewDialerGroup(
 					return
 				}
 				if group.fixedFallbackRunning.CompareAndSwap(false, true) {
-					group.fixedFallbackStopCh = make(chan struct{})
-					group.fixedFallbackMu.Lock()
+				group.fixedFallbackMu.Lock()
 					group.fixedFallbackDeadSince = time.Now().UnixNano()
 					group.fixedFallbackRetryCount = 0
 					group.fixedFallbackMu.Unlock()
@@ -498,6 +496,8 @@ func (g *DialerGroup) _select(networkType *dialer.NetworkType, state *dialerGrou
 				wasDead := g.fixedFallbackDeadSince != 0
 				g.fixedFallbackDeadSince = 0
 				g.fixedFallbackRetryCount = 0
+				g.fixedFallbackLastRetryNano = 0
+				g.fixedFallbackDone = false
 				g.fixedFallbackMu.Unlock()
 				if wasDead {
 					g.logFixedFallback(0, fixed, nt)
@@ -516,19 +516,27 @@ func (g *DialerGroup) _select(networkType *dialer.NetworkType, state *dialerGrou
 			g.fixedFallbackMu.Lock()
 			nowNano = time.Now().UnixNano()
 			deadSinceNano = g.fixedFallbackDeadSince
+			done := g.fixedFallbackDone
+
+			if done {
+				// Retries exhausted by background goroutine.
+				// Fallback until health check recovers the node.
+				g.fixedFallbackMu.Unlock()
+				g.logFixedFallback(-1, fixed, nt)
+				goto doFallback
+			}
 
 			if deadSinceNano == 0 {
 				// First Select() finding this node dead.
-				// Start background retry goroutine if not already running
-				// (may have been started by aliveTransitionCallback already).
 				g.fixedFallbackDeadSince = nowNano
 				g.fixedFallbackRetryCount = 0
 				g.fixedFallbackMu.Unlock()
 				g.logFixedFallback(1, fixed, nt)
 
+				// Start background retry goroutine if not already running
+				// (may have been started by aliveTransitionCallback already).
 				if g.fixedFallbackRunning.CompareAndSwap(false, true) {
-					g.fixedFallbackStopCh = make(chan struct{})
-					go g.runFixedFallbackRetry(fixed, policy, nt)
+				go g.runFixedFallbackRetry(fixed, policy, nt)
 				}
 
 				// Background goroutine handles retries separately.
@@ -756,12 +764,33 @@ func alternateNetworkType(networkType *dialer.NetworkType) *dialer.NetworkType {
 	}
 }
 
+// resetFixedFallback clears all fixed_fallback retry state.
+func (g *DialerGroup) resetFixedFallback() {
+	g.fixedFallbackMu.Lock()
+	g.fixedFallbackDeadSince = 0
+	g.fixedFallbackRetryCount = 0
+	g.fixedFallbackLastRetryNano = 0
+	g.fixedFallbackDone = false
+	g.fixedFallbackMu.Unlock()
+}
+
 // runFixedFallbackRetry is a background goroutine that drives the
 // timeout × retries cycle for the fixed_fallback policy independently
 // of traffic. It fires probes at each FixedFallbackTimeout interval,
 // and after maxRetries, marks the node for fallback.
 func (g *DialerGroup) runFixedFallbackRetry(fixed *dialer.Dialer, policy DialerSelectionPolicy, nt *dialer.NetworkType) {
 	defer g.fixedFallbackRunning.Store(false)
+
+	// retries <= 0: give up immediately, no ticker needed.
+	// Node stays marked as done until health check recovers it.
+	if policy.FixedFallbackRetries <= 0 {
+		g.fixedFallbackMu.Lock()
+		g.fixedFallbackDone = true
+		g.fixedFallbackDeadSince = time.Now().UnixNano() - 1
+		g.fixedFallbackMu.Unlock()
+		g.logFixedFallback(-1, fixed, nt)
+		return
+	}
 
 	actualTimeout := policy.FixedFallbackTimeout
 	if actualTimeout < 2*time.Second {
@@ -779,17 +808,12 @@ func (g *DialerGroup) runFixedFallbackRetry(fixed *dialer.Dialer, policy DialerS
 
 	for {
 		select {
-		case <-g.fixedFallbackStopCh:
-			return
 		case <-ticker.C:
 		}
 
 		// Check if node has recovered
 		if fixed.MustGetAlive(nt) {
-			g.fixedFallbackMu.Lock()
-			g.fixedFallbackDeadSince = 0
-			g.fixedFallbackRetryCount = 0
-			g.fixedFallbackMu.Unlock()
+			g.resetFixedFallback()
 			return
 		}
 
@@ -800,10 +824,8 @@ func (g *DialerGroup) runFixedFallbackRetry(fixed *dialer.Dialer, policy DialerS
 
 		shouldFallback := g.fixedFallbackRetryCount >= int64(policy.FixedFallbackRetries)
 		if shouldFallback {
-			// Make deadSince far in the past so any Select() immediately
-			// sees elapsed >> timeout and falls back.
-			g.fixedFallbackDeadSince = time.Now().UnixNano() -
-				int64(policy.FixedFallbackTimeout)*int64(policy.FixedFallbackRetries) - 1
+			g.fixedFallbackDone = true
+			g.fixedFallbackDeadSince = time.Now().UnixNano() - 1
 		} else {
 			g.fixedFallbackDeadSince = time.Now().UnixNano()
 		}

--- a/component/outbound/dialer_group.go
+++ b/component/outbound/dialer_group.go
@@ -108,7 +108,7 @@ func NewDialerGroup(
 					group.fixedFallbackDeadSince = time.Now().UnixNano()
 					group.fixedFallbackRetryCount = 0
 					group.fixedFallbackMu.Unlock()
-					go group.runFixedFallbackRetry(fixed, p, nt)
+					go group.runFixedFallbackRetry(fixed, group.currentSelectionState().policy, nt)
 				}
 			})
 		}

--- a/component/outbound/dialer_group.go
+++ b/component/outbound/dialer_group.go
@@ -42,8 +42,9 @@ type DialerGroup struct {
 	noAliveLogLastTimes [8]atomic.Int64
 
 	// fixed_fallback retry state
-	fixedFallbackDeadSince  atomic.Int64
-	fixedFallbackRetryCount atomic.Int64
+	fixedFallbackDeadSince      atomic.Int64
+	fixedFallbackRetryCount     atomic.Int64
+	fixedFallbackLastRetryNano  atomic.Int64
 
 	// fixed_fallback log rate limit
 	fixedFallbackLastLogMark atomic.Int64 // 0=alive, 1=dead_detected, 2+=retry_step, -1=fallen_back
@@ -298,19 +299,12 @@ func (g *DialerGroup) logNoAlive(
 	}).Warn("no alive dialer for selection (rate-limited)")
 }
 
-// logFixedFallback logs fixed_fallback events in a rate-limited, state-aware manner.
+// logFixedFallback logs fixed_fallback events in a state-aware manner.
 // mark is used to deduplicate: same mark → skipped, different mark → logged.
 // Special marks: 0=alive/recovery, 1=dead_detected, 2+N=retry_step, -1=fallen_back.
 func (g *DialerGroup) logFixedFallback(level logrus.Level, mark int64, dialerName, format string, args ...interface{}) {
-	const logInterval = 10 * time.Second
-
 	// Deduplicate by mark: skip if we already logged this state
 	if g.fixedFallbackLastLogMark.Load() == mark {
-		return
-	}
-
-	// Rate limit: max one log per interval
-	if !g.tryDoRateLimitedAction(&g.fixedFallbackLastLogTime, logInterval) {
 		return
 	}
 
@@ -459,17 +453,36 @@ func (g *DialerGroup) _select(networkType *dialer.NetworkType, state *dialerGrou
 				return fixedDialer, 0, selected, nil
 			}
 
-			// Timeout passed → this counts as one retry
-			newRetries := retries + 1
-			if int(newRetries) < policy.FixedFallbackRetries {
-				// Still have retries left → reset timer, keep trying
+			// Timeout passed → dedup-protected retry count increment.
+			// Multiple networkTypes may trigger concurrently and share
+			// the same retry state; requiring FixedFallbackTimeout/2
+			// between increments prevents batch-advance of the counter.
+			nowNano := time.Now().UnixNano()
+			lastRetryNano := g.fixedFallbackLastRetryNano.Load()
+			shouldIncrement := nowNano-lastRetryNano > int64(policy.FixedFallbackTimeout)/2
+			if shouldIncrement {
+				newRetries := retries + 1
+				g.fixedFallbackLastRetryNano.Store(nowNano)
 				g.fixedFallbackRetryCount.Store(newRetries)
 				g.fixedFallbackDeadSince.Store(nowUnix)
+
+				// Log every retry, including the last one before fallback.
 				g.logFixedFallback(logrus.InfoLevel, 2+newRetries, fixedName,
 					"fixed dialer retry %d/%d", newRetries, policy.FixedFallbackRetries)
-				selected := preferAlternateSelectionNetworkType(fixedDialer, networkType)
-				return fixedDialer, 0, selected, nil
+
+				if int(newRetries) < policy.FixedFallbackRetries {
+					// Still have retries left → keep trying fixed node
+					selected := preferAlternateSelectionNetworkType(fixedDialer, networkType)
+					return fixedDialer, 0, selected, nil
+				}
+
+				// Fire emergency probes on the last timeout so the node gets
+				// a resuscitation chance before we fully fallback.
+				fixedDialer.NotifyCheckTcp()
+				fixedDialer.NotifyCheckDnsUdp()
 			}
+			// else: dedup blocks → fall through to fallback
+
 			// Max retries reached → fallback (but keep state so we don't
 			// reset until the node revives)
 			g.logFixedFallback(logrus.WarnLevel, -1, fixedName,

--- a/component/outbound/dialer_group.go
+++ b/component/outbound/dialer_group.go
@@ -104,7 +104,7 @@ func NewDialerGroup(
 					return
 				}
 				if group.fixedFallbackRunning.CompareAndSwap(false, true) {
-				group.fixedFallbackMu.Lock()
+					group.fixedFallbackMu.Lock()
 					group.fixedFallbackDeadSince = time.Now().UnixNano()
 					group.fixedFallbackRetryCount = 0
 					group.fixedFallbackMu.Unlock()
@@ -525,7 +525,7 @@ func (g *DialerGroup) _select(networkType *dialer.NetworkType, state *dialerGrou
 			nt := &networkTypes[i]
 
 			// Try fixed dialer first
-			if fixed != nil && fixed.MustGetAlive(nt) {
+			if fixed != nil && fixed.AliveForRetry(nt) {
 				// Node is alive → reset retry state and use it
 				g.fixedFallbackMu.Lock()
 				wasDead := g.fixedFallbackDeadSince != 0
@@ -571,7 +571,7 @@ func (g *DialerGroup) _select(networkType *dialer.NetworkType, state *dialerGrou
 				// Start background retry goroutine if not already running
 				// (may have been started by aliveTransitionCallback already).
 				if g.fixedFallbackRunning.CompareAndSwap(false, true) {
-				go g.runFixedFallbackRetry(fixed, policy, nt)
+					go g.runFixedFallbackRetry(fixed, policy, nt)
 				}
 
 				// Background goroutine handles retries separately.
@@ -844,12 +844,10 @@ func (g *DialerGroup) runFixedFallbackRetry(fixed *dialer.Dialer, policy DialerS
 	defer ticker.Stop()
 
 	for {
-		select {
-		case <-ticker.C:
-		}
+		<-ticker.C
 
 		// Check if node has recovered
-		if fixed.MustGetAlive(nt) {
+		if fixed.AliveForRetry(nt) {
 			g.resetFixedFallback()
 			return
 		}

--- a/component/outbound/dialer_group.go
+++ b/component/outbound/dialer_group.go
@@ -95,6 +95,14 @@ func NewDialerGroup(
 	// Register a callback on the fixed dialer so the background retry
 	// goroutine starts when the health check marks the node as dead,
 	// not only when traffic flows through Select().
+	//
+	// NOTE: RegisterAliveTransitionCallback only appends and is never
+	// unregistered (see dialer.go). This is currently safe because a
+	// config reload builds a fresh DialerGroup via Clone(), discarding
+	// the old dialer instances and their callbacks, so no callback
+	// leak accumulates across reloads. If DialerGroup ever gains an
+	// in-place update path that reuses dialers, an Unregister (or a
+	// one-shot guard) will be required to avoid duplicate goroutines.
 	if p.Policy == consts.DialerSelectionPolicy_FixedWithFallback &&
 		p.FixedIndex >= 0 && p.FixedIndex < len(dialers) {
 		fixed := dialers[p.FixedIndex]
@@ -831,11 +839,15 @@ func (g *DialerGroup) runFixedFallbackRetry(fixed *dialer.Dialer, policy DialerS
 	actualTimeout := policy.FixedFallbackTimeout
 	if actualTimeout < 2*time.Second {
 		actualTimeout = 2 * time.Second
+		nodeName := ""
+		if fixed != nil && fixed.Property() != nil {
+			nodeName = fixed.Property().Name
+		}
 		g.log.WithFields(logrus.Fields{
 			"group":        g.Name,
 			"configured":   policy.FixedFallbackTimeout.String(),
 			"actual":       actualTimeout.String(),
-			"node":         fixed.Property().Name,
+			"node":         nodeName,
 			"network_type": nt.String(),
 		}).Warnln("fixed_fallback timeout too low, clamped to minimum 2s to prevent probe storm")
 	}

--- a/component/outbound/dialer_group_test.go
+++ b/component/outbound/dialer_group_test.go
@@ -529,3 +529,146 @@ func TestDialerGroup_Select_DataUdpFixedPolicyDoesNotFallback(t *testing.T) {
 		t.Fatalf("expected fixed policy to keep selecting dialers[1], got another dialer")
 	}
 }
+
+func TestDialerGroup_Select_FixedWithFallback_Alive(t *testing.T) {
+	g, dialers := newTestGroupForSelection(DialerSelectionPolicy{
+		Policy:               consts.DialerSelectionPolicy_FixedWithFallback,
+		FixedIndex:           1,
+		FixedFallbackTimeout: 3 * time.Second,
+		FixedFallbackRetries: 3,
+		FallbackPolicy:       consts.DialerSelectionPolicy_MinMovingAverageLatencies,
+	})
+
+	// Mark all dialers alive.
+	for _, d := range dialers {
+		g.MustGetAliveDialerSet(TestNetworkType).NotifyLatencyChange(d, true)
+	}
+
+	// When fixed dialer is alive, it should always be selected.
+	for i := 0; i < 10; i++ {
+		selected, _, err := g.Select(TestNetworkType, false)
+		if err != nil {
+			t.Fatalf("Select() error = %v", err)
+		}
+		if selected != dialers[1] {
+			t.Fatalf("[%d] expected dialers[1] (alive fixed), got %v", i, selected)
+		}
+	}
+}
+
+func TestDialerGroup_Select_FixedWithFallback_DeadFallback(t *testing.T) {
+	g, dialers := newTestGroupForSelection(DialerSelectionPolicy{
+		Policy:               consts.DialerSelectionPolicy_FixedWithFallback,
+		FixedIndex:           1,
+		FixedFallbackTimeout: 1 * time.Second,
+		FixedFallbackRetries: 1,
+		FallbackPolicy:       consts.DialerSelectionPolicy_MinMovingAverageLatencies,
+	})
+
+	// Mark all dialers dead.
+	for _, d := range dialers {
+		g.MustGetAliveDialerSet(TestNetworkType).NotifyLatencyChange(d, false)
+	}
+
+	// First select: fixed dialer dead → start retry (retries exhausted immediately since retries=1)
+	// After retries exhausted, fallback kicks in.
+	selected, _, err := g.Select(TestNetworkType, false)
+	if err != nil {
+		t.Fatalf("Select() error = %v", err)
+	}
+	if selected == dialers[1] {
+		t.Fatalf("expected fallback (fixed dialer retries exhausted), got fixed dialer")
+	}
+}
+
+func TestDialerGroup_Select_FixedWithFallback_ZeroRetriesNoFallback(t *testing.T) {
+	g, dialers := newTestGroupForSelection(DialerSelectionPolicy{
+		Policy:               consts.DialerSelectionPolicy_FixedWithFallback,
+		FixedIndex:           1,
+		FixedFallbackTimeout: 3 * time.Second,
+		FixedFallbackRetries: 0, // No retries allowed
+		FallbackPolicy:       consts.DialerSelectionPolicy_MinMovingAverageLatencies,
+	})
+
+	// Mark fixed dialer dead, others alive.
+	dialers[0].MustGetLatencies10(TestNetworkType).AppendLatency(100 * time.Millisecond)
+	g.MustGetAliveDialerSet(TestNetworkType).NotifyLatencyChange(dialers[0], true)
+	g.MustGetAliveDialerSet(TestNetworkType).NotifyLatencyChange(dialers[1], false)
+
+	// With retries=0, first dead detection immediately falls back.
+	selected, _, err := g.Select(TestNetworkType, false)
+	if err != nil {
+		t.Fatalf("Select() error = %v", err)
+	}
+	// Should fall back to dialers[0] (min_moving_avg).
+	if selected == dialers[1] {
+		t.Fatalf("expected fallback to dialers[0], still got fixed dialer")
+	}
+}
+
+func TestDialerGroup_Select_FixedWithFallback_Recovery(t *testing.T) {
+	g, dialers := newTestGroupForSelection(DialerSelectionPolicy{
+		Policy:               consts.DialerSelectionPolicy_FixedWithFallback,
+		FixedIndex:           1,
+		FixedFallbackTimeout: 1 * time.Second,
+		FixedFallbackRetries: 1,
+		FallbackPolicy:       consts.DialerSelectionPolicy_MinMovingAverageLatencies,
+	})
+
+	// Mark fixed dialer dead, others alive so fallback works.
+	dialers[0].MustGetLatencies10(TestNetworkType).AppendLatency(100 * time.Millisecond)
+	g.MustGetAliveDialerSet(TestNetworkType).NotifyLatencyChange(dialers[0], true)
+	g.MustGetAliveDialerSet(TestNetworkType).NotifyLatencyChange(dialers[1], false)
+
+	// Exhaust retries so we're in fallback.
+	g.Select(TestNetworkType, false)
+
+	// Now fixed dialer revives.
+	g.MustGetAliveDialerSet(TestNetworkType).NotifyLatencyChange(dialers[1], true)
+
+	// Recovery: traffic should return to fixed dialer immediately.
+	selected, _, err := g.Select(TestNetworkType, false)
+	if err != nil {
+		t.Fatalf("Select() error = %v", err)
+	}
+	if selected != dialers[1] {
+		t.Fatalf("expected fixed dialer after recovery, got %v", selected)
+	}
+}
+
+func TestDialerGroup_Select_FixedWithFallback_RetryTimeoutBehavior(t *testing.T) {
+	g, dialers := newTestGroupForSelection(DialerSelectionPolicy{
+		Policy:               consts.DialerSelectionPolicy_FixedWithFallback,
+		FixedIndex:           1,
+		FixedFallbackTimeout: 2 * time.Second,
+		FixedFallbackRetries: 3,
+		FallbackPolicy:       consts.DialerSelectionPolicy_MinMovingAverageLatencies,
+	})
+
+	// Fixed dialer dead; others alive for fallback.
+	dialers[0].MustGetLatencies10(TestNetworkType).AppendLatency(50 * time.Millisecond)
+	g.MustGetAliveDialerSet(TestNetworkType).NotifyLatencyChange(dialers[0], true)
+	g.MustGetAliveDialerSet(TestNetworkType).NotifyLatencyChange(dialers[1], false)
+
+	// First call: deadSince set, retry 0. Fixed dialer returned.
+	d, _, _ := g.Select(TestNetworkType, false)
+	if d != dialers[1] {
+		t.Fatalf("first select: expected fixed (dead detected), got %v", d)
+	}
+
+	// Call within timeout window: still return fixed.
+	time.Sleep(500 * time.Millisecond)
+	d, _, _ = g.Select(TestNetworkType, false)
+	if d != dialers[1] {
+		t.Fatalf("select within timeout: expected fixed, got %v", d)
+	}
+
+	// After timeout + retries exhausted, fallback to dialers[0].
+	// retries=1 at first timeout, retries=2 at second, retries=3 at third → exhausted.
+	// Wait long enough for 3 timeouts to pass.
+	time.Sleep(7 * time.Second)
+	d, _, _ = g.Select(TestNetworkType, false)
+	if d == dialers[1] {
+		t.Fatalf("after retries exhausted: expected fallback, still got fixed dialer")
+	}
+}

--- a/component/outbound/dialer_group_test.go
+++ b/component/outbound/dialer_group_test.go
@@ -636,39 +636,80 @@ func TestDialerGroup_Select_FixedWithFallback_Recovery(t *testing.T) {
 	}
 }
 
-func TestDialerGroup_Select_FixedWithFallback_RetryTimeoutBehavior(t *testing.T) {
-	g, dialers := newTestGroupForSelection(DialerSelectionPolicy{
+// TestDialerGroup_Select_FixedWithFallback_ImmediateFallback verifies the
+// core fixed_fallback requirement: when the fixed node is dead, Select() must
+// fall back to a live node IMMEDIATELY on the very first call — it must never
+// return the dead fixed node while it is down. A background retry goroutine
+// probes the dead node independently (timeout × retries), but that must not
+// delay or block the fallback.
+//
+// The dialers are created with DisableCheck so the test is hermetic: the retry
+// goroutine still fires emergency probes, but with checks disabled those probes
+// cannot revive a node over the network. Aliveness is controlled deterministically
+// via NotifyLatencyChange, so the test does not depend on outbound connectivity.
+func TestDialerGroup_Select_FixedWithFallback_ImmediateFallback(t *testing.T) {
+	option := &dialer.GlobalOption{
+		Log:               log,
+		TcpCheckOptionRaw: dialer.TcpCheckOptionRaw{Raw: []string{testTcpCheckUrl}},
+		CheckDnsOptionRaw: dialer.CheckDnsOptionRaw{Raw: []string{testUdpCheckDns}},
+		CheckInterval:     15 * time.Second,
+		CheckTolerance:    0,
+	}
+	dialers := []*dialer.Dialer{
+		newNoopDialer(option),
+		newNoopDialer(option),
+	}
+	policy := DialerSelectionPolicy{
 		Policy:               consts.DialerSelectionPolicy_FixedWithFallback,
 		FixedIndex:           1,
 		FixedFallbackTimeout: 2 * time.Second,
 		FixedFallbackRetries: 3,
 		FallbackPolicy:       consts.DialerSelectionPolicy_MinMovingAverageLatencies,
-	})
+	}
+	g := NewDialerGroup(option, "test-group", dialers, newEmptyAnnotations(len(dialers)), policy,
+		func(alive bool, networkType *dialer.NetworkType, isInit bool) {})
 
-	// Fixed dialer dead; others alive for fallback.
+	// Fixed dialer dead; the other dialer alive so fallback has a target.
 	dialers[0].MustGetLatencies10(TestNetworkType).AppendLatency(50 * time.Millisecond)
 	g.MustGetAliveDialerSet(TestNetworkType).NotifyLatencyChange(dialers[0], true)
 	g.MustGetAliveDialerSet(TestNetworkType).NotifyLatencyChange(dialers[1], false)
 
-	// First call: deadSince set, retry 0. Fixed dialer returned.
-	d, _, _ := g.Select(TestNetworkType, false)
-	if d != dialers[1] {
-		t.Fatalf("first select: expected fixed (dead detected), got %v", d)
+	// Requirement: first Select on a dead fixed node must immediately fall back.
+	d, _, err := g.Select(TestNetworkType, false)
+	if err != nil {
+		t.Fatalf("Select() error = %v", err)
 	}
-
-	// Call within timeout window: still return fixed.
-	time.Sleep(500 * time.Millisecond)
-	d, _, _ = g.Select(TestNetworkType, false)
-	if d != dialers[1] {
-		t.Fatalf("select within timeout: expected fixed, got %v", d)
-	}
-
-	// After timeout + retries exhausted, fallback to dialers[0].
-	// retries=1 at first timeout, retries=2 at second, retries=3 at third → exhausted.
-	// Wait long enough for 3 timeouts to pass.
-	time.Sleep(7 * time.Second)
-	d, _, _ = g.Select(TestNetworkType, false)
 	if d == dialers[1] {
-		t.Fatalf("after retries exhausted: expected fallback, still got fixed dialer")
+		t.Fatalf("first select: expected immediate fallback, got dead fixed dialer %v", d)
+	}
+
+	// Repeated selects while the fixed node stays dead keep falling back.
+	for i := 0; i < 5; i++ {
+		d, _, err = g.Select(TestNetworkType, false)
+		if err != nil {
+			t.Fatalf("select #%d error = %v", i, err)
+		}
+		if d == dialers[1] {
+			t.Fatalf("select #%d: expected fallback, got dead fixed dialer %v", i, d)
+		}
+	}
+
+	// The background retry goroutine must drive the timeout×retries cycle
+	// without crashing, and the dead fixed node must NOT be returned. With
+	// checks disabled it cannot be revived by probes, so after the retry window
+	// the node stays dead and fixedFallbackDone is set.
+	time.Sleep(7 * time.Second)
+	g.fixedFallbackMu.Lock()
+	done := g.fixedFallbackDone
+	g.fixedFallbackMu.Unlock()
+	if !done {
+		t.Fatalf("expected fixedFallbackDone after retry window; retry goroutine may not have run")
+	}
+	d, _, err = g.Select(TestNetworkType, false)
+	if err != nil {
+		t.Fatalf("Select() error = %v", err)
+	}
+	if d == dialers[1] {
+		t.Fatalf("after retry window: fixed still dead, expected fallback, got dead fixed dialer %v", d)
 	}
 }

--- a/component/outbound/dialer_group_test.go
+++ b/component/outbound/dialer_group_test.go
@@ -621,7 +621,7 @@ func TestDialerGroup_Select_FixedWithFallback_Recovery(t *testing.T) {
 	g.MustGetAliveDialerSet(TestNetworkType).NotifyLatencyChange(dialers[1], false)
 
 	// Exhaust retries so we're in fallback.
-	g.Select(TestNetworkType, false)
+	_, _, _ = g.Select(TestNetworkType, false)
 
 	// Now fixed dialer revives.
 	g.MustGetAliveDialerSet(TestNetworkType).NotifyLatencyChange(dialers[1], true)

--- a/component/outbound/dialer_selection_policy.go
+++ b/component/outbound/dialer_selection_policy.go
@@ -18,8 +18,8 @@ import (
 type DialerSelectionPolicy struct {
 	Policy               consts.DialerSelectionPolicy
 	FixedIndex           int
-	FixedFallbackTimeout time.Duration     // 节点超时时间
-	FixedFallbackRetries int              // 超时重试次数
+	FixedFallbackTimeout time.Duration                // 节点超时时间
+	FixedFallbackRetries int                          // 超时重试次数
 	FallbackPolicy       consts.DialerSelectionPolicy // 重试耗尽后的回退策略，默认 min_moving_avg
 }
 
@@ -142,6 +142,7 @@ func parsePolicyName(s string) (consts.DialerSelectionPolicy, error) {
 		return consts.DialerSelectionPolicy(0), fmt.Errorf("unsupported fallback policy %q (supported: random, min_moving_avg, min_last_latency, min_avg10)", s)
 	}
 }
+
 // Supported: "ms" (milliseconds), "s" (seconds), "m" (minutes).
 // No suffix defaults to seconds for backward compatibility.
 // Examples: "500ms", "5s", "2m", "10".

--- a/component/outbound/dialer_selection_policy.go
+++ b/component/outbound/dialer_selection_policy.go
@@ -64,7 +64,7 @@ func NewDialerSelectionPolicyFromGroupParam(param *config.Group) (policy *Dialer
 			return nil, fmt.Errorf("policy param does not support not operator: !%v()", f.Name)
 		}
 		if len(f.Params) < 1 || len(f.Params) > 4 {
-			return nil, fmt.Errorf(`invalid "%v" param format: expected 1-3 params, got %v`, f.Name, len(f.Params))
+			return nil, fmt.Errorf(`invalid "%v" param format: expected 1-4 params, got %v`, f.Name, len(f.Params))
 		}
 		// Parse index (required, first param)
 		if f.Params[0].Key != "" {

--- a/component/outbound/dialer_selection_policy.go
+++ b/component/outbound/dialer_selection_policy.go
@@ -18,8 +18,9 @@ import (
 type DialerSelectionPolicy struct {
 	Policy               consts.DialerSelectionPolicy
 	FixedIndex           int
-	FixedFallbackTimeout time.Duration // 节点超时时间
-	FixedFallbackRetries int           // 超时重试次数
+	FixedFallbackTimeout time.Duration     // 节点超时时间
+	FixedFallbackRetries int              // 超时重试次数
+	FallbackPolicy       consts.DialerSelectionPolicy // 重试耗尽后的回退策略，默认 min_moving_avg
 }
 
 func NewDialerSelectionPolicyFromGroupParam(param *config.Group) (policy *DialerSelectionPolicy, err error) {
@@ -98,11 +99,24 @@ func NewDialerSelectionPolicyFromGroupParam(param *config.Group) (policy *Dialer
 				return nil, fmt.Errorf(`invalid "%v" param format: retries must be >= 1`, f.Name)
 			}
 		}
+		// Parse fallback policy (optional, fourth param)
+		fallbackPolicy := consts.DialerSelectionPolicy_MinMovingAverageLatencies // default
+		if len(f.Params) >= 4 {
+			if f.Params[3].Key != "" {
+				return nil, fmt.Errorf(`invalid "%v" param format: fourth param must be fallback policy name (no key)`, f.Name)
+			}
+			fp, err := parsePolicyName(f.Params[3].Val)
+			if err != nil {
+				return nil, fmt.Errorf(`invalid "%v" param format: fallback policy: %w`, f.Name, err)
+			}
+			fallbackPolicy = fp
+		}
 		return &DialerSelectionPolicy{
 			Policy:               consts.DialerSelectionPolicy_FixedWithFallback,
 			FixedIndex:           index,
 			FixedFallbackTimeout: timeout,
 			FixedFallbackRetries: retries,
+			FallbackPolicy:       fallbackPolicy,
 		}, nil
 
 	default:
@@ -110,7 +124,24 @@ func NewDialerSelectionPolicyFromGroupParam(param *config.Group) (policy *Dialer
 	}
 }
 
-// parseDurationWithUnit parses a duration string with optional unit suffix.
+// parsePolicyName maps a policy name string to the corresponding DialerSelectionPolicy constant.
+// Supported fallback policies: random, min_moving_avg, min_last_latency, min_avg10.
+// Fixed and fixed_fallback are not supported as fallback policies (would cause infinite recursion).
+func parsePolicyName(s string) (consts.DialerSelectionPolicy, error) {
+	s = strings.TrimSpace(s)
+	switch s {
+	case "random":
+		return consts.DialerSelectionPolicy_Random, nil
+	case "min_moving_avg":
+		return consts.DialerSelectionPolicy_MinMovingAverageLatencies, nil
+	case "min_last_latency":
+		return consts.DialerSelectionPolicy_MinLastLatency, nil
+	case "min_avg10":
+		return consts.DialerSelectionPolicy_MinAverage10Latencies, nil
+	default:
+		return 0, fmt.Errorf("unsupported fallback policy %q (supported: random, min_moving_avg, min_last_latency, min_avg10)", s)
+	}
+}
 // Supported: "ms" (milliseconds), "s" (seconds), "m" (minutes).
 // No suffix defaults to seconds for backward compatibility.
 // Examples: "500ms", "5s", "2m", "10".

--- a/component/outbound/dialer_selection_policy.go
+++ b/component/outbound/dialer_selection_policy.go
@@ -85,7 +85,9 @@ func NewDialerSelectionPolicyFromGroupParam(param *config.Group) (policy *Dialer
 				return nil, fmt.Errorf(`invalid "%v" param format: %w`, f.Name, err)
 			}
 		}
-		// Parse retries (optional, third param)
+		// Parse retries (optional, third param). Default 3. 0 means the node
+		// falls back immediately on first failure with no background retry
+		// (matches the canonical "retries<=0 = do not retry" semantics).
 		retries := 3 // default
 		if len(f.Params) >= 3 {
 			if f.Params[2].Key != "" {
@@ -95,8 +97,8 @@ func NewDialerSelectionPolicyFromGroupParam(param *config.Group) (policy *Dialer
 			if err != nil {
 				return nil, fmt.Errorf(`invalid "%v" param format: retries must be an integer: %w`, f.Name, err)
 			}
-			if retries < 1 {
-				return nil, fmt.Errorf(`invalid "%v" param format: retries must be >= 1`, f.Name)
+			if retries < 0 {
+				return nil, fmt.Errorf(`invalid "%v" param format: retries must be >= 0`, f.Name)
 			}
 		}
 		// Parse fallback policy (optional, fourth param)

--- a/component/outbound/dialer_selection_policy.go
+++ b/component/outbound/dialer_selection_policy.go
@@ -8,14 +8,18 @@ package outbound
 import (
 	"fmt"
 	"strconv"
+	"strings"
+	"time"
 
 	"github.com/daeuniverse/dae/common/consts"
 	"github.com/daeuniverse/dae/config"
 )
 
 type DialerSelectionPolicy struct {
-	Policy     consts.DialerSelectionPolicy
-	FixedIndex int
+	Policy               consts.DialerSelectionPolicy
+	FixedIndex           int
+	FixedFallbackTimeout time.Duration // 节点超时时间
+	FixedFallbackRetries int           // 超时重试次数
 }
 
 func NewDialerSelectionPolicyFromGroupParam(param *config.Group) (policy *DialerSelectionPolicy, err error) {
@@ -35,8 +39,7 @@ func NewDialerSelectionPolicyFromGroupParam(param *config.Group) (policy *Dialer
 		return &DialerSelectionPolicy{
 			Policy: fName,
 		}, nil
-	case consts.DialerSelectionPolicy_Fixed,
-		consts.DialerSelectionPolicy_FixedWithFallback:
+	case consts.DialerSelectionPolicy_Fixed:
 
 		if f.Not {
 			return nil, fmt.Errorf("policy param does not support not operator: !%v()", f.Name)
@@ -54,7 +57,100 @@ func NewDialerSelectionPolicyFromGroupParam(param *config.Group) (policy *Dialer
 			FixedIndex: index,
 		}, nil
 
+	case consts.DialerSelectionPolicy_FixedWithFallback:
+
+		if f.Not {
+			return nil, fmt.Errorf("policy param does not support not operator: !%v()", f.Name)
+		}
+		if len(f.Params) < 1 || len(f.Params) > 3 {
+			return nil, fmt.Errorf(`invalid "%v" param format: expected 1-3 params, got %v`, f.Name, len(f.Params))
+		}
+		// Parse index (required, first param)
+		if f.Params[0].Key != "" {
+			return nil, fmt.Errorf(`invalid "%v" param format: first param must be index (no key)`, f.Name)
+		}
+		index, err := strconv.Atoi(f.Params[0].Val)
+		if err != nil {
+			return nil, fmt.Errorf(`invalid "%v" param format: %w`, f.Name, err)
+		}
+		// Parse timeout (optional, second param, with unit suffix: ms/s/m)
+		timeout := 3 * time.Second // default
+		if len(f.Params) >= 2 {
+			if f.Params[1].Key != "" {
+				return nil, fmt.Errorf(`invalid "%v" param format: second param must be timeout (no key)`, f.Name)
+			}
+			timeout, err = parseDurationWithUnit(f.Params[1].Val)
+			if err != nil {
+				return nil, fmt.Errorf(`invalid "%v" param format: %w`, f.Name, err)
+			}
+		}
+		// Parse retries (optional, third param)
+		retries := 3 // default
+		if len(f.Params) >= 3 {
+			if f.Params[2].Key != "" {
+				return nil, fmt.Errorf(`invalid "%v" param format: third param must be retry count (no key)`, f.Name)
+			}
+			retries, err = strconv.Atoi(f.Params[2].Val)
+			if err != nil {
+				return nil, fmt.Errorf(`invalid "%v" param format: retries must be an integer: %w`, f.Name, err)
+			}
+			if retries < 1 {
+				return nil, fmt.Errorf(`invalid "%v" param format: retries must be >= 1`, f.Name)
+			}
+		}
+		return &DialerSelectionPolicy{
+			Policy:               consts.DialerSelectionPolicy_FixedWithFallback,
+			FixedIndex:           index,
+			FixedFallbackTimeout: timeout,
+			FixedFallbackRetries: retries,
+		}, nil
+
 	default:
 		return nil, fmt.Errorf("unexpected policy: %v", f.Name)
 	}
+}
+
+// parseDurationWithUnit parses a duration string with optional unit suffix.
+// Supported: "ms" (milliseconds), "s" (seconds), "m" (minutes).
+// No suffix defaults to seconds for backward compatibility.
+// Examples: "500ms", "5s", "2m", "10".
+func parseDurationWithUnit(s string) (time.Duration, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("empty duration string")
+	}
+
+	// Check "ms" first (must precede "s" check)
+	if strings.HasSuffix(s, "ms") {
+		val, err := strconv.ParseFloat(strings.TrimSuffix(s, "ms"), 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid duration %q: %w", s, err)
+		}
+		return time.Duration(val * float64(time.Millisecond)), nil
+	}
+
+	// "s" suffix
+	if strings.HasSuffix(s, "s") {
+		val, err := strconv.ParseFloat(strings.TrimSuffix(s, "s"), 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid duration %q: %w", s, err)
+		}
+		return time.Duration(val * float64(time.Second)), nil
+	}
+
+	// "m" suffix
+	if strings.HasSuffix(s, "m") {
+		val, err := strconv.ParseFloat(strings.TrimSuffix(s, "m"), 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid duration %q: %w", s, err)
+		}
+		return time.Duration(val * float64(time.Minute)), nil
+	}
+
+	// No suffix: treat as seconds (backward compatible)
+	val, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid duration %q: %w", s, err)
+	}
+	return time.Duration(val * float64(time.Second)), nil
 }

--- a/component/outbound/dialer_selection_policy.go
+++ b/component/outbound/dialer_selection_policy.go
@@ -35,7 +35,8 @@ func NewDialerSelectionPolicyFromGroupParam(param *config.Group) (policy *Dialer
 		return &DialerSelectionPolicy{
 			Policy: fName,
 		}, nil
-	case consts.DialerSelectionPolicy_Fixed:
+	case consts.DialerSelectionPolicy_Fixed,
+		consts.DialerSelectionPolicy_FixedWithFallback:
 
 		if f.Not {
 			return nil, fmt.Errorf("policy param does not support not operator: !%v()", f.Name)

--- a/component/outbound/dialer_selection_policy.go
+++ b/component/outbound/dialer_selection_policy.go
@@ -63,7 +63,7 @@ func NewDialerSelectionPolicyFromGroupParam(param *config.Group) (policy *Dialer
 		if f.Not {
 			return nil, fmt.Errorf("policy param does not support not operator: !%v()", f.Name)
 		}
-		if len(f.Params) < 1 || len(f.Params) > 3 {
+		if len(f.Params) < 1 || len(f.Params) > 4 {
 			return nil, fmt.Errorf(`invalid "%v" param format: expected 1-3 params, got %v`, f.Name, len(f.Params))
 		}
 		// Parse index (required, first param)
@@ -139,7 +139,7 @@ func parsePolicyName(s string) (consts.DialerSelectionPolicy, error) {
 	case "min_avg10":
 		return consts.DialerSelectionPolicy_MinAverage10Latencies, nil
 	default:
-		return 0, fmt.Errorf("unsupported fallback policy %q (supported: random, min_moving_avg, min_last_latency, min_avg10)", s)
+		return consts.DialerSelectionPolicy(0), fmt.Errorf("unsupported fallback policy %q (supported: random, min_moving_avg, min_last_latency, min_avg10)", s)
 	}
 }
 // Supported: "ms" (milliseconds), "s" (seconds), "m" (minutes).

--- a/component/outbound/dialer_selection_policy.go
+++ b/component/outbound/dialer_selection_policy.go
@@ -139,7 +139,7 @@ func parsePolicyName(s string) (consts.DialerSelectionPolicy, error) {
 	case "min_avg10":
 		return consts.DialerSelectionPolicy_MinAverage10Latencies, nil
 	default:
-		return consts.DialerSelectionPolicy(0), fmt.Errorf("unsupported fallback policy %q (supported: random, min_moving_avg, min_last_latency, min_avg10)", s)
+		return consts.DialerSelectionPolicy(""), fmt.Errorf("unsupported fallback policy %q (supported: random, min_moving_avg, min_last_latency, min_avg10)", s)
 	}
 }
 

--- a/component/outbound/dialer_selection_policy_test.go
+++ b/component/outbound/dialer_selection_policy_test.go
@@ -7,6 +7,7 @@ package outbound
 
 import (
 	"testing"
+	"time"
 
 	"github.com/daeuniverse/dae/config"
 	"github.com/stretchr/testify/require"
@@ -18,4 +19,37 @@ func TestNewDialerSelectionPolicyFromGroupParamRejectsInvalidPolicyType(t *testi
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unsupported function-list-or-string value type")
+}
+
+func TestParseDurationWithUnit(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		want    time.Duration
+		wantErr bool
+	}{
+		{"milliseconds", "500ms", 500 * time.Millisecond, false},
+		{"seconds with suffix", "5s", 5 * time.Second, false},
+		{"minutes", "2m", 2 * time.Minute, false},
+		{"no suffix defaults to seconds", "10", 10 * time.Second, false},
+		{"zero no suffix", "0", 0, false},
+		{"float seconds", "1.5s", 1500 * time.Millisecond, false},
+		{"float minutes", "0.5m", 30 * time.Second, false},
+		{"whitespace tolerated", "  3s  ", 3 * time.Second, false},
+		{"empty string errors", "", 0, true},
+		{"bare s errors", "s", 0, true},
+		{"non numeric errors", "abc", 0, true},
+		{"garbage with ms errors", "abcms", 0, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := parseDurationWithUnit(c.input)
+			if c.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, c.want, got)
+		})
+	}
 }

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -525,10 +525,15 @@ func newControlPlaneWithContextOptions(
 	}
 	locationFinder := assets.NewLocationFinder(externGeoDataDirs)
 
-	// Warn if health check is implicitly disabled (no explicit config).
-	if global.CheckInterval == 0 && len(global.TcpCheckUrl) == 0 && len(global.UdpCheckDns) == 0 {
-		log.Warnln("Health check is DISABLED: check_interval, tcp_check_url, and udp_check_dns are all not explicitly configured. " +
-			"Nodes will not be probed. Set check_interval and configure tcp_check_url/udp_check_dns to enable.")
+	// Warn about health-check configuration that would silently disable probing.
+	// check_interval=0 disables ALL probing (including any configured URLs),
+	// so it must be reported even when tcp_check_url/udp_check_dns are set.
+	if global.CheckInterval == 0 {
+		log.Warnln("Health check is DISABLED: check_interval is 0. Nodes will NOT be probed even if " +
+			"tcp_check_url/udp_check_dns are configured. Set check_interval (>0) to enable health checks.")
+	} else if len(global.TcpCheckUrl) == 0 && len(global.UdpCheckDns) == 0 {
+		log.Warnln("Health check has no probe target: tcp_check_url and udp_check_dns are both empty. " +
+			"Nodes will not be probed. Configure at least one to enable health checks.")
 	}
 	option := dialer.NewGlobalOption(global, log)
 	option.DaeDNS, err = daedns.NewWithOption(log, global, dnsConfig, &daedns.NewOption{LocationFinder: locationFinder})

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -524,6 +524,12 @@ func newControlPlaneWithContextOptions(
 		log.Warnln("AllowInsecure is enabled, but it is not recommended. Please make sure you have to turn it on.")
 	}
 	locationFinder := assets.NewLocationFinder(externGeoDataDirs)
+
+	// Warn if health check is implicitly disabled (no explicit config).
+	if global.CheckInterval == 0 && len(global.TcpCheckUrl) == 0 && len(global.UdpCheckDns) == 0 {
+		log.Warnln("Health check is DISABLED: check_interval, tcp_check_url, and udp_check_dns are all not explicitly configured. " +
+			"Nodes will not be probed. Set check_interval and configure tcp_check_url/udp_check_dns to enable.")
+	}
 	option := dialer.NewGlobalOption(global, log)
 	option.DaeDNS, err = daedns.NewWithOption(log, global, dnsConfig, &daedns.NewOption{LocationFinder: locationFinder})
 	if err != nil {

--- a/example.dae
+++ b/example.dae
@@ -315,6 +315,11 @@ group {
         # Select the first node from the group for every connection.
         #policy: fixed(0)
 
+        # Select the first node when alive, fall back to min_moving_avg when dead.
+        # When the fixed node revives (periodic health check restores it),
+        # traffic automatically returns to it.
+        #policy: fixed_fallback(0)
+
         # Select the node with min last latency from the group for every connection.
         #policy: min
 

--- a/example.dae
+++ b/example.dae
@@ -315,9 +315,12 @@ group {
         # Select the first node from the group for every connection.
         #policy: fixed(0)
 
-        # Select the first node when alive, fall back to min_moving_avg when dead.
+        # Select the n-th node when alive, fall back to min_moving_avg when dead.
         # When the fixed node revives (periodic health check restores it),
         # traffic automatically returns to it.
+        # Optional params: timeout (default 3s), retries (default 3):
+        #   fixed_fallback(n, timeout_seconds, max_retries)
+        #   Example: fixed_fallback(0, 5, 3) — wait 5s between retries, give up after 3 retries
         #policy: fixed_fallback(0)
 
         # Select the node with min last latency from the group for every connection.

--- a/example.dae
+++ b/example.dae
@@ -315,12 +315,14 @@ group {
         # Select the first node from the group for every connection.
         #policy: fixed(0)
 
-        # Select the n-th node when alive, fall back to min_moving_avg when dead.
+        # Select the n-th node when alive, fall back to a configurable policy when dead.
         # When the fixed node revives (periodic health check restores it),
         # traffic automatically returns to it.
-        # Optional params: timeout (default 3s), retries (default 3):
-        #   fixed_fallback(n, timeout_seconds, max_retries)
-        #   Example: fixed_fallback(0, 5, 3) — wait 5s between retries, give up after 3 retries
+        # Optional params: timeout (default 3s), retries (default 3), fallback_policy (default min_moving_avg):
+        #   fixed_fallback(n, timeout, max_retries, fallback_policy)
+        #   timeout supports unit suffix: 500ms, 5s, 2m, or bare number (seconds)
+        #   fallback_policy: random, min_moving_avg (default), min_last_latency, min_avg10
+        #   Example: fixed_fallback(0, 5s, 3, random) — fallback to random after retries exhausted
         #policy: fixed_fallback(0)
 
         # Select the node with min last latency from the group for every connection.


### PR DESCRIPTION
## Problem

The existing `fixed()` dialer policy is **all-or-nothing**: when the configured node dies, traffic either fails immediately (if no fallback) or falls back without any retry window. The original `fixed_fallback()` (this PR's initial version) improved this but still had three major flaws:

1. **Traffic-driven retries**: Retry counting depends on natural traffic passing through Select() to compute elapsed/retryCount. If the dead node has no traffic, retries never advance and fallback never happens.
2. **First timeout window wasted**: After node death, up to one full timeout window's worth of traffic hits the dead node before fallback.
3. **Health check dead, but retry unaware**: Health check confirms node dead, but fixed_fallback state doesn't update — must wait for natural traffic.

## Solution: v2 — Two-Layer Architecture

The rewrite introduces a **background goroutine** that independently drives retries, completely decoupled from natural traffic.

### How It Works

```
                    .-- MustGetAlive=true  --- Return fixed node normally
                    |
  Select() ---------+                                    Natural Traffic
                    |                                       .
                    .-- MustGetAlive=false --- . goto doFallback . Backup node
                                               |
                                               +--- Start background goroutine (if not running)
                                               |     |
                                               |     +--- Fire immediate probes (NotifyCheckTcp/DnsUdp)
                                               |     |    . immediate probe counts as first retry (retryCount=1)
                                               |     |    . recovers brief transient failures (~300ms) instantly
                                               |     |
                                               |     +--- ticker every timeout ---+--- Probe OK . deadSince=0
                                               |     |                            .   Fail . retryCount++
                                               |     |                                          .   .retries . permanent fallback
                                               |     |
                                               |     .--- Fire NotifyCheckTcp/DnsUdp probes each tick
                                               |
                                               .--- Subsequent Select() . deadSince!=0 . goto doFallback
```

### Two-Layer Architecture

| Layer | Responsibility | Sends traffic to dead node? |
|-------|---------------|---------------------------|
| **Natural Traffic** (Select()) | Fallback immediately on dead; switch back immediately on alive | No (first byte goes to backup) |
| **Background Goroutine** | Independent ticker-driven retry cycle; fires immediate probe on start, then periodic probes | Yes, probe-only (health check requests) |

### Four Key Event Flows

**Node Go Dead (two paths)**
```
Path A . Health check detects death:
  connectivity_check: Alive=false
    . aliveTransitionCallback fires
    . CompareAndSwap(false,true)
    . start background goroutine  . no traffic needed!

Path B . Select() discovers death:
  MustGetAlive=false, deadSince==0
    . record deadSince timestamp
    . start goroutine if not already running
    . goto doFallback  . immediately!
```

**Natural Traffic During Death**
```
Select() . MustGetAlive=false . deadSince!=0 . goto doFallback . return backup node
```
Zero traffic wasted on dead node. **Natural traffic does NOT participate in retry counting.**

**Background Retry Probing**
```
Goroutine starts:
  . Fire immediate NotifyCheckTcp() + NotifyCheckDnsUdp() probes
  . retryCount = 1 (immediate probe counts as first retry)

Ticker fires (e.g. 3s later):
  . MustGetAlive?
       +--- true  . deadSince=0, retryCount=0 . return (goroutine exits)
       .   false
            +--- retryCount >= retries (from immediate reset) . permanent fallback . return
            .   retryCount++ . fire probes . wait next tick
```

The immediate probe on goroutine start eliminates the first-ticker wait for transient failures. NotifyCheckTcp() and NotifyCheckDnsUdp() are also fired each subsequent tick.

**Node Revive**
```
Traffic/probe succeeds . MustGetAlive=true
  +--- Goroutine path . deadSince=0, retryCount=0 . return
  .   Select() path . deadSince=0, retryCount=0 . return fixed node
```

Zero-latency switch back: recovery within probe RTT (~150ms) for brief glitches, or within ticker cycle for sustained failures.

### Retry Counting Semantics

| retries | Immediate probe | Ticker probes | Total probes | Recovery window |
|---------|----------------|---------------|--------------|-----------------|
| 0 | None | None | 0 | Relies on periodic health check (M1) |
| 1 | 1 (counts as 1st) | 0 (tick exits immediately) | 1 | ~150ms |
| 3 | 1 (counts as 1st) | 2 (ticks 1-2) | 3 | ~6s (3s x 2 ticks) |

The immediate probe counts toward the retries budget, so retries=3 means immediate + 2 tickers = 3 total probes.

### Key Implementation Details

- **aliveTransitionCallback**: Health check on dead transition automatically starts the goroutine . no traffic required
- **deadSince Timestamp**: Records when death was first observed, distinguishing first vs subsequent Select()
- **CompareAndSwap**: Ensures exactly one goroutine runs
- **Probe Cooldown**: timeout below 2s clamped to 2s with WARN log, prevents probe storm
- **Immediate Probe**: NotifyCheckTcp fires before first ticker tick, eliminating 3s first-probe latency
- **NotifyCheckTcp 2s Cooldown**: Built-in CAS rate limiting prevents probe storms from concurrent callers
- **Mutex protection**: Retry state (deadSince + retryCount) protected by single sync.Mutex for atomic multi-field reads
- **State Cleanup on Revive**: MustGetAlive=true clears both deadSince and retryCount

## Configuration

### Basic: 3s x 3 retry, random fallback
```
group {
  name 'my-group'
  policy 'fixed_fallback(0, 3s, 3, random)'
}
```
Behavior: Always use dialer[0]. Dies -> natural traffic -> backup; goroutine probes immediately, then 3s x 2; if all fail, goroutine exits; node recovers -> instant switchback.

### Aggressive: Quick fallback
```
policy 'fixed_fallback(1, 5s, 2, min_moving_avg)'
```
Behavior: Prefer dialer[1]. Dies -> immediate fallback, goroutine immediate probe + 1 ticker retry.

### Conservative: Long retry window
```
policy 'fixed_fallback(0, 60s, 5)'
```
Behavior: Prefer dialer[0]. Goroutine immediate probe + 4 ticker retries = ~4 minutes before giving up.

### Minimal: Safety net
```
policy 'fixed_fallback(0)'
```
Behavior: Same as fixed(0) with safety net . defaults timeout=3s, retries=3, fallback=min_moving_avg.

## Parameter Reference

| Param | Position | Default | Description |
|-------|----------|---------|-------------|
| index | 1st (required) | - | Dialer index (0-based) |
| timeout | 2nd | 3s | Retry interval. Below 2s clamped with WARN. Supports ms/s/m. |
| retries | 3rd | 3 | Max retries. 0 = no probes, rely on periodic health check. |
| fallback_policy | 4th | min_moving_avg | Policy after exhaust: random, min, min_moving_avg, min_avg10 |

## Benefits vs Original Approach

| Aspect | Original (v1) | Improved (v2) |
|--------|--------------|--------------|
| Retry driver | Natural traffic only | Background goroutine (independent) |
| Dead->fallback delay | Up to 1 timeout window | Zero (immediate) |
| First probe latency | 1 full timeout window (e.g. 3s) | Immediate (~150ms, instant probe before ticker) |
| Dead->start retry | Wait for traffic | Immediate (health check or traffic) |
| Retry counting | Traffic-dependent | Immediate probe counts as first retry; clean 1+2=3 |
| Probe storm protection | None | 2s minimum + NotifyCheckTcp 2s cooldown CAS |
| State access | Non-atomic atomic.Int64 | Mutex-protected single struct |

## Changes Summary

- **Select()**: Natural traffic always falls back immediately on dead node, no timeout window wasted
- **Background goroutine**: Independent ticker drives retry cycle, fires NotifyCheck probes
- **Immediate probe**: NotifyCheckTcp fires before first ticker tick, recovers transient failures instantly
- **Retry counting**: Immediate probe counts as retry 1; retries=N = immediate + (N-1) tickers
- **aliveTransitionCallback**: Health check dead transition starts goroutine without waiting for traffic
- **2s minimum**: timeout clamped to minimum 2s with WARN log
- **Mutex state**: deadSince + retryCount protected under single sync.Mutex
- **Node operational logging**: WARN on DEAD, INFO on ALIVE (merged from #1020)
- **DNS-UDP false-positive fix**: Mirror DNS-UDP liveness to same-IP-family TCP at the retry-decision site via `AliveForRetry` (collections stay independent — no coupling that would break UDP health-domain independence / snapshot-restore)
- **gofmt + DRY + tests**: Clean code, deduplicated IP-family check, 7 unit tests
- **Docs**: Flow diagram, two-layer architecture, bilingual (zh/en) documentation

Closes #1020, Closes #1022