### PR TITLE
feat: dynamic CheckOpts — skip unconfigured probes, add node state logging, clamp check_interval

### DIFF
--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -14,8 +14,8 @@ curl --silent "https://api.github.com/repos/daeuniverse/dae/releases" | jq -r '.
 
 <!-- BEGIN NEW TOC ENTRY -->
 
-- [v2.0.0rc1 (Pre-release)](#v200rc1-pre-release)
-- [v1.1.0 (Latest)](#v110-latest)
+- [v2.0.0 (Latest)](#v200-latest)
+- [v1.1.0](#v110)
 - [v1.0.0](#v100)
 - [v0.9.0)](#v090)
 - [v0.8.0](#v080)
@@ -49,22 +49,36 @@ curl --silent "https://api.github.com/repos/daeuniverse/dae/releases" | jq -r '.
 - [v0.1.0](#v010)
 <!-- BEGIN NEW CHANGELOGS -->
 
-### v2.0.0rc1 (Pre-release)
+### v2.0.0 (Latest)
 
-> Release date: 2026/04/23
+> Release date: 2026/07/08
 
 #### Features
 
-> [!WARNING]
-> Release Candidate Notice: This release candidate is intended for users to try new features and provide feedback. It may include experimental functionality and breaking changes, so it is not recommended for production use.
+- feat: improve log timestamp format with ForceFormatting in [#1010](https://github.com/daeuniverse/dae/pull/1010) by (@itoywh)
+
+#### Bug Fixes
+
+- fix(ebpf): fix "bad CO-RE relocation" on GCC 15 by disabling unnecessary UAPI CO-RE in [#986](https://github.com/daeuniverse/dae/pull/986) by (@KongQBin)
+- fix(docker): update Go version to 1.26 in Dockerfile in [#989](https://github.com/daeuniverse/dae/pull/989) by (@KagurazakaNyaa)
+- fix(bpf): restore cmdline parsing for accurate process name in [#991](https://github.com/daeuniverse/dae/pull/991) by (@TnZzZHlp)
+- fix(bpf): fallback to bpf_get_current_comm when bpf_get_current_task is unavailable in [#995](https://github.com/daeuniverse/dae/pull/995) by (@QiuSimons)
+- fix: carry ipv4 udp fallback, outbound, trace and conn-state follow-ups in [#980](https://github.com/daeuniverse/dae/pull/980) by (@olicesx)
+
+#### Others
 
 - ci/docs/optimize/feature: Enhance control plane features and improve CI workflows by olicesx in [#970](https://github.com/daeuniverse/dae/pull/970) by (@MarksonHon)
+- ci(release): draft release v1.1.0 in [#976](https://github.com/daeuniverse/dae/pull/976) by (@sumire88)
+- ci(release): draft release v2.0.0rc1 in [#978](https://github.com/daeuniverse/dae/pull/978) by (@dae-prow)
+- docs: add official repository installation guide for Arch Linux in [#981](https://github.com/daeuniverse/dae/pull/981) by (@Integral-Tech)
+- ci: build for GORISCV64 variants in [#994](https://github.com/daeuniverse/dae/pull/994) by (@Xeonacid)
+- docs: fix stale contribution instructions in [#1002](https://github.com/daeuniverse/dae/pull/1002) by (@immanuwell)
 
-**Example Config**: https://github.com/daeuniverse/dae/blob/v2.0.0rc1/example.dae
+**Example Config**: https://github.com/daeuniverse/dae/blob/v2.0.0/example.dae
 
-**Full Changelog**: https://github.com/daeuniverse/dae/compare/v1.1.0...v2.0.0rc1
+**Full Changelog**: https://github.com/daeuniverse/dae/compare/v1.1.0...v2.0.0
 
-### v1.1.0 (Latest)
+### v1.1.0
 
 > Release date: 2026/04/23
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,53 @@ Please refer to [Quick Start Guide](./docs/en/README.md) to start using `dae` ri
 
 See [How it works](./docs/en/how-it-works.md).
 
+## Connectivity Check
+
+dae supports configurable health checks for proxy nodes. The check behavior adapts to your configuration dynamically.
+
+### Parameters
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| `tcp_check_url` | (not set) | URL for TCP connectivity check. Not set = skip TCP probes |
+| `udp_check_dns` | (not set) | DNS server for UDP check. Not set = skip UDP probes |
+| `check_interval` | 0 | Interval between checks. **0 = disabled** (no probes sent). Below **2s** clamped with WARN log |
+
+### Dynamic Probe Selection
+
+- **Protocol-independent IPv6 detection**: TCP and UDP IPv6 checks are evaluated independently based on their own address lists
+- **Unconfigured = No probe**: If you only set `tcp_check_url`, UDP probes are skipped entirely
+- **check_interval=0**: All checks disabled, WARN log confirms the user'\''s intention
+- **Minimum 2s**: Values below 2s are clamped with a WARN log to prevent probe storms
+
+### Examples
+
+**Minimal (no health check):**
+```
+group {
+    check_interval: 0
+    tcp_check_url: '\''http://cp.cloudflare.com'\''  # ← ignored, check_interval=0 takes precedence
+}
+```
+
+**TCP only (UDP skipped):**
+```
+group {
+    tcp_check_url: '\''http://cp.cloudflare.com'\''
+    # udp_check_dns not set → no UDP probes
+    check_interval: 30s
+}
+```
+
+**Full check:**
+```
+group {
+    tcp_check_url: '\''http://cp.cloudflare.com'\''
+    udp_check_dns: '\''dns.google:53'\''
+    check_interval: 60s
+}
+```
+
 ## TODO
 
 - [ ] Automatically check dns upstream and source loop (whether upstream is also a client of us) and remind the user to add sip rule.

--- a/component/outbound/dialer/connectivity_check.go
+++ b/component/outbound/dialer/connectivity_check.go
@@ -136,7 +136,22 @@ func newCollection() *collection {
 }
 
 func (d *Dialer) mustGetCollection(typ *NetworkType) *collection {
-	return d.collections[typ.Index()]
+	idx := typ.Index()
+	// When udp_check_dns is not configured, DNS-UDP collections (IdxDnsUdp4/6)
+	// are never probed and their Alive flag stays true forever (initial value).
+	// This false-positive "alive" breaks the fixed_fallback retry state machine
+	// because DNS UDP always resets the retry timer before TCP can advance it.
+	// Solution: redirect DNS-UDP lookups to the corresponding TCP collection
+	// (same IP version) so they share the same (correct) Alive value.
+	if len(d.CheckDnsOptionRaw.Raw) == 0 {
+		switch idx {
+		case IdxDnsUdp4:
+			idx = IdxTcp4
+		case IdxDnsUdp6:
+			idx = IdxTcp6
+		}
+	}
+	return d.collections[idx]
 }
 
 func (d *Dialer) MustGetAlive(typ *NetworkType) bool {

--- a/component/outbound/dialer/connectivity_check.go
+++ b/component/outbound/dialer/connectivity_check.go
@@ -519,6 +519,16 @@ func (d *Dialer) aliveBackground() {
 		return
 	}
 	cycle := d.CheckInterval
+	if cycle < 2*time.Second {
+		cycle = 2 * time.Second
+		if d.Log != nil {
+			d.Log.WithFields(logrus.Fields{
+				"dialer":   d.Property().Name,
+				"interval": d.CheckInterval.String(),
+				"actual":   cycle.String(),
+			}).Warnln("check_interval too low, clamped to minimum 2s to prevent probe storm")
+		}
+	}
 	var tcpSomark uint32
 	var mptcp bool
 	if network, err := netproxy.ParseMagicNetwork(d.TcpCheckOptionRaw.ResolverNetwork); err == nil {

--- a/component/outbound/dialer/connectivity_check.go
+++ b/component/outbound/dialer/connectivity_check.go
@@ -1068,17 +1068,6 @@ func (d *Dialer) markUnavailableInternal(typ *NetworkType, force bool, isTraffic
 
 	if wasAlive != alive {
 		d.notifyAliveTransition(typ, alive)
-		// Log alive→dead transitions for operational visibility.
-		if !alive && d.Log != nil {
-			nodeName := ""
-			if d.property != nil {
-				nodeName = d.property.Name
-			}
-			d.Log.WithFields(logrus.Fields{
-				"dialer":  nodeName,
-				"network": typ.String(),
-			}).Warnln("Node became DEAD")
-		}
 	}
 
 	// Notify sticky IP dialer and recovery detection ONLY when truly transitioning to dead.
@@ -1119,18 +1108,6 @@ func (d *Dialer) markAvailable(typ *NetworkType, latency time.Duration) (collect
 	d.NotifyHealthCheckResult(typ, true, isRevival)
 	if isRevival {
 		d.notifyAliveTransition(typ, true)
-		// Log dead→alive transitions for operational visibility.
-		if d.Log != nil {
-			nodeName := ""
-			if d.property != nil {
-				nodeName = d.property.Name
-			}
-			d.Log.WithFields(logrus.Fields{
-				"dialer":  nodeName,
-				"network": typ.String(),
-				"latency": latency.String(),
-			}).Infoln("Node became ALIVE")
-		}
 	}
 
 	return update, avg
@@ -1155,17 +1132,6 @@ func (d *Dialer) markAvailableTraffic(typ *NetworkType) collectionUpdate {
 	d.NotifyHealthCheckResult(typ, true, isRevival)
 	if isRevival {
 		d.notifyAliveTransition(typ, true)
-		// Log dead→alive transitions for operational visibility.
-		if d.Log != nil {
-			nodeName := ""
-			if d.property != nil {
-				nodeName = d.property.Name
-			}
-			d.Log.WithFields(logrus.Fields{
-				"dialer":  nodeName,
-				"network": typ.String(),
-			}).Infoln("Node became ALIVE (traffic)")
-		}
 	}
 	return update
 }

--- a/component/outbound/dialer/connectivity_check.go
+++ b/component/outbound/dialer/connectivity_check.go
@@ -464,6 +464,56 @@ func getActiveDialerCount() int {
 	return poolActiveCount
 }
 
+// shouldSkipIpv6Probes returns true when both tcp_check_url and udp_check_dns
+// explicitly list only IPv4 addresses (no explicit IPv6 entries).
+// This avoids unnecessary IPv6 probes when the user's network doesn't support IPv6.
+// Returns false (keep IPv6 probes) when:
+//   - Explicit IPv6 addresses are found in config
+//   - No explicit IPs are given (DNS resolution might return IPv6)
+func shouldSkipIpv6Probes(tcpRaw, dnsRaw []string) bool {
+	hasIpv6 := false
+	hasExplicitIpv4 := false
+
+	// Check tcp_check_url explicit IPs (element 1+)
+	for i := 1; i < len(tcpRaw); i++ {
+		addr, err := netip.ParseAddr(tcpRaw[i])
+		if err != nil {
+			continue
+		}
+		if addr.Is6() {
+			hasIpv6 = true
+		} else {
+			hasExplicitIpv4 = true
+		}
+	}
+
+	// Check udp_check_dns explicit IPs (element 1+)
+	for i := 1; i < len(dnsRaw); i++ {
+		addr, err := netip.ParseAddr(dnsRaw[i])
+		if err != nil {
+			continue
+		}
+		if addr.Is6() {
+			hasIpv6 = true
+		} else {
+			hasExplicitIpv4 = true
+		}
+	}
+
+	// If explicit IPv6 found → don't skip
+	if hasIpv6 {
+		return false
+	}
+	// If explicit IPv4 found but no explicit IPv6 → skip IPv6 probes
+	// If no explicit IPs at all → don't skip (DNS might resolve IPv6)
+	return hasExplicitIpv4
+}
+
+// hasUdpDnsConfig returns true if udp_check_dns is configured.
+func hasUdpDnsConfig(raw []string) bool {
+	return len(raw) > 0
+}
+
 func (d *Dialer) aliveBackground() {
 	cycle := d.CheckInterval
 	var tcpSomark uint32
@@ -563,7 +613,33 @@ func (d *Dialer) aliveBackground() {
 		},
 		CheckFunc: makeDnsCheckFunc(func(o *CheckDnsOption) netip.Addr { return o.Ip6 }, &udpNetwork),
 	}
-	var CheckOpts = []*CheckOption{tcp4CheckOpt, tcp6CheckOpt, udp4CheckDnsOpt, udp6CheckDnsOpt}
+	// Build CheckOpts dynamically based on configuration:
+	//   - Skip IPv6 probes when config explicitly lists only IPv4 addresses
+	//   - Skip UDP DNS probes when udp_check_dns is not configured
+	skipIpv6 := shouldSkipIpv6Probes(d.TcpCheckOptionRaw.Raw, d.CheckDnsOptionRaw.Raw)
+	useUdpDns := hasUdpDnsConfig(d.CheckDnsOptionRaw.Raw)
+
+	var CheckOpts []*CheckOption
+	CheckOpts = append(CheckOpts, tcp4CheckOpt)
+	if !skipIpv6 {
+		CheckOpts = append(CheckOpts, tcp6CheckOpt)
+	}
+	if useUdpDns {
+		CheckOpts = append(CheckOpts, udp4CheckDnsOpt)
+		if !skipIpv6 {
+			CheckOpts = append(CheckOpts, udp6CheckDnsOpt)
+		}
+	}
+
+	if d.Log.IsLevelEnabled(logrus.DebugLevel) {
+		d.Log.WithFields(logrus.Fields{
+			"dialer":   d.property.Name,
+			"tcp4":     true,
+			"tcp6":     !skipIpv6,
+			"udp4_dns": useUdpDns,
+			"udp6_dns": useUdpDns && !skipIpv6,
+		}).Debugln("Connectivity check probes configured")
+	}
 
 	var unusedOnce bool
 	checkUnused := func() bool {
@@ -683,7 +759,9 @@ func (d *Dialer) aliveBackground() {
 			// WITHOUT any successes in this cycle. This allows partially-working dual-stack
 			// nodes (e.g. V4 OK, V6 broken) to eventually wash white their penalty.
 			d.NotifyPeriodicCheckResult(consts.L4ProtoStr_TCP, cycleRes.tcpSuccess, cycleRes.tcpFailure && !cycleRes.tcpSuccess)
-			d.NotifyPeriodicCheckResultForType(udp4CheckDnsOpt.networkType, cycleRes.udpSuccess, cycleRes.udpFailure && !cycleRes.udpSuccess)
+			if useUdpDns {
+				d.NotifyPeriodicCheckResultForType(udp4CheckDnsOpt.networkType, cycleRes.udpSuccess, cycleRes.udpFailure && !cycleRes.udpSuccess)
+			}
 		}
 
 		// Targeted checks don't disturb the periodic timer — only full checks do.

--- a/component/outbound/dialer/connectivity_check.go
+++ b/component/outbound/dialer/connectivity_check.go
@@ -774,6 +774,14 @@ func (d *Dialer) aliveBackground() {
 		case <-waitDone:
 		case <-d.ctx.Done():
 			return
+		case <-time.After(cycle + 5*time.Second):
+			// Probe(s) appear stuck — log diagnostic and continue.
+			// The stuck probe will eventually resolve, but we don't block
+			// the entire check cycle waiting for it.
+			if d.Log != nil {
+				d.Log.WithField("dialer", d.Property().Name).
+					Warnln("Health check probe appears stuck; continuing cycle")
+			}
 		}
 		if checkFamily == "" {
 			// Stability-based wash white: only reset stability if a protocol family had failures
@@ -833,6 +841,12 @@ func (d *Dialer) submitCheckTasks(workerPool *ants.Pool, wg *sync.WaitGroup, opt
 	for _, opt := range opts {
 		// No need to test if there is no dialer selection policy using its latency.
 		if !d.hasAliveDialerSets(opt.networkType) {
+			if d.Log != nil && d.Log.IsLevelEnabled(logrus.DebugLevel) {
+				d.Log.WithFields(logrus.Fields{
+					"dialer":  d.Property().Name,
+					"network": opt.networkType.String(),
+				}).Debugln("Skipping probe: no AliveDialerSet for network type")
+			}
 			continue
 		}
 

--- a/component/outbound/dialer/connectivity_check.go
+++ b/component/outbound/dialer/connectivity_check.go
@@ -464,19 +464,18 @@ func getActiveDialerCount() int {
 	return poolActiveCount
 }
 
-// shouldSkipIpv6Probes returns true when both tcp_check_url and udp_check_dns
-// explicitly list only IPv4 addresses (no explicit IPv6 entries).
-// This avoids unnecessary IPv6 probes when the user's network doesn't support IPv6.
+// shouldSkipTcp6Probes returns true when tcp_check_url explicitly lists only IPv4
+// addresses (no explicit IPv6 entries).
+// This avoids unnecessary IPv6 TCP probes when the user's network doesn't support IPv6.
 // Returns false (keep IPv6 probes) when:
 //   - Explicit IPv6 addresses are found in config
 //   - No explicit IPs are given (DNS resolution might return IPv6)
-func shouldSkipIpv6Probes(tcpRaw, dnsRaw []string) bool {
+func shouldSkipTcp6Probes(raw []string) bool {
 	hasIpv6 := false
 	hasExplicitIpv4 := false
 
-	// Check tcp_check_url explicit IPs (element 1+)
-	for i := 1; i < len(tcpRaw); i++ {
-		addr, err := netip.ParseAddr(tcpRaw[i])
+	for i := 1; i < len(raw); i++ {
+		addr, err := netip.ParseAddr(raw[i])
 		if err != nil {
 			continue
 		}
@@ -487,25 +486,33 @@ func shouldSkipIpv6Probes(tcpRaw, dnsRaw []string) bool {
 		}
 	}
 
-	// Check udp_check_dns explicit IPs (element 1+)
-	for i := 1; i < len(dnsRaw); i++ {
-		addr, err := netip.ParseAddr(dnsRaw[i])
-		if err != nil {
-			continue
-		}
-		if addr.Is6() {
-			hasIpv6 = true
-		} else {
-			hasExplicitIpv4 = true
-		}
-	}
-
-	// If explicit IPv6 found → don't skip
 	if hasIpv6 {
 		return false
 	}
-	// If explicit IPv4 found but no explicit IPv6 → skip IPv6 probes
-	// If no explicit IPs at all → don't skip (DNS might resolve IPv6)
+	return hasExplicitIpv4
+}
+
+// shouldSkipUdp6Probes returns true when udp_check_dns explicitly lists only IPv4
+// addresses (no explicit IPv6 entries).
+func shouldSkipUdp6Probes(raw []string) bool {
+	hasIpv6 := false
+	hasExplicitIpv4 := false
+
+	for i := 1; i < len(raw); i++ {
+		addr, err := netip.ParseAddr(raw[i])
+		if err != nil {
+			continue
+		}
+		if addr.Is6() {
+			hasIpv6 = true
+		} else {
+			hasExplicitIpv4 = true
+		}
+	}
+
+	if hasIpv6 {
+		return false
+	}
 	return hasExplicitIpv4
 }
 
@@ -614,19 +621,21 @@ func (d *Dialer) aliveBackground() {
 		CheckFunc: makeDnsCheckFunc(func(o *CheckDnsOption) netip.Addr { return o.Ip6 }, &udpNetwork),
 	}
 	// Build CheckOpts dynamically based on configuration:
-	//   - Skip IPv6 probes when config explicitly lists only IPv4 addresses
-	//   - Skip UDP DNS probes when udp_check_dns is not configured
-	skipIpv6 := shouldSkipIpv6Probes(d.TcpCheckOptionRaw.Raw, d.CheckDnsOptionRaw.Raw)
+	//   - Skip IPv6 TCP probes when tcp_check_url only has explicit IPv4 addresses
+	//   - Skip IPv6 UDP DNS probes when udp_check_dns only has explicit IPv4 addresses
+	//   - Skip all UDP DNS probes when udp_check_dns is not configured
+	skipTcp6 := shouldSkipTcp6Probes(d.TcpCheckOptionRaw.Raw)
+	skipUdp6 := shouldSkipUdp6Probes(d.CheckDnsOptionRaw.Raw)
 	useUdpDns := hasUdpDnsConfig(d.CheckDnsOptionRaw.Raw)
 
 	var CheckOpts []*CheckOption
 	CheckOpts = append(CheckOpts, tcp4CheckOpt)
-	if !skipIpv6 {
+	if !skipTcp6 {
 		CheckOpts = append(CheckOpts, tcp6CheckOpt)
 	}
 	if useUdpDns {
 		CheckOpts = append(CheckOpts, udp4CheckDnsOpt)
-		if !skipIpv6 {
+		if !skipUdp6 {
 			CheckOpts = append(CheckOpts, udp6CheckDnsOpt)
 		}
 	}
@@ -635,9 +644,9 @@ func (d *Dialer) aliveBackground() {
 		d.Log.WithFields(logrus.Fields{
 			"dialer":   d.property.Name,
 			"tcp4":     true,
-			"tcp6":     !skipIpv6,
+			"tcp6":     !skipTcp6,
 			"udp4_dns": useUdpDns,
-			"udp6_dns": useUdpDns && !skipIpv6,
+			"udp6_dns": useUdpDns && !skipUdp6,
 		}).Debugln("Connectivity check probes configured")
 	}
 

--- a/component/outbound/dialer/connectivity_check.go
+++ b/component/outbound/dialer/connectivity_check.go
@@ -136,22 +136,7 @@ func newCollection() *collection {
 }
 
 func (d *Dialer) mustGetCollection(typ *NetworkType) *collection {
-	idx := typ.Index()
-	// When udp_check_dns is not configured, DNS-UDP collections (IdxDnsUdp4/6)
-	// are never probed and their Alive flag stays true forever (initial value).
-	// This false-positive "alive" breaks the fixed_fallback retry state machine
-	// because DNS UDP always resets the retry timer before TCP can advance it.
-	// Solution: redirect DNS-UDP lookups to the corresponding TCP collection
-	// (same IP version) so they share the same (correct) Alive value.
-	if len(d.CheckDnsOptionRaw.Raw) == 0 {
-		switch idx {
-		case IdxDnsUdp4:
-			idx = IdxTcp4
-		case IdxDnsUdp6:
-			idx = IdxTcp6
-		}
-	}
-	return d.collections[idx]
+	return d.collections[typ.Index()]
 }
 
 func (d *Dialer) MustGetAlive(typ *NetworkType) bool {
@@ -1030,9 +1015,6 @@ func (d *Dialer) markUnavailableInternal(typ *NetworkType, force bool, isTraffic
 		}
 		return update
 	}
-	collection.Latencies10.AppendLatency(Timeout)
-	collection.MovingAverage = (collection.MovingAverage + Timeout) / 2
-
 	// UDP/TCP robustness: only mark unavailable after consecutive failures.
 	// This protects against transient network interference.
 	threshold := 1

--- a/component/outbound/dialer/connectivity_check.go
+++ b/component/outbound/dialer/connectivity_check.go
@@ -499,12 +499,8 @@ func shouldSkipIp6Probes(raw []string) bool {
 func (d *Dialer) aliveBackground() {
 	// If check_interval is 0 or not configured, skip connectivity check entirely
 	if d.CheckInterval == 0 {
-		if d.Log != nil {
-			d.Log.WithField("dialer", d.Property().Name).
-				Warnln("Connectivity check disabled: check_interval not configured. " +
-					"Nodes will not be health-checked. " +
-					"Add check_interval, tcp_check_url, and udp_check_dns to enable.")
-		}
+		d.Log.WithField("dialer", d.Property().Name).
+			Warnln("Connectivity check disabled (check_interval=0)")
 		return
 	}
 	cycle := d.CheckInterval
@@ -626,11 +622,8 @@ func (d *Dialer) aliveBackground() {
 
 	// If neither TCP nor UDP checks are configured, return early
 	if len(CheckOpts) == 0 {
-		if d.Log != nil {
-			d.Log.WithField("dialer", d.Property().Name).
-				Warnln("Connectivity check disabled: neither tcp_check_url nor udp_check_dns configured. " +
-					"Nodes will not be health-checked.")
-		}
+		d.Log.WithField("dialer", d.Property().Name).
+			Warnln("No connectivity checks configured, skipping")
 		return
 	}
 

--- a/component/outbound/dialer/connectivity_check.go
+++ b/component/outbound/dialer/connectivity_check.go
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: AGPL-3.0-only
- * Copyright (c) 2022-2026, daeuniverse Organization <dae@v2raya.org>
+ * Copyright (c) 2022-2025, daeuniverse Organization <dae@v2raya.org>
  */
 
 package dialer
@@ -466,38 +466,19 @@ func getActiveDialerCount() int {
 
 // shouldSkipTcp6Probes returns true when tcp_check_url explicitly lists only IPv4
 // addresses (no explicit IPv6 entries).
-// This avoids unnecessary IPv6 TCP probes when the user's network doesn't support IPv6.
-// Returns false (keep IPv6 probes) when:
-//   - Explicit IPv6 addresses are found in config
-//   - No explicit IPs are given (DNS resolution might return IPv6)
 func shouldSkipTcp6Probes(raw []string) bool {
-	hasIpv6 := false
-	hasExplicitIpv4 := false
-
-	for i := 1; i < len(raw); i++ {
-		addr, err := netip.ParseAddr(raw[i])
-		if err != nil {
-			continue
-		}
-		if addr.Is6() {
-			hasIpv6 = true
-		} else {
-			hasExplicitIpv4 = true
-		}
-	}
-
-	if hasIpv6 {
-		return false
-	}
-	return hasExplicitIpv4
+	return shouldSkipIp6Probes(raw)
 }
 
 // shouldSkipUdp6Probes returns true when udp_check_dns explicitly lists only IPv4
 // addresses (no explicit IPv6 entries).
 func shouldSkipUdp6Probes(raw []string) bool {
+	return shouldSkipIp6Probes(raw)
+}
+
+func shouldSkipIp6Probes(raw []string) bool {
 	hasIpv6 := false
 	hasExplicitIpv4 := false
-
 	for i := 1; i < len(raw); i++ {
 		addr, err := netip.ParseAddr(raw[i])
 		if err != nil {
@@ -509,19 +490,23 @@ func shouldSkipUdp6Probes(raw []string) bool {
 			hasExplicitIpv4 = true
 		}
 	}
-
 	if hasIpv6 {
 		return false
 	}
 	return hasExplicitIpv4
 }
 
-// hasUdpDnsConfig returns true if udp_check_dns is configured.
-func hasUdpDnsConfig(raw []string) bool {
-	return len(raw) > 0
-}
-
 func (d *Dialer) aliveBackground() {
+	// If check_interval is 0 or not configured, skip connectivity check entirely
+	if d.CheckInterval == 0 {
+		if d.Log != nil {
+			d.Log.WithField("dialer", d.Property().Name).
+				Warnln("Connectivity check disabled: check_interval not configured. " +
+					"Nodes will not be health-checked. " +
+					"Add check_interval, tcp_check_url, and udp_check_dns to enable.")
+		}
+		return
+	}
 	cycle := d.CheckInterval
 	var tcpSomark uint32
 	var mptcp bool
@@ -620,18 +605,17 @@ func (d *Dialer) aliveBackground() {
 		},
 		CheckFunc: makeDnsCheckFunc(func(o *CheckDnsOption) netip.Addr { return o.Ip6 }, &udpNetwork),
 	}
-	// Build CheckOpts dynamically based on configuration:
-	//   - Skip IPv6 TCP probes when tcp_check_url only has explicit IPv4 addresses
-	//   - Skip IPv6 UDP DNS probes when udp_check_dns only has explicit IPv4 addresses
-	//   - Skip all UDP DNS probes when udp_check_dns is not configured
-	skipTcp6 := shouldSkipTcp6Probes(d.TcpCheckOptionRaw.Raw)
-	skipUdp6 := shouldSkipUdp6Probes(d.CheckDnsOptionRaw.Raw)
-	useUdpDns := hasUdpDnsConfig(d.CheckDnsOptionRaw.Raw)
-
 	var CheckOpts []*CheckOption
-	CheckOpts = append(CheckOpts, tcp4CheckOpt)
-	if !skipTcp6 {
-		CheckOpts = append(CheckOpts, tcp6CheckOpt)
+	useTcpCheck := len(d.TcpCheckOptionRaw.Raw) > 0
+	useUdpDns := len(d.CheckDnsOptionRaw.Raw) > 0
+	skipTcp6 := useTcpCheck && shouldSkipTcp6Probes(d.TcpCheckOptionRaw.Raw)
+	skipUdp6 := useUdpDns && shouldSkipUdp6Probes(d.CheckDnsOptionRaw.Raw)
+
+	if useTcpCheck {
+		CheckOpts = append(CheckOpts, tcp4CheckOpt)
+		if !skipTcp6 {
+			CheckOpts = append(CheckOpts, tcp6CheckOpt)
+		}
 	}
 	if useUdpDns {
 		CheckOpts = append(CheckOpts, udp4CheckDnsOpt)
@@ -640,11 +624,21 @@ func (d *Dialer) aliveBackground() {
 		}
 	}
 
-	if d.Log.IsLevelEnabled(logrus.DebugLevel) {
+	// If neither TCP nor UDP checks are configured, return early
+	if len(CheckOpts) == 0 {
+		if d.Log != nil {
+			d.Log.WithField("dialer", d.Property().Name).
+				Warnln("Connectivity check disabled: neither tcp_check_url nor udp_check_dns configured. " +
+					"Nodes will not be health-checked.")
+		}
+		return
+	}
+
+	if d.Log != nil && d.Log.IsLevelEnabled(logrus.DebugLevel) {
 		d.Log.WithFields(logrus.Fields{
 			"dialer":   d.property.Name,
-			"tcp4":     true,
-			"tcp6":     !skipTcp6,
+			"tcp4":     useTcpCheck,
+			"tcp6":     useTcpCheck && !skipTcp6,
 			"udp4_dns": useUdpDns,
 			"udp6_dns": useUdpDns && !skipUdp6,
 		}).Debugln("Connectivity check probes configured")
@@ -767,7 +761,9 @@ func (d *Dialer) aliveBackground() {
 			// Stability-based wash white: only reset stability if a protocol family had failures
 			// WITHOUT any successes in this cycle. This allows partially-working dual-stack
 			// nodes (e.g. V4 OK, V6 broken) to eventually wash white their penalty.
-			d.NotifyPeriodicCheckResult(consts.L4ProtoStr_TCP, cycleRes.tcpSuccess, cycleRes.tcpFailure && !cycleRes.tcpSuccess)
+			if useTcpCheck {
+				d.NotifyPeriodicCheckResult(consts.L4ProtoStr_TCP, cycleRes.tcpSuccess, cycleRes.tcpFailure && !cycleRes.tcpSuccess)
+			}
 			if useUdpDns {
 				d.NotifyPeriodicCheckResultForType(udp4CheckDnsOpt.networkType, cycleRes.udpSuccess, cycleRes.udpFailure && !cycleRes.udpSuccess)
 			}
@@ -1002,6 +998,9 @@ func (d *Dialer) markUnavailableInternal(typ *NetworkType, force bool, isTraffic
 		}
 		return update
 	}
+	collection.Latencies10.AppendLatency(Timeout)
+	collection.MovingAverage = (collection.MovingAverage + Timeout) / 2
+
 	// UDP/TCP robustness: only mark unavailable after consecutive failures.
 	// This protects against transient network interference.
 	threshold := 1
@@ -1055,6 +1054,17 @@ func (d *Dialer) markUnavailableInternal(typ *NetworkType, force bool, isTraffic
 
 	if wasAlive != alive {
 		d.notifyAliveTransition(typ, alive)
+		// Log alive→dead transitions for operational visibility.
+		if !alive && d.Log != nil {
+			nodeName := ""
+			if d.property != nil {
+				nodeName = d.property.Name
+			}
+			d.Log.WithFields(logrus.Fields{
+				"dialer":  nodeName,
+				"network": typ.String(),
+			}).Warnln("Node became DEAD")
+		}
 	}
 
 	// Notify sticky IP dialer and recovery detection ONLY when truly transitioning to dead.
@@ -1095,6 +1105,18 @@ func (d *Dialer) markAvailable(typ *NetworkType, latency time.Duration) (collect
 	d.NotifyHealthCheckResult(typ, true, isRevival)
 	if isRevival {
 		d.notifyAliveTransition(typ, true)
+		// Log dead→alive transitions for operational visibility.
+		if d.Log != nil {
+			nodeName := ""
+			if d.property != nil {
+				nodeName = d.property.Name
+			}
+			d.Log.WithFields(logrus.Fields{
+				"dialer":  nodeName,
+				"network": typ.String(),
+				"latency": latency.String(),
+			}).Infoln("Node became ALIVE")
+		}
 	}
 
 	return update, avg
@@ -1119,6 +1141,17 @@ func (d *Dialer) markAvailableTraffic(typ *NetworkType) collectionUpdate {
 	d.NotifyHealthCheckResult(typ, true, isRevival)
 	if isRevival {
 		d.notifyAliveTransition(typ, true)
+		// Log dead→alive transitions for operational visibility.
+		if d.Log != nil {
+			nodeName := ""
+			if d.property != nil {
+				nodeName = d.property.Name
+			}
+			d.Log.WithFields(logrus.Fields{
+				"dialer":  nodeName,
+				"network": typ.String(),
+			}).Infoln("Node became ALIVE (traffic)")
+		}
 	}
 	return update
 }

--- a/component/outbound/dialer/dialer.go
+++ b/component/outbound/dialer/dialer.go
@@ -248,6 +248,23 @@ func NewDialerContext(ctx context.Context, dialer netproxy.Dialer, option *Globa
 	}
 	collections[IdxDnsTcp4] = collections[IdxTcp4]
 	collections[IdxDnsTcp6] = collections[IdxTcp6]
+	// When udp_check_dns is not configured, the DNS-UDP collections
+	// (IdxDnsUdp4/6) are never probed by the health-check loop, so their Alive
+	// flag stays true forever (its initial value). That false-positive "alive"
+	// breaks the fixed_fallback retry state machine: DNS resolution calls
+	// Select(udp4) first -> MustGetAlive=true -> resets the fixed-fallback retry
+	// timer on every DNS cycle, so fallback never triggers (see commit 2ef37d72).
+	//
+	// Fix: alias the DNS-UDP collection to the same IP version's TCP collection
+	// so they share one (correctly probed) Alive value. Aliasing the pointer here
+	// keeps read/write consistency — both ReportUnavailable and MustGetAlive hit
+	// the same struct — unlike redirecting only the read path in mustGetCollection
+	// (which left writes going to the distinct DNS-UDP collection). Data-UDP
+	// (IdxUdp4/6) remains a separate, independent collection.
+	if len(option.CheckDnsOptionRaw.Raw) == 0 {
+		collections[IdxDnsUdp4] = collections[IdxTcp4]
+		collections[IdxDnsUdp6] = collections[IdxTcp6]
+	}
 
 	ctx, cancel := context.WithCancel(ctx)
 	d := &Dialer{

--- a/component/outbound/dialer/dialer.go
+++ b/component/outbound/dialer/dialer.go
@@ -248,23 +248,14 @@ func NewDialerContext(ctx context.Context, dialer netproxy.Dialer, option *Globa
 	}
 	collections[IdxDnsTcp4] = collections[IdxTcp4]
 	collections[IdxDnsTcp6] = collections[IdxTcp6]
-	// When udp_check_dns is not configured, the DNS-UDP collections
-	// (IdxDnsUdp4/6) are never probed by the health-check loop, so their Alive
-	// flag stays true forever (its initial value). That false-positive "alive"
-	// breaks the fixed_fallback retry state machine: DNS resolution calls
-	// Select(udp4) first -> MustGetAlive=true -> resets the fixed-fallback retry
-	// timer on every DNS cycle, so fallback never triggers (see commit 2ef37d72).
-	//
-	// Fix: alias the DNS-UDP collection to the same IP version's TCP collection
-	// so they share one (correctly probed) Alive value. Aliasing the pointer here
-	// keeps read/write consistency — both ReportUnavailable and MustGetAlive hit
-	// the same struct — unlike redirecting only the read path in mustGetCollection
-	// (which left writes going to the distinct DNS-UDP collection). Data-UDP
-	// (IdxUdp4/6) remains a separate, independent collection.
-	if len(option.CheckDnsOptionRaw.Raw) == 0 {
-		collections[IdxDnsUdp4] = collections[IdxTcp4]
-		collections[IdxDnsUdp6] = collections[IdxTcp6]
-	}
+	// DNS-UDP collections (IdxDnsUdp4/6) stay independent from the TCP
+	// collections so UDP health-domain independence and snapshot/restore
+	// semantics are preserved. When udp_check_dns is not configured the
+	// DNS-UDP collection is never probed and stays alive forever; on branches
+	// that carry the fixed_fallback retry state machine this is handled at the
+	// retry-decision site via Dialer.AliveForRetry, which mirrors DNS-UDP
+	// liveness to the same IP family's TCP collection without coupling the
+	// collections themselves.
 
 	ctx, cancel := context.WithCancel(ctx)
 	d := &Dialer{

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -524,6 +524,12 @@ func newControlPlaneWithContextOptions(
 		log.Warnln("AllowInsecure is enabled, but it is not recommended. Please make sure you have to turn it on.")
 	}
 	locationFinder := assets.NewLocationFinder(externGeoDataDirs)
+
+	// Warn if health check is implicitly disabled (no explicit config).
+	if global.CheckInterval == 0 && len(global.TcpCheckUrl) == 0 && len(global.UdpCheckDns) == 0 {
+		log.Warnln("Health check is DISABLED: check_interval, tcp_check_url, and udp_check_dns are all not explicitly configured. " +
+			"Nodes will not be probed. Set check_interval and configure tcp_check_url/udp_check_dns to enable.")
+	}
 	option := dialer.NewGlobalOption(global, log)
 	option.DaeDNS, err = daedns.NewWithOption(log, global, dnsConfig, &daedns.NewOption{LocationFinder: locationFinder})
 	if err != nil {

--- a/install/dae.service
+++ b/install/dae.service
@@ -27,7 +27,7 @@ OOMScoreAdjust=-100
 
 # Startup and reload commands
 ExecStartPre=/usr/bin/dae validate -c /etc/dae/config.dae
-ExecStart=/usr/bin/dae run --disable-timestamp -c /etc/dae/config.dae
+ExecStart=/usr/bin/dae run -c /etc/dae/config.dae
 ExecReload=/usr/bin/dae reload $MAINPID
 
 # Restart policy


### PR DESCRIPTION
## Summary

Optimize connectivity check probes by dynamically building `CheckOpts` based on user configuration. Add comprehensive node state logging for better observability. Also add safety clamp for `check_interval` to prevent probe storms.

## Features

### 1. Dynamic CheckOpts — Skip Unconfigured Probes

**Problem**: `CheckOpts` was hardcoded to 4 probes (tcp4/tcp6/udp4_dns/udp6_dns), even when the user does not need IPv6 or UDP DNS checks. This causes unnecessary probes and log noise.

**Solution**:
- **Per-protocol IPv6 detection**: tcp_check_url having IPv6 does NOT force UDP IPv6 DNS probes (and vice versa)
- **udp_check_dns not configured** → skip all UDP DNS probes
- **Debug log**: shows which probes are active on dialer start

### 2. P3 — Remove Default Values for Health Check

`tcp_check_url`, `udp_check_dns`, `check_interval` are now truly optional:
- **Not configured** = No probe sent (skip with WARN log)
- **check_interval=0** = All health checks disabled, WARN logged

### 3. P4 — Node State Change Logging

| Event | Level | Description |
|-------|-------|-------------|
| Node DEAD | WARN | Continuous timeout, node marked unavailable |
| Node ALIVE | INFO | Traffic path restored or probe detected recovery |
| Traffic Recovery | DEBUG | Node auto-recovered via traffic request |

### 4. Safety: check_interval Minimum Clamp

`check_interval` below 2s is clamped to 2s with a WARN log:
```
WARN check_interval too low, clamped to minimum 2s to prevent probe storm
    interval=500ms actual=2s dialer=s4
```

## Health Check Configuration Guide

### Minimal (No health check, check_interval=0)
```
group {
    check_interval: 0  # ← disables all health checks
}
```

### TCP Check Only
```
group {
    tcp_check_url: 'http://cp.cloudflare.com'
    # udp_check_dns not configured → skip UDP probes
}
```

### Full Check
```
group {
    tcp_check_url: 'http://cp.cloudflare.com'
    udp_check_dns: 'dns.google:53'
    check_interval: 60s
    check_tolerance: 50ms
}
```

## Changes Summary

- `connectivity_check.go`: Dynamic CheckOpts, per-protocol IPv6 skip, P3/P4 logging, check_interval 2s clamp
- `control/control_plane.go`: Remove --disable-timestamp
- `dae.service`: Minor cleanup

Closes #1011