### PR TITLE
fix(dns): restore LAN-client DNS handling when dns bind is configured

### DIFF
--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -3072,44 +3072,11 @@ func (c *ControlPlane) Serve(readyChan chan<- bool, listener *Listener) (err err
 				// reduce hot-path overhead, but best-effort preserve tuple metadata
 				// for rules matching (pname/mac/dscp).
 				if realDst.Port() == 53 {
-					// IMPORTANT: Check if this is destined for our own DNS listener.
-					// If so, skip fast path processing to avoid double-handling.
-					// Traffic to 127.0.0.1:53 (or our configured listen address) should be
-					// handled only by the DNS listener, not by UDP ingress fast path.
-					if c.dnsListener != nil {
-						listenAddr := c.dnsListener.Addr()
-						// Match both exact address and wildcard port 53 to our listener
-						if listenAddr != "" && listenAddr == realDst.String() {
-							// This is destined for our own DNS listener - let it handle normally
-							if c.log.IsLevelEnabled(logrus.TraceLevel) {
-								c.log.WithFields(logrus.Fields{
-									"src":        convergeSrc.String(),
-									"dst":        realDst.String(),
-									"listenAddr": listenAddr,
-								}).Trace("Skipping DNS fast path for traffic to our own DNS listener")
-							}
-							// Fall through to normal UDP processing (will be dropped/ignored)
-							return
-						}
-						// Also check for common local addresses
-						if realDst.Addr().IsLoopback() || realDst.Addr().IsUnspecified() {
-							// For local addresses, verify we have a DNS listener on port 53
-							if _, portStr, err := net.SplitHostPort(listenAddr); err == nil {
-								if port, err := strconv.Atoi(portStr); err == nil && port == 53 {
-									// We have a DNS listener on port 53, skip fast path
-									if c.log.IsLevelEnabled(logrus.TraceLevel) {
-										c.log.WithFields(logrus.Fields{
-											"src":        convergeSrc.String(),
-											"dst":        realDst.String(),
-											"listenAddr": listenAddr,
-										}).Trace("Skipping DNS fast path for local loopback DNS listener traffic")
-									}
-									return
-								}
-							}
-						}
-					}
-
+					// LAN-intercepted DNS (including queries to our own bind address like
+					// 192.168.1.15:53) must be handled by the DNS controller here.
+					// The DNSListener (miekg/dns server) only serves host-local traffic
+					// that reaches it via loopback; eBPF has already consumed LAN-client
+					// packets so they never arrive at the root-namespace socket.
 					if dnsMessage, _ := ChooseNatTimeout(data, true); dnsMessage != nil {
 						dnsRoutingResult := &bpfRoutingResult{
 							Outbound: uint8(consts.OutboundControlPlaneRouting),


### PR DESCRIPTION
## Summary

- **Bug**: LAN clients lose DNS resolution (timeout) when `dns bind` is set to the host's LAN-facing IP (e.g. `192.168.1.15:53`).
- **Root cause**: #970 introduced `DNSListener` (a `miekg/dns` server bound to the configured address) and simultaneously added a guard in `Serve()` that **drops** eBPF-intercepted DNS packets whose destination matches that bind address, assuming `DNSListener` would handle them instead. That assumption is wrong: the eBPF `dae_lan_ingress_l2` TC hook consumes LAN-client packets at ingress and redirects them to userspace before they can ever reach the root-namespace socket that `DNSListener` listens on. The guard therefore caused every LAN-client DNS query to be silently dropped, while host-local queries (delivered via loopback, bypassing eBPF) kept working — masking the regression in local testing.
- **Fix**: Remove the 37-line early-return block. All eBPF-intercepted DNS, including queries explicitly addressed to the configured bind address, falls through to the existing `dnsController.Handle_()` path — the correct handler for this traffic. `DNSListener` is unaffected and continues to serve host-local traffic arriving via loopback.

## Test plan

- [ ] Start dae with `dns bind: <host-lan-ip>:53`
- [ ] From a LAN client (separate machine), query a domain against `<host-lan-ip>:53` — should resolve successfully
- [ ] From the dae host itself, query via loopback — should also resolve (`DNSListener` still serves this path)
- [ ] Verify no regression on normal DNS routing when `dns bind` is not set

## Comparison with #980

While preparing this PR I found that #980 (merged before this branch was rebased) independently touched the exact same guard, replacing it with a narrower `shouldSkipDNSFastPathForLocalListenerTraffic(listenAddr, src, dst)` check instead of removing it outright. Both approaches fix the reported LAN-client timeout (the original bug), but they differ in one corner case:

| | This PR (#1014) | #980's `shouldSkipDNSFastPathForLocalListenerTraffic` |
|---|---|---|
| LAN client → bind IP:53 (the reported bug) | Falls through to `Handle_()` — fixed | `src` is a real LAN IP, doesn't match "local" → falls through to `Handle_()` — fixed |
| Host-local query via loopback | Never reaches this code path (eBPF doesn't intercept `lo`) — unaffected either way | Same — unaffected either way |
| **Corner case**: a process on the dae host itself addresses a DNS query to the host's own LAN-bound IP (not via loopback, e.g. `src == dst == 192.168.1.15`) and that traffic happens to traverse the ingress hook | Falls through to `Handle_()` — same DNS controller path serves it | Matches the "self-directed" condition (`src.Addr() == dst.Addr()`) → guard returns `true` → packet is dropped without calling `Handle_()`, on the assumption `DNSListener` will serve it. Whether `DNSListener` actually receives that packet depends on whether the host route sends such traffic through loopback or through the NIC ingress hook — if the latter, the packet has already been consumed by eBPF and `DNSListener` never sees it, so this corner case may silently drop self-addressed-via-NIC DNS queries. |

I don't have a confirmed repro for the corner case (it depends on host routing behavior for self-addressed traffic to a non-loopback bound IP), so I can't say definitively whether #980's narrower guard reintroduces a smaller version of the original bug for that specific case. Filing this comparison so a maintainer with more context on the routing/netns setup can decide:

- If #980's behavior is verified correct for the self-addressed case, this PR is redundant and can be closed in favor of #980.
- If the corner case above is a real (if rare) regression under #980's guard, this PR's full-removal approach avoids it at the cost of one redundant `Handle_()` call for genuinely local self-directed traffic (negligible — that path is not hot).

## Verification: corner case is unreachable — closing in favor of #980

Ran the cheapest possible check on the actual dae host (`192.168.1.15`, the LAN-bound DNS address from this report):

```
$ ip route get 192.168.1.15
local 192.168.1.15 dev lo src 192.168.1.15 uid 1000
    cache <local>
```

This is the kernel's routing decision, independent of which dae binary/version is running. `RTN_LOCAL` means any traffic addressed to `192.168.1.15` from the host itself — regardless of the source address used — is delivered via `lo` and **never traverses the LAN interface's ingress path**. Since `dae_lan_ingress_l2` only intercepts packets entering on a physical/virtual LAN-facing interface, it can never see this traffic, so the `src == dst.Addr()` ("self-directed via the real NIC") branch in #980's `shouldSkipDNSFastPathForLocalListenerTraffic` can never be reached by genuine traffic under standard Linux routing.

This resolves the open question above: **#980's narrower guard is safe** — the corner case it appears to special-case is unreachable in practice, so there's no regression versus this PR's full-removal approach for any traffic that can actually occur.

Closing this PR in favor of #980, which is already merged into `main` and covers the originally reported bug correctly.
