### PR TITLE
feat(metrics): add Prometheus /metrics endpoint with DNS, dialer, connection, and runtime stats

### DIFF
--- a/.plan/metrics/dae_Transparent_Proxy-Grafana_dashboard.json
+++ b/.plan/metrics/dae_Transparent_Proxy-Grafana_dashboard.json
@@ -1,0 +1,3319 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "dae eBPF transparent proxy — full metrics dashboard (Phase 1 gauges + Phase 2 counters/histograms)",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": 38,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "panels": [],
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Number of alive proxy dialers (network=tcp4, all groups)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 0,
+        "y": 1
+      },
+      "id": 101,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(dae_dialer_alive{network=\"$network\", group=~\"$group\"})",
+          "instant": true,
+          "legendFormat": "Alive Dialers",
+          "refId": "A"
+        }
+      ],
+      "title": "Alive Dialers",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Current active TCP connections being proxied through dae",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 3,
+        "y": 1
+      },
+      "id": 104,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "dae_tcp_connections_active",
+          "instant": true,
+          "legendFormat": "Active",
+          "refId": "A"
+        }
+      ],
+      "title": "Active TCP Conn",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "DNS queries per second handled by dae",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 6,
+        "y": 1
+      },
+      "id": 102,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(dae_dns_query_total[$__rate_interval])",
+          "legendFormat": "DNS qps",
+          "refId": "A"
+        }
+      ],
+      "title": "DNS Query Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Fraction of DNS queries served from cache (fresh hits only). Stale/lazy hits excluded.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.3
+              },
+              {
+                "color": "green",
+                "value": 0.7
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 9,
+        "y": 1
+      },
+      "id": 103,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(dae_dns_cache_hit_total[$__rate_interval]) / clamp_min(rate(dae_dns_query_total[$__rate_interval]), 0.001)",
+          "legendFormat": "Hit Ratio",
+          "refId": "A"
+        }
+      ],
+      "title": "DNS Cache Hit Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Current active UDP endpoint associations and task queues",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 5,
+        "x": 13,
+        "y": 1
+      },
+      "id": 105,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "dae_udp_endpoints_active",
+          "instant": true,
+          "legendFormat": "UDP Endpoints",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "dae_udp_task_queues_active",
+          "instant": true,
+          "legendFormat": "UDP Task Queues",
+          "refId": "B"
+        }
+      ],
+      "title": "Active UDP",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Process resident memory (RSS)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 134217728
+              },
+              {
+                "color": "red",
+                "value": 536870912
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 5,
+        "x": 18,
+        "y": 1
+      },
+      "id": 106,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "process_resident_memory_bytes",
+          "instant": true,
+          "legendFormat": "RSS",
+          "refId": "A"
+        }
+      ],
+      "title": "Memory (RSS)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Cumulative bytes uploaded and downloaded since last process start. Resets on restart.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Upload Total"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Download Total"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 4
+      },
+      "id": 702,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "vertical",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "dae_runtime_upload_bytes_total",
+          "instant": true,
+          "legendFormat": "Upload Total",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "dae_runtime_download_bytes_total",
+          "instant": true,
+          "legendFormat": "Download Total",
+          "refId": "B"
+        }
+      ],
+      "title": "Cumulative Traffic",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Real-time upload and download throughput sampled by the runtime traffic statistics engine (250 ms buckets). These are direct gauge values — no rate() needed.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Upload"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Download"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 17,
+        "x": 6,
+        "y": 4
+      },
+      "id": 701,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "dae_runtime_upload_rate_bytes_per_second",
+          "legendFormat": "Upload",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "dae_runtime_download_rate_bytes_per_second",
+          "legendFormat": "Download",
+          "refId": "B"
+        }
+      ],
+      "title": "Network Throughput",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 200,
+      "panels": [],
+      "title": "Dialer Health",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.8
+              },
+              {
+                "color": "green",
+                "value": 0.95
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 0,
+        "y": 10
+      },
+      "id": 202,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_min(1 - sum(increase(dae_health_check_failure_total{network=\"$network\", group=~\"$group\", group!~\"block|direct\"}[$__range])) / clamp_min(sum(increase(dae_health_check_total{network=\"$network\", group=~\"$group\", group!~\"block|direct\"}[$__range])), 1), 0)",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Health Check Success Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "时间范围内 TCP 健康检查发生连接错误的累计次数。不含尚未探测（0ms）的节点——那些节点仍为 alive=1，只是首次检查还未执行。",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 3,
+        "y": 10
+      },
+      "id": 203,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(dae_health_check_failure_total{network=\"$network\", group=~\"$group\", group!~\"block|direct\"}[$__range]))",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Health Check Failures",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Number of alive dialers per group for the selected network type. Drop to 0 = group is unusable.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 17,
+        "x": 6,
+        "y": 10
+      },
+      "id": 201,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(dae_dialer_alive{network=\"$network\", group=~\"$group\"}) by (group)",
+          "legendFormat": "{{group}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Alive Dialers by Group (network=$network)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "每个存活 dialer 最近一次健康检查的实际 TCP 延迟。0ms（灰色）= 节点存活但尚未完成首次探测（check_interval=900s）；非 0ms 为真实探测延迟。已失败（alive=0）的节点不显示。",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "gray",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              },
+              {
+                "color": "#EAB839",
+                "value": 200
+              },
+              {
+                "color": "red",
+                "value": 300
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 13
+      },
+      "id": 301,
+      "options": {
+        "displayMode": "gradient",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 40,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "text": {
+          "titleSize": 10
+        },
+        "valueMode": "color"
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sort_desc(\n  (\n    (dae_dialer_latency_last_seconds{network=\"$network\", group=~\"$group\", group!~\"block|direct\"} * 1000)\n    and (dae_dialer_alive{network=\"$network\", group=~\"$group\", group!~\"block|direct\"} == 1)\n  )\n  or (0 * (dae_dialer_alive{network=\"$network\", group=~\"$group\", group!~\"block|direct\"} == 1))\n)",
+          "instant": true,
+          "legendFormat": "{{group}} / {{dialer}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Last Health Check Latency (network=$network)",
+      "transparent": true,
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "EWMA（指数加权移动平均，α=0.5）与最新瞬时延迟对比。0ms（灰色）= 节点存活但尚未完成首次探测，EWMA 尚未初始化；非 0ms 为路由决策使用的真实 EWMA 值。",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "gray",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
+            "properties": []
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 11,
+        "x": 12,
+        "y": 13
+      },
+      "id": 302,
+      "options": {
+        "displayMode": "gradient",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "text": {
+          "titleSize": 10
+        },
+        "valueMode": "color"
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sort_desc(\n  (\n    (dae_dialer_latency_moving_avg_seconds{network=\"$network\", group=~\"$group\", group!~\"block|direct\"} * 1000)\n    and (dae_dialer_alive{network=\"$network\", group=~\"$group\", group!~\"block|direct\"} == 1)\n  )\n  or (0 * (dae_dialer_alive{network=\"$network\", group=~\"$group\", group!~\"block|direct\"} == 1))\n)",
+          "instant": true,
+          "legendFormat": "{{group}} / {{dialer}}",
+          "range": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sort_desc(\n  (\n    (dae_dialer_latency_last_seconds{network=\"$network\", group=~\"$group\", group!~\"block|direct\"} * 1000)\n    and (dae_dialer_alive{network=\"$network\", group=~\"$group\", group!~\"block|direct\"} == 1)\n  )\n  or (0 * (dae_dialer_alive{network=\"$network\", group=~\"$group\", group!~\"block|direct\"} == 1))\n)",
+          "hide": true,
+          "instant": true,
+          "legendFormat": "{{group}} / {{dialer}} (instant)",
+          "range": false,
+          "refId": "B"
+        }
+      ],
+      "title": "Latency: EWMA vs Instantaneous (network=$network)",
+      "transparent": true,
+      "type": "bargauge"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 400,
+      "panels": [],
+      "title": "DNS",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 23,
+        "x": 0,
+        "y": 24
+      },
+      "id": 409,
+      "interval": "30s",
+      "maxDataPoints": 50,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "RdYlGn",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "decimals": 1,
+          "reverse": false,
+          "unit": "s"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "ceil(increase(dae_dns_response_latency_seconds_bucket{le!=\"+Inf\"}[$__interval]))",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "DNS Response Latency Heatmap",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "DNS upstream forwarding attempt and error rates per upstream server. High error rates indicate upstream availability issues.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 7,
+        "x": 0,
+        "y": 33
+      },
+      "id": 405,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(dae_dns_upstream_query_total[$__rate_interval])",
+          "legendFormat": "Query: {{upstream}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(dae_dns_upstream_err_total[$__rate_interval])",
+          "legendFormat": "Error: {{upstream}}",
+          "refId": "B"
+        }
+      ],
+      "title": "DNS Upstream Query & Error Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "DNS upstream round-trip latency percentiles per upstream server. Measures time from forwarding request to receiving response.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 7,
+        "y": 33
+      },
+      "id": 406,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(dae_dns_upstream_latency_seconds_bucket[$__rate_interval])) by (le, upstream)) * 1000",
+          "legendFormat": "p50 {{upstream}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(dae_dns_upstream_latency_seconds_bucket[$__rate_interval])) by (le, upstream)) * 1000",
+          "legendFormat": "p95 {{upstream}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(dae_dns_upstream_latency_seconds_bucket[$__rate_interval])) by (le, upstream)) * 1000",
+          "legendFormat": "p99 {{upstream}}",
+          "refId": "C"
+        }
+      ],
+      "title": "DNS Upstream Latency (per upstream)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "End-to-end DNS handling latency percentiles (p50/p95/p99). Measured from query receipt to response sent, including cache lookup, forwarding, and response processing.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p95"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 15,
+        "y": 33
+      },
+      "id": 403,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(dae_dns_response_latency_seconds_bucket[$__rate_interval])) by (le)) * 1000",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(dae_dns_response_latency_seconds_bucket[$__rate_interval])) by (le)) * 1000",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(dae_dns_response_latency_seconds_bucket[$__rate_interval])) by (le)) * 1000",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "DNS Response Latency (end-to-end)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "DNS query rate broken down by cache outcome: fresh hit (served from valid cache), lazy/stale hit (reserved for future stale-while-revalidate — currently always 0), and miss (derived from per-upstream forwarded query rate).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Total Queries"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Cache Miss"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Cache Hit"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Lazy (Stale) Hit"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 7,
+        "x": 0,
+        "y": 41
+      },
+      "id": 401,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(dae_dns_query_total[$__rate_interval])",
+          "legendFormat": "Total Queries",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(dae_dns_cache_hit_total[$__rate_interval])",
+          "legendFormat": "Cache Hit",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(dae_dns_cache_lazy_hit_total[$__rate_interval])",
+          "hide": true,
+          "legendFormat": "Lazy (Stale) Hit",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(dae_dns_upstream_query_total[$__rate_interval]))",
+          "legendFormat": "Cache Miss",
+          "refId": "D"
+        }
+      ],
+      "title": "DNS Query & Cache Breakdown",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Fresh hit ratio = cache_hit / total_queries. Total hit ratio includes stale (lazy) hits served during background refresh. Lower fresh hit ratio with higher total hit ratio indicates active background refresh. Stale-while-revalidate is not yet implemented upstream; the lazy-hit term is reserved and always 0, so Total and Fresh overlap today.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "Fresh Hit Ratio"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 7,
+        "y": 41
+      },
+      "id": 402,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(dae_dns_cache_hit_total[$__rate_interval]) / clamp_min(rate(dae_dns_query_total[$__rate_interval]), 0.001)",
+          "hide": false,
+          "legendFormat": "Fresh Hit Ratio",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "(rate(dae_dns_cache_hit_total[$__rate_interval]) + rate(dae_dns_cache_lazy_hit_total[$__rate_interval])) / clamp_min(rate(dae_dns_query_total[$__rate_interval]), 0.001)",
+          "hide": true,
+          "legendFormat": "Total Hit Ratio (incl. stale)",
+          "refId": "B"
+        }
+      ],
+      "title": "DNS Cache Hit Ratio",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "DNS cache entries currently cached, forwarder connections cached, and refused/rejected query counts.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "C"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "D"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 15,
+        "y": 41
+      },
+      "id": 407,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "dae_dns_cache_entries",
+          "legendFormat": "Cache Entries",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "dae_dns_forwarder_cache_entries",
+          "legendFormat": "Forwarder Cache",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(dae_dns_rejected_total[$__rate_interval])",
+          "legendFormat": "Rejected/s",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(dae_dns_refused_total[$__rate_interval])",
+          "legendFormat": "Refused/s (overload)",
+          "refId": "D"
+        }
+      ],
+      "title": "DNS Cache State & Error Events",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "DNS query concurrency in use — saturation gauge counting client DNS queries currently being handled by dae (inc on `HandleWithResponseWriter_` entry, dec on return). No hard limit is enforced upstream; persistent non-zero values indicate slow upstream or head-of-line queueing.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "In Use"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 49
+      },
+      "id": 404,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "dae_dns_concurrency_in_use",
+          "legendFormat": "In Use",
+          "refId": "A"
+        }
+      ],
+      "title": "DNS Concurrency In Use",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Number of in-flight DNS requests currently being forwarded to each upstream. Persistently high values suggest slow upstream or high concurrency.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 11,
+        "x": 12,
+        "y": 49
+      },
+      "id": 408,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "dae_dns_forwarder_in_flight",
+          "legendFormat": "{{upstream}}",
+          "refId": "A"
+        }
+      ],
+      "title": "DNS Forwarder In-Flight (per upstream)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 57
+      },
+      "id": 500,
+      "panels": [],
+      "title": "Connections",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "TCP proxy connection establishment rate per outbound group and protocol. Shows proxy throughput — each increment is a new successfully established proxied connection.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 58
+      },
+      "id": 501,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "last"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(dae_tcp_connections_total[$__rate_interval])",
+          "legendFormat": "{{group}} / {{protocol}}",
+          "refId": "A"
+        }
+      ],
+      "title": "TCP Connection Establishment Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Current active TCP connections, UDP endpoint associations, and UDP task queues. These are instantaneous gauges, not rates.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 11,
+        "x": 12,
+        "y": 58
+      },
+      "id": 502,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "dae_tcp_connections_active",
+          "legendFormat": "TCP Active",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "dae_udp_endpoints_active",
+          "legendFormat": "UDP Endpoints",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "dae_udp_task_queues_active",
+          "legendFormat": "UDP Task Queues",
+          "refId": "C"
+        }
+      ],
+      "title": "Active Connection Pools",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "UDP new endpoint association rate per group and protocol. Each increment is a new NAT mapping created for a UDP flow.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 66
+      },
+      "id": 503,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "last"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(dae_udp_connections_total[$__rate_interval])",
+          "legendFormat": "{{group}} / {{protocol}}",
+          "refId": "A"
+        }
+      ],
+      "title": "UDP New Endpoint Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Cumulative total TCP and UDP connections proxied since last restart (or SIGUSR1 reload). Resets on reload — use rate() for throughput.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 11,
+        "x": 12,
+        "y": 66
+      },
+      "id": 504,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "dae_tcp_connections_total",
+          "legendFormat": "TCP {{group}}/{{protocol}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "dae_udp_connections_total",
+          "legendFormat": "UDP {{group}}/{{protocol}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Cumulative Connection Totals (resets on reload)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 74
+      },
+      "id": 600,
+      "panels": [],
+      "title": "Go Runtime & Process",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "CPU time consumed per second. Value of 1.0 = one full CPU core. Values > number of cores indicate compute saturation.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 75
+      },
+      "id": 603,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "rate(process_cpu_seconds_total[$__rate_interval])",
+          "legendFormat": "CPU Usage",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Go heap memory: allocated (in-use objects) vs. in-use heap spans. Sustained growth between GC cycles indicates memory pressure.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 11,
+        "x": 12,
+        "y": 75
+      },
+      "id": 602,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "go_memstats_heap_alloc_bytes",
+          "legendFormat": "Heap Alloc",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "go_memstats_heap_inuse_bytes",
+          "legendFormat": "Heap In-Use",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "process_resident_memory_bytes",
+          "legendFormat": "RSS",
+          "refId": "C"
+        }
+      ],
+      "title": "Memory",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Number of goroutines. Sudden spikes may indicate goroutine leak. Gradual growth under load is normal.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 83
+      },
+      "id": 601,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "go_goroutines",
+          "legendFormat": "Goroutines",
+          "refId": "A"
+        }
+      ],
+      "title": "Goroutines",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "GC pause duration percentiles. p99 > 10ms may cause latency spikes in proxy handling. Consider GOGC tuning if consistently high.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 11,
+        "x": 12,
+        "y": 83
+      },
+      "id": 705,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "go_gc_duration_seconds{quantile=\"0.5\"} * 1000",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "go_gc_duration_seconds{quantile=\"1\"} * 1000",
+          "legendFormat": "p99 (max)",
+          "refId": "B"
+        }
+      ],
+      "title": "GC Pause Duration",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "30s",
+  "schemaVersion": 40,
+  "tags": [
+    "dae",
+    "proxy",
+    "ebpf"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "prometheus",
+          "value": "cfa1zpgywwiyod"
+        },
+        "includeAll": false,
+        "label": "Datasource",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "text": [
+            "Evoxt-MY",
+            "FC-HK",
+            "FC-Netflix"
+          ],
+          "value": [
+            "Evoxt-MY",
+            "FC-HK",
+            "FC-Netflix"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(dae_dialer_alive, group)",
+        "includeAll": true,
+        "label": "Group",
+        "multi": true,
+        "name": "group",
+        "options": [],
+        "query": {
+          "query": "label_values(dae_dialer_alive, group)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "tcp4",
+          "value": "tcp4"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(dae_dialer_latency_last_seconds{network!~\".*DNS.*\"}, network)",
+        "includeAll": false,
+        "label": "Network",
+        "name": "network",
+        "options": [],
+        "query": {
+          "query": "label_values(dae_dialer_latency_last_seconds{network!~\".*DNS.*\"}, network)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "dae Transparent Proxy-v5",
+  "uid": "dae-metrics-v5",
+  "version": 22,
+  "weekStart": ""
+}

--- a/.plan/metrics/dae_Transparent_Proxy-Grafana_dashboard.json
+++ b/.plan/metrics/dae_Transparent_Proxy-Grafana_dashboard.json
@@ -3290,13 +3290,13 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(dae_dialer_latency_last_seconds{network!~\".*DNS.*\"}, network)",
+        "definition": "label_values(dae_dialer_alive{network!~\".*DNS.*\"}, network)",
         "includeAll": false,
         "label": "Network",
         "name": "network",
         "options": [],
         "query": {
-          "query": "label_values(dae_dialer_latency_last_seconds{network!~\".*DNS.*\"}, network)",
+          "query": "label_values(dae_dialer_alive{network!~\".*DNS.*\"}, network)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 2,

--- a/cmd/endpoint_config.go
+++ b/cmd/endpoint_config.go
@@ -1,0 +1,74 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2025, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/daeuniverse/dae/common"
+	"github.com/daeuniverse/dae/config"
+	"github.com/daeuniverse/dae/pkg/metricshttp"
+	"github.com/sirupsen/logrus"
+)
+
+func endpointConfigFromGlobal(conf *config.Config, log *logrus.Logger) metricshttp.EndpointConfig {
+	cfg := metricshttp.EndpointConfig{
+		ListenAddress:     conf.Global.EndpointListenAddress,
+		Username:          conf.Global.EndpointUsername,
+		Password:          conf.Global.EndpointPassword,
+		TlsCertificate:    conf.Global.EndpointTlsCertificate,
+		TlsKey:            conf.Global.EndpointTlsKey,
+		PrometheusEnabled: conf.Global.EndpointPrometheusEnabled,
+		PrometheusPath:    conf.Global.EndpointPrometheusPath,
+		PprofEnabled:      conf.Global.PprofPort != 0,
+	}
+	if cfg.ListenAddress == "" && conf.Global.PprofPort != 0 {
+		log.Warnln("pprof_port is deprecated, please use endpoint_listen_address instead")
+		cfg.ListenAddress = fmt.Sprintf("localhost:%d", conf.Global.PprofPort)
+	}
+	return cfg
+}
+
+func endpointConfigChanged(a, b metricshttp.EndpointConfig) bool {
+	return a != b
+}
+
+func validateEndpointTLSFiles(cfg metricshttp.EndpointConfig) error {
+	if cfg.TlsCertificate == "" && cfg.TlsKey == "" {
+		return nil
+	}
+	if cfg.TlsCertificate == "" || cfg.TlsKey == "" {
+		return fmt.Errorf("endpoint_tls_certificate and endpoint_tls_key must be configured together")
+	}
+
+	certFile, err := os.Open(cfg.TlsCertificate)
+	if err != nil {
+		return fmt.Errorf("cannot open endpoint_tls_certificate '%s': %w", cfg.TlsCertificate, err)
+	}
+	defer func() { _ = certFile.Close() }()
+	certFi, err := certFile.Stat()
+	if err != nil {
+		return fmt.Errorf("cannot stat endpoint_tls_certificate '%s': %w", cfg.TlsCertificate, err)
+	}
+	if err = common.ValidateFilePermissionAllowed(cfg.TlsCertificate, certFi, 0o640, 0o644); err != nil {
+		return fmt.Errorf("invalid endpoint_tls_certificate: %w", err)
+	}
+
+	keyFile, err := os.Open(cfg.TlsKey)
+	if err != nil {
+		return fmt.Errorf("cannot open endpoint_tls_key '%s': %w", cfg.TlsKey, err)
+	}
+	defer func() { _ = keyFile.Close() }()
+	keyFi, err := keyFile.Stat()
+	if err != nil {
+		return fmt.Errorf("cannot stat endpoint_tls_key '%s': %w", cfg.TlsKey, err)
+	}
+	if err = common.ValidateFilePermissionAllowed(cfg.TlsKey, keyFi, 0o600); err != nil {
+		return fmt.Errorf("invalid endpoint_tls_key: %w", err)
+	}
+	return nil
+}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -40,6 +40,8 @@ import (
 	"github.com/daeuniverse/dae/control"
 	"github.com/daeuniverse/dae/pkg/config_parser"
 	"github.com/daeuniverse/dae/pkg/logger"
+	"github.com/daeuniverse/dae/pkg/metrics"
+	"github.com/daeuniverse/dae/pkg/metricshttp"
 	"github.com/mohae/deepcopy"
 	"github.com/okzk/sdnotify"
 	"github.com/sirupsen/logrus"
@@ -322,6 +324,11 @@ func (r *Runner) Run() (err error) {
 	// Remove AbortFile at beginning.
 	_ = os.Remove(AbortFile)
 
+	endpointCfg := endpointConfigFromGlobal(conf, log)
+	if err = validateEndpointTLSFiles(endpointCfg); err != nil {
+		return fmt.Errorf("invalid endpoint tls config: %w", err)
+	}
+
 	// New ControlPlane.
 	ctx, cancel := context.WithCancel(context.Background())
 	currCancel = cancel
@@ -338,6 +345,25 @@ func (r *Runner) Run() (err error) {
 		pprofServer = &http.Server{Addr: pprofAddr, Handler: nil}
 		go func() { _ = pprofServer.ListenAndServe() }()
 	}
+
+	metricsState := metrics.NewState()
+	metricsState.SetControlPlane(c)
+	metricsRegistry := metrics.NewRegistry(metricsState)
+
+	var endpointServer *http.Server
+	startEndpointServer := func(cfg metricshttp.EndpointConfig) {
+		if cfg.ListenAddress == "" {
+			endpointServer = nil
+			return
+		}
+		endpointServer = metricshttp.NewEndpointServer(cfg, metricsRegistry)
+		go func(server *http.Server, endpointCfg metricshttp.EndpointConfig) {
+			if e := metricshttp.StartEndpointServer(server, endpointCfg); e != nil && !errors.Is(e, http.ErrServerClosed) {
+				log.WithError(e).Errorln("Endpoint server stopped with error")
+			}
+		}(endpointServer, cfg)
+	}
+	startEndpointServer(endpointCfg)
 
 	// Serve tproxy TCP/UDP server util signals.
 	var listener *control.Listener
@@ -446,6 +472,16 @@ func (r *Runner) Run() (err error) {
 
 			portChanged := conf.Global.TproxyPort != newConf.Global.TproxyPort
 			stagedHotHandoff := !portChanged && listener != nil
+
+			newEndpointCfg := endpointConfigFromGlobal(newConf, log)
+			if err = validateEndpointTLSFiles(newEndpointCfg); err != nil {
+				log.WithFields(logrus.Fields{
+					"err": err,
+				}).Errorln("[Reload] Failed to reload")
+				_ = sdnotify.Ready()
+				_ = os.WriteFile(SignalProgressFilePath, append([]byte{consts.ReloadError}, []byte("\n"+err.Error())...), 0644)
+				continue
+			}
 
 			// New control plane.
 			obj := c.PeekBpf()
@@ -640,6 +676,7 @@ func (r *Runner) Run() (err error) {
 			reloadManager.clearPendingRetirement()
 			reloadManager.setPendingReloadMetadata(reloadStartedAt, reloadStartedAtMono)
 			reloadManager.beginHandoff()
+			metricsState.SetControlPlane(newC)
 
 			// Ready to close.
 			if oldC != nil && reloadManager.currentPendingStagedHandoff() == nil {
@@ -652,6 +689,14 @@ func (r *Runner) Run() (err error) {
 			}
 
 			reloadManager.refreshPprofServer(log, &pprofServer, newConf.Global.PprofPort)
+
+			if endpointConfigChanged(endpointCfg, newEndpointCfg) {
+				if endpointServer != nil {
+					_ = endpointServer.Shutdown(context.Background())
+				}
+				endpointCfg = newEndpointCfg
+				startEndpointServer(endpointCfg)
+			}
 
 			notifyRunStateChange(runStateChanges)
 
@@ -833,6 +878,7 @@ loop:
 				// Listening error.
 				log.Errorln("[Critical] Listener failed; exiting")
 				break loop
+
 			}
 		}
 	}
@@ -844,6 +890,9 @@ loop:
 			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 			_ = pprofServer.Shutdown(ctx)
 			cancel()
+		}
+		if endpointServer != nil {
+			_ = endpointServer.Shutdown(context.Background())
 		}
 		_ = os.Remove(PidFilePath)
 	}()

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -852,6 +852,7 @@ loop:
 						c.InheritLpmIndices(oldC.EjectLpmIndices())
 					}
 					reloadManager.clearPendingStagedHandoff()
+					metricsState.SetControlPlane(c)
 
 					if oldListener != nil {
 						if err := oldListener.Close(); err != nil {

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -1,0 +1,102 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2025, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/daeuniverse/dae/config"
+	"github.com/daeuniverse/dae/pkg/metricshttp"
+	"github.com/sirupsen/logrus"
+)
+
+func writeEndpointFile(t *testing.T, name string, mode os.FileMode) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write endpoint file: %v", err)
+	}
+	if err := os.Chmod(path, mode); err != nil {
+		t.Fatalf("chmod endpoint file: %v", err)
+	}
+	return path
+}
+
+func TestEndpointConfigFromGlobalUsesEndpointSettings(t *testing.T) {
+	conf := &config.Config{}
+	conf.Global.EndpointListenAddress = "127.0.0.1:5556"
+	conf.Global.EndpointUsername = "dae"
+	conf.Global.EndpointPassword = "secret"
+	conf.Global.EndpointTlsCertificate = "/tmp/cert.pem"
+	conf.Global.EndpointTlsKey = "/tmp/key.pem"
+	conf.Global.EndpointPrometheusEnabled = true
+	conf.Global.EndpointPrometheusPath = "/custom-metrics"
+	conf.Global.PprofPort = 0
+
+	cfg := endpointConfigFromGlobal(conf, logrus.New())
+	if cfg.ListenAddress != "127.0.0.1:5556" {
+		t.Fatalf("unexpected listen address: got=%q", cfg.ListenAddress)
+	}
+	if cfg.Username != "dae" || cfg.Password != "secret" {
+		t.Fatalf("unexpected credentials: got=%q/%q", cfg.Username, cfg.Password)
+	}
+	if !cfg.PrometheusEnabled || cfg.PrometheusPath != "/custom-metrics" {
+		t.Fatalf("unexpected prometheus settings: enabled=%v path=%q", cfg.PrometheusEnabled, cfg.PrometheusPath)
+	}
+	if cfg.PprofEnabled {
+		t.Fatal("pprof should be disabled when pprof_port is zero")
+	}
+}
+
+func TestEndpointConfigFromGlobalFallsBackToPprofPort(t *testing.T) {
+	conf := &config.Config{}
+	conf.Global.PprofPort = 6060
+
+	cfg := endpointConfigFromGlobal(conf, logrus.New())
+	if cfg.ListenAddress != "localhost:6060" {
+		t.Fatalf("unexpected pprof fallback address: got=%q want=%q", cfg.ListenAddress, "localhost:6060")
+	}
+	if !cfg.PprofEnabled {
+		t.Fatal("pprof should be enabled when pprof_port is non-zero")
+	}
+}
+
+func TestValidateEndpointTLSFilesRequiresPair(t *testing.T) {
+	err := validateEndpointTLSFiles(endpointConfigFromGlobal(&config.Config{}, logrus.New()))
+	if err != nil {
+		t.Fatalf("empty endpoint tls config should pass: %v", err)
+	}
+
+	err = validateEndpointTLSFiles(metricshttp.EndpointConfig{
+		TlsCertificate: "/tmp/cert.pem",
+	})
+	if err == nil {
+		t.Fatal("expected certificate-only config to fail")
+	}
+}
+
+func TestValidateEndpointTLSFilesChecksPermissions(t *testing.T) {
+	cert := writeEndpointFile(t, "cert.pem", 0o640)
+	key := writeEndpointFile(t, "key.pem", 0o600)
+
+	if err := validateEndpointTLSFiles(metricshttp.EndpointConfig{
+		TlsCertificate: cert,
+		TlsKey:         key,
+	}); err != nil {
+		t.Fatalf("expected valid certificate/key permissions to pass: %v", err)
+	}
+
+	tooOpenCert := writeEndpointFile(t, "cert-open.pem", 0o666)
+	err := validateEndpointTLSFiles(metricshttp.EndpointConfig{
+		TlsCertificate: tooOpenCert,
+		TlsKey:         key,
+	})
+	if err == nil {
+		t.Fatal("expected too-open certificate permissions to fail")
+	}
+}

--- a/common/file_permission.go
+++ b/common/file_permission.go
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2025, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package common
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+func ValidateFilePermissionNotTooOpen(path string, fi os.FileInfo) error {
+	if fi.IsDir() {
+		return fmt.Errorf("cannot read a directory: %v", path)
+	}
+	if fi.Mode()&0o037 > 0 {
+		return fmt.Errorf("permissions %04o for '%v' are too open; requires the file is NOT writable by the same group and NOT accessible by others; suggest 0640 or 0600", fi.Mode()&0o777, path)
+	}
+	return nil
+}
+
+func ValidateFilePermissionAllowed(path string, fi os.FileInfo, allowedModes ...os.FileMode) error {
+	if fi.IsDir() {
+		return fmt.Errorf("cannot read a directory: %v", path)
+	}
+	perm := fi.Mode().Perm()
+	for _, mode := range allowedModes {
+		if perm == mode.Perm() {
+			return nil
+		}
+	}
+	if len(allowedModes) == 0 {
+		return fmt.Errorf("permissions %04o for '%v' are invalid", perm, path)
+	}
+	allowed := make([]string, 0, len(allowedModes))
+	for _, mode := range allowedModes {
+		allowed = append(allowed, fmt.Sprintf("%04o", mode.Perm()))
+	}
+	sort.Strings(allowed)
+	return fmt.Errorf("permissions %04o for '%v' are invalid; allowed: %s", perm, path, strings.Join(allowed, ", "))
+}

--- a/common/file_permission_test.go
+++ b/common/file_permission_test.go
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2025, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package common
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeTempFile(t *testing.T, mode os.FileMode) (string, os.FileInfo) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "x")
+	if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	if err := os.Chmod(path, mode); err != nil {
+		t.Fatalf("chmod temp file: %v", err)
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat temp file: %v", err)
+	}
+	return path, fi
+}
+
+func TestValidateFilePermissionNotTooOpen(t *testing.T) {
+	_, fi0600 := writeTempFile(t, 0o600)
+	if err := ValidateFilePermissionNotTooOpen("test-0600", fi0600); err != nil {
+		t.Fatalf("0600 should pass: %v", err)
+	}
+
+	_, fi0640 := writeTempFile(t, 0o640)
+	if err := ValidateFilePermissionNotTooOpen("test-0640", fi0640); err != nil {
+		t.Fatalf("0640 should pass: %v", err)
+	}
+
+	_, fi0644 := writeTempFile(t, 0o644)
+	if err := ValidateFilePermissionNotTooOpen("test-0644", fi0644); err == nil {
+		t.Fatal("0644 should fail as too open")
+	}
+}
+
+func TestValidateFilePermissionAllowed(t *testing.T) {
+	_, fi0600 := writeTempFile(t, 0o600)
+	if err := ValidateFilePermissionAllowed("key", fi0600, 0o600); err != nil {
+		t.Fatalf("0600 should pass for key: %v", err)
+	}
+	if err := ValidateFilePermissionAllowed("key", fi0600, 0o640, 0o644); err == nil {
+		t.Fatal("0600 should fail for cert-only allowed modes")
+	}
+
+	_, fi0640 := writeTempFile(t, 0o640)
+	if err := ValidateFilePermissionAllowed("cert", fi0640, 0o640, 0o644); err != nil {
+		t.Fatalf("0640 should pass for cert: %v", err)
+	}
+
+	_, fi0644 := writeTempFile(t, 0o644)
+	if err := ValidateFilePermissionAllowed("cert", fi0644, 0o640, 0o644); err != nil {
+		t.Fatalf("0644 should pass for cert: %v", err)
+	}
+}

--- a/component/outbound/dialer/alive_dialer_set.go
+++ b/component/outbound/dialer/alive_dialer_set.go
@@ -141,6 +141,12 @@ func (a *AliveDialerSet) Len() int {
 	return len(a.aliveEntries)
 }
 
+func (a *AliveDialerSet) AliveCount() int {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return len(a.aliveEntries)
+}
+
 func (a *AliveDialerSet) SortingLatency(d *Dialer) time.Duration {
 	a.mu.RLock()
 	defer a.mu.RUnlock()

--- a/component/outbound/dialer/connectivity_check.go
+++ b/component/outbound/dialer/connectivity_check.go
@@ -124,6 +124,8 @@ type collection struct {
 	MovingAverage     time.Duration
 	LastProbe         DialerProbeObservationSnapshot
 	Alive             atomic.Bool
+	CheckTotal        atomic.Uint64
+	CheckFailureTotal atomic.Uint64
 }
 
 func newCollection() *collection {
@@ -845,6 +847,29 @@ func (d *Dialer) MustGetLatencies10(typ *NetworkType) *LatenciesN {
 	return d.mustGetCollection(typ).Latencies10
 }
 
+func (d *Dialer) GetCollectionState(typ *NetworkType) (alive bool, lastLatency, avg10, movingAvg time.Duration, hasLastLatency bool) {
+	d.collectionFineMu.Lock()
+	col := d.mustGetCollection(typ)
+	alive = col.Alive.Load()
+	movingAvg = col.MovingAverage
+	lastProbe := col.LastProbe
+	d.collectionFineMu.Unlock()
+	// Use LastProbe.Latency rather than Latencies10.LastLatency() so that
+	// timeout-penalty values (10 s injected on failure) are never surfaced
+	// as a real "last latency" reading.
+	if lastProbe.HasLatency {
+		lastLatency = lastProbe.Latency
+		hasLastLatency = true
+	}
+	avg10, _ = col.Latencies10.AvgLatency()
+	return
+}
+
+func (d *Dialer) GetCollectionCounters(typ *NetworkType) (checkTotal, checkFailureTotal uint64) {
+	col := d.mustGetCollection(typ)
+	return col.CheckTotal.Load(), col.CheckFailureTotal.Load()
+}
+
 // RegisterAliveDialerSet is thread-safe.
 func (d *Dialer) RegisterAliveDialerSet(a *AliveDialerSet) {
 	if a == nil {
@@ -1105,6 +1130,7 @@ func (d *Dialer) check(opts *CheckOption, isResuscitation bool, cycle *cycleResu
 	const maxAttempts = 2
 	var bestLatency time.Duration
 	checkedAt := time.Now()
+	d.mustGetCollection(opts.networkType).CheckTotal.Add(1)
 
 	for i := 0; i < maxAttempts; i++ {
 		ctx, cancel := context.WithTimeout(d.ctx, Timeout)
@@ -1173,6 +1199,7 @@ func (d *Dialer) check(opts *CheckOption, isResuscitation bool, cycle *cycleResu
 			Alive:     false,
 			Message:   err.Error(),
 		}
+		collection.CheckFailureTotal.Add(1)
 		d.collectionFineMu.Unlock()
 
 		// Failure: mark unavailable only if there's an actual error.

--- a/component/outbound/dialer_group.go
+++ b/component/outbound/dialer_group.go
@@ -146,6 +146,10 @@ func (g *DialerGroup) MinCheckInterval() time.Duration {
 	return min
 }
 
+func (g *DialerGroup) AliveDialerSets() [8]*dialer.AliveDialerSet {
+	return g.currentSelectionState().aliveDialerSets
+}
+
 func (d *DialerGroup) MustGetAliveDialerSet(typ *dialer.NetworkType) *dialer.AliveDialerSet {
 	return d.currentSelectionState().aliveDialerSets[typ.Index()]
 }

--- a/config/config.go
+++ b/config/config.go
@@ -39,21 +39,28 @@ type Global struct {
 	EnableLocalTcpFastRedirect bool `mapstructure:"enable_local_tcp_fast_redirect" default:"false"`
 	AutoConfigKernelParameter  bool `mapstructure:"auto_config_kernel_parameter" default:"false"`
 	// Deprecated: not used as of https://github.com/daeuniverse/dae/pull/458.
-	AutoConfigFirewallRule bool          `mapstructure:"auto_config_firewall_rule" default:"false"`
-	SniffingTimeout        time.Duration `mapstructure:"sniffing_timeout" default:"30ms"`
-	TlsImplementation      string        `mapstructure:"tls_implementation" default:"tls"`
-	UtlsImitate            string        `mapstructure:"utls_imitate" default:"chrome_auto"`
-	TlsFragment            bool          `mapstructure:"tls_fragment" default:"false"`
-	TlsFragmentLength      string        `mapstructure:"tls_fragment_length" default:"50-100"`
-	TlsFragmentInterval    string        `mapstructure:"tls_fragment_interval" default:"10-20"`
-	PprofPort              uint16        `mapstructure:"pprof_port" default:"0"`
-	Mptcp                  bool          `mapstructure:"mptcp" default:"false"`
-	BootstrapResolver      string        `mapstructure:"bootstrap_resolver"`
-	FallbackResolver       string        `mapstructure:"fallback_resolver" default:"8.8.8.8:53"`
-	BandwidthMaxTx         string        `mapstructure:"bandwidth_max_tx" default:"0"`
-	BandwidthMaxRx         string        `mapstructure:"bandwidth_max_rx" default:"0"`
-	UDPHopInterval         time.Duration `mapstructure:"udphop_interval" default:"30s"`
-	BpfConnStateMapSize    uint32        `mapstructure:"bpf_conn_state_map_size" default:"262144"`
+	AutoConfigFirewallRule    bool          `mapstructure:"auto_config_firewall_rule" default:"false"`
+	SniffingTimeout           time.Duration `mapstructure:"sniffing_timeout" default:"30ms"`
+	TlsImplementation         string        `mapstructure:"tls_implementation" default:"tls"`
+	UtlsImitate               string        `mapstructure:"utls_imitate" default:"chrome_auto"`
+	TlsFragment               bool          `mapstructure:"tls_fragment" default:"false"`
+	TlsFragmentLength         string        `mapstructure:"tls_fragment_length" default:"50-100"`
+	TlsFragmentInterval       string        `mapstructure:"tls_fragment_interval" default:"10-20"`
+	PprofPort                 uint16        `mapstructure:"pprof_port" default:"0"`
+	Mptcp                     bool          `mapstructure:"mptcp" default:"false"`
+	BootstrapResolver         string        `mapstructure:"bootstrap_resolver"`
+	FallbackResolver          string        `mapstructure:"fallback_resolver" default:"8.8.8.8:53"`
+	BandwidthMaxTx            string        `mapstructure:"bandwidth_max_tx" default:"0"`
+	BandwidthMaxRx            string        `mapstructure:"bandwidth_max_rx" default:"0"`
+	UDPHopInterval            time.Duration `mapstructure:"udphop_interval" default:"30s"`
+	BpfConnStateMapSize       uint32        `mapstructure:"bpf_conn_state_map_size" default:"262144"`
+	EndpointListenAddress     string        `mapstructure:"endpoint_listen_address" default:""`
+	EndpointUsername          string        `mapstructure:"endpoint_username" default:""`
+	EndpointPassword          string        `mapstructure:"endpoint_password" default:""`
+	EndpointTlsCertificate    string        `mapstructure:"endpoint_tls_certificate" default:""`
+	EndpointTlsKey            string        `mapstructure:"endpoint_tls_key" default:""`
+	EndpointPrometheusEnabled bool          `mapstructure:"endpoint_prometheus_enabled" default:"false"`
+	EndpointPrometheusPath    string        `mapstructure:"endpoint_prometheus_path" default:"/metrics"`
 }
 
 type Utls struct {

--- a/control/connection_metrics.go
+++ b/control/connection_metrics.go
@@ -1,0 +1,78 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2025, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package control
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+type ConnMetricKey struct {
+	Protocol string
+	Group    string
+}
+
+func incrementConnectionTotal(counters *sync.Map, protocol string, group string) {
+	if counters == nil || protocol == "" || group == "" {
+		return
+	}
+	key := ConnMetricKey{
+		Protocol: protocol,
+		Group:    group,
+	}
+
+	if val, ok := counters.Load(key); ok {
+		if counter, ok := val.(*atomic.Uint64); ok {
+			counter.Add(1)
+			return
+		}
+	}
+
+	counter := new(atomic.Uint64)
+	counter.Store(1)
+	actual, loaded := counters.LoadOrStore(key, counter)
+	if loaded {
+		if existing, ok := actual.(*atomic.Uint64); ok {
+			existing.Add(1)
+		}
+	}
+}
+
+func snapshotConnectionTotals(counters *sync.Map) map[ConnMetricKey]uint64 {
+	snapshot := make(map[ConnMetricKey]uint64)
+	if counters == nil {
+		return snapshot
+	}
+	counters.Range(func(key, value interface{}) bool {
+		metricKey, ok := key.(ConnMetricKey)
+		if !ok {
+			return true
+		}
+		counter, ok := value.(*atomic.Uint64)
+		if !ok {
+			return true
+		}
+		snapshot[metricKey] = counter.Load()
+		return true
+	})
+	return snapshot
+}
+
+func (c *ControlPlane) AddTcpConnectionTotal(protocol string, group string) {
+	incrementConnectionTotal(&c.tcpConnectionTotals, protocol, group)
+}
+
+func (c *ControlPlane) AddUdpConnectionTotal(protocol string, group string) {
+	incrementConnectionTotal(&c.udpConnectionTotals, protocol, group)
+}
+
+func (c *ControlPlane) TcpConnectionTotalsSnapshot() map[ConnMetricKey]uint64 {
+	return snapshotConnectionTotals(&c.tcpConnectionTotals)
+}
+
+func (c *ControlPlane) UdpConnectionTotalsSnapshot() map[ConnMetricKey]uint64 {
+	return snapshotConnectionTotals(&c.udpConnectionTotals)
+}

--- a/control/connection_metrics_test.go
+++ b/control/connection_metrics_test.go
@@ -1,0 +1,43 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2025, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package control
+
+import "testing"
+
+func TestControlPlaneConnectionTotalsSnapshot(t *testing.T) {
+	cp := &ControlPlane{}
+
+	cp.AddTcpConnectionTotal("tcp4", "HK")
+	cp.AddTcpConnectionTotal("tcp4", "HK")
+	cp.AddTcpConnectionTotal("tcp6", "US")
+	cp.AddUdpConnectionTotal("udp4", "HK")
+	cp.AddUdpConnectionTotal("udp4", "HK")
+	cp.AddUdpConnectionTotal("udp6", "US")
+	cp.AddUdpConnectionTotal("", "ignored")
+	cp.AddTcpConnectionTotal("tcp4", "")
+
+	tcpSnapshot := cp.TcpConnectionTotalsSnapshot()
+	if got := tcpSnapshot[ConnMetricKey{Protocol: "tcp4", Group: "HK"}]; got != 2 {
+		t.Fatalf("unexpected tcp4/HK count: got=%d want=2", got)
+	}
+	if got := tcpSnapshot[ConnMetricKey{Protocol: "tcp6", Group: "US"}]; got != 1 {
+		t.Fatalf("unexpected tcp6/US count: got=%d want=1", got)
+	}
+	if len(tcpSnapshot) != 2 {
+		t.Fatalf("unexpected tcp snapshot size: got=%d want=2", len(tcpSnapshot))
+	}
+
+	udpSnapshot := cp.UdpConnectionTotalsSnapshot()
+	if got := udpSnapshot[ConnMetricKey{Protocol: "udp4", Group: "HK"}]; got != 2 {
+		t.Fatalf("unexpected udp4/HK count: got=%d want=2", got)
+	}
+	if got := udpSnapshot[ConnMetricKey{Protocol: "udp6", Group: "US"}]; got != 1 {
+		t.Fatalf("unexpected udp6/US count: got=%d want=1", got)
+	}
+	if len(udpSnapshot) != 2 {
+		t.Fatalf("unexpected udp snapshot size: got=%d want=2", len(udpSnapshot))
+	}
+}

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -60,6 +60,9 @@ type ControlPlane struct {
 	inConnections        sync.Map
 	rejectNewConnections atomic.Bool
 	drainTracker         *controlPlaneDrainTracker
+	// key: ConnMetricKey, value: *atomic.Uint64
+	tcpConnectionTotals sync.Map
+	udpConnectionTotals sync.Map
 
 	controlPlaneDNSRuntime
 	dnsHandoffMu         sync.Mutex
@@ -3669,6 +3672,18 @@ func (c *ControlPlane) Close() (err error) {
 	})
 
 	return c.closeErr
+}
+
+func (c *ControlPlane) Outbounds() []*outbound.DialerGroup {
+	return c.outbounds
+}
+
+func (c *ControlPlane) GetDnsController() *DnsController {
+	return c.dnsHandoffController.Load()
+}
+
+func (c *ControlPlane) CountTcpConnections() int {
+	return c.ActiveTCPConnections()
 }
 
 // StopDNSListener stops the DNS listener if it's running

--- a/control/dns_control.go
+++ b/control/dns_control.go
@@ -129,6 +129,17 @@ type dnsControllerStore struct {
 	// When ip_version_prefer is set, non-preferred responses wait briefly
 	// for preferred responses to arrive (RFC 8305 Happy Eyeballs).
 	prefWaitRegistry *preferenceWaitRegistry
+
+	// DNS metrics — on store so they persist across reloads.
+	dnsMetricsInit         sync.Once
+	dnsQueryTotal          atomic.Uint64
+	dnsCacheHitTotal       atomic.Uint64
+	dnsCacheLazyHitTotal   atomic.Uint64
+	dnsConcurrencyInFlight atomic.Int64
+	dnsRejectedTotal       atomic.Uint64
+	dnsRefusedTotal        atomic.Uint64
+	dnsResponseLatency     *dnsLatencyHistogram
+	dnsUpstreamMetrics     sync.Map
 }
 
 // DnsController is a lightweight generation-local facade over a shared
@@ -629,6 +640,27 @@ func (c *DnsController) ResetDnsForwarders() error {
 	// Retire cached forwarders so new requests redial using the replacement
 	// generation's runtime, while in-flight upstream exchanges finish cleanly.
 	return errors.Join(c.retireAllDnsForwarders()...)
+}
+
+func (c *DnsController) CacheSize() int {
+	n := 0
+	c.requireStore().dnsCache.Range(func(_, _ any) bool {
+		n++
+		return true
+	})
+	return n
+}
+
+func (c *DnsController) ConcurrencyInUse() int {
+	return int(c.dnsConcurrencyInFlight.Load())
+}
+
+func (c *DnsController) ForwarderCacheInfo() (count int) {
+	c.requireStore().dnsForwarderCache.Range(func(_, _ any) bool {
+		count++
+		return true
+	})
+	return count
 }
 
 var (
@@ -2176,6 +2208,11 @@ func (c *DnsController) Handle_(ctx context.Context, dnsMessage *dnsmessage.Msg,
 
 func (c *DnsController) HandleWithResponseWriter_(ctx context.Context, dnsMessage *dnsmessage.Msg, req *udpRequest, responseWriter dnsmessage.ResponseWriter) (err error) {
 	c.requireStore()
+	c.dnsQueryTotal.Add(1)
+	c.dnsConcurrencyInFlight.Add(1)
+	defer c.dnsConcurrencyInFlight.Add(-1)
+	start := time.Now()
+	defer func() { c.observeDnsResponseLatency(time.Since(start)) }()
 	var upstreamIndex consts.DnsRequestOutboundIndex
 	var upstream *dns.Upstream
 
@@ -2228,9 +2265,11 @@ func (c *DnsController) HandleWithResponseWriter_(ctx context.Context, dnsMessag
 
 		// Check cache after routing (non-reject case)
 		if resp, needRefresh := c.LookupDnsRespCache_(dnsMessage, responseCacheKey, false); resp != nil {
+			c.dnsCacheHitTotal.Add(1)
 			// Cache hit - return immediately without singleflight
 			// OPTIMISTIC CACHE: resp may be stale, trigger background refresh if needed
 			if needRefresh {
+				c.dnsCacheLazyHitTotal.Add(1)
 				// Background refresh - don't block the current request
 				go c.backgroundRefresh(responseCacheKey, dnsMessage, req, upstreamIndex, upstream)
 			}
@@ -2457,7 +2496,6 @@ func (c *DnsController) handleWithResponseWriter_(
 		}
 		return nil
 	}
-
 	if c.log.IsLevelEnabled(logrus.TraceLevel) {
 		upstreamName := upstreamIndex.String()
 		if upstream != nil {
@@ -2572,6 +2610,7 @@ func (c *DnsController) sendDnsErrorResponse_(
 
 // sendRefusedWithResponseWriter_ sends REFUSED response when overload protection is triggered.
 func (c *DnsController) sendRefusedWithResponseWriter_(dnsMessage *dnsmessage.Msg, req *udpRequest, responseWriter dnsmessage.ResponseWriter) (err error) {
+	c.dnsRefusedTotal.Add(1)
 	return c.sendDnsErrorResponse_(dnsMessage, dnsmessage.RcodeRefused, "Refused due to concurrency limit", req, responseWriter)
 }
 
@@ -2605,6 +2644,7 @@ func (c *DnsController) sendDnsTruncatedResponse_(dnsMessage *dnsmessage.Msg, re
 
 // sendRejectWithResponseWriter_ send empty answer.
 func (c *DnsController) sendRejectWithResponseWriter_(dnsMessage *dnsmessage.Msg, req *udpRequest, responseWriter dnsmessage.ResponseWriter) (err error) {
+	c.dnsRejectedTotal.Add(1)
 	return c.sendDnsErrorResponse_(dnsMessage, dnsmessage.RcodeSuccess, "Reject", req, responseWriter)
 }
 
@@ -2717,6 +2757,8 @@ func (c *DnsController) dialSend(
 	} else {
 		upstreamName = upstream.String()
 	}
+	upstreamMetric := c.getOrCreateDnsUpstreamMetric(upstreamName)
+	upstreamMetric.queryTotal.Add(1)
 
 	// Select best dial arguments (outbound, dialer, l4proto, ipversion, etc.)
 	rt := c.runtime()
@@ -2731,8 +2773,13 @@ func (c *DnsController) dialSend(
 	// Dial and send.
 	var respMsg *dnsmessage.Msg
 	var usedDialArg *dialArgument
+	upstreamMetric.inFlight.Add(1)
+	forwardStart := time.Now()
 	respMsg, usedDialArg, err = c.forwardWithFallback(ctx, req, upstream, dialArg, data)
+	upstreamMetric.inFlight.Add(-1)
+	upstreamMetric.latency.Observe(time.Since(forwardStart).Seconds())
 	if err != nil {
+		upstreamMetric.errTotal.Add(1)
 		return err
 	}
 

--- a/control/dns_metrics.go
+++ b/control/dns_metrics.go
@@ -1,0 +1,195 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2025, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package control
+
+import (
+	"math"
+	"sync/atomic"
+	"time"
+)
+
+var dnsLatencyHistogramBounds = []float64{
+	0.001, 0.0025, 0.005, 0.01, 0.025, 0.05,
+	0.1, 0.25, 0.5, 1, 2, 5,
+}
+
+type DnsHistogramSnapshot struct {
+	Count   uint64
+	Sum     float64
+	Buckets map[float64]uint64
+}
+
+type DnsCountersSnapshot struct {
+	QueryTotal         uint64
+	CacheHitTotal      uint64
+	CacheLazyHitTotal  uint64
+	UpstreamQueryTotal uint64
+	UpstreamErrTotal   uint64
+	RejectedTotal      uint64
+	RefusedTotal       uint64
+}
+
+type DnsUpstreamMetricsSnapshot struct {
+	QueryTotal uint64
+	ErrTotal   uint64
+	InFlight   int32
+	Latency    DnsHistogramSnapshot
+}
+
+type dnsLatencyHistogram struct {
+	count   atomic.Uint64
+	sumBits atomic.Uint64
+	buckets []atomic.Uint64
+}
+
+type dnsUpstreamMetric struct {
+	queryTotal atomic.Uint64
+	errTotal   atomic.Uint64
+	inFlight   atomic.Int32
+	latency    *dnsLatencyHistogram
+}
+
+func newDnsLatencyHistogram() *dnsLatencyHistogram {
+	return &dnsLatencyHistogram{
+		buckets: make([]atomic.Uint64, len(dnsLatencyHistogramBounds)+1),
+	}
+}
+
+func newDnsUpstreamMetric() *dnsUpstreamMetric {
+	return &dnsUpstreamMetric{
+		latency: newDnsLatencyHistogram(),
+	}
+}
+
+func addAtomicFloat64(bits *atomic.Uint64, delta float64) {
+	for {
+		oldBits := bits.Load()
+		newBits := math.Float64bits(math.Float64frombits(oldBits) + delta)
+		if bits.CompareAndSwap(oldBits, newBits) {
+			return
+		}
+	}
+}
+
+func (h *dnsLatencyHistogram) Observe(seconds float64) {
+	if h == nil {
+		return
+	}
+	if seconds < 0 {
+		seconds = 0
+	}
+	idx := len(dnsLatencyHistogramBounds)
+	for i, bound := range dnsLatencyHistogramBounds {
+		if seconds <= bound {
+			idx = i
+			break
+		}
+	}
+	h.buckets[idx].Add(1)
+	h.count.Add(1)
+	addAtomicFloat64(&h.sumBits, seconds)
+}
+
+func (h *dnsLatencyHistogram) Snapshot() DnsHistogramSnapshot {
+	if h == nil {
+		return DnsHistogramSnapshot{Buckets: map[float64]uint64{}}
+	}
+	buckets := make(map[float64]uint64, len(dnsLatencyHistogramBounds))
+	var cumulative uint64
+	for i, bound := range dnsLatencyHistogramBounds {
+		cumulative += h.buckets[i].Load()
+		buckets[bound] = cumulative
+	}
+	count := h.count.Load()
+	if count < cumulative {
+		count = cumulative
+	}
+	return DnsHistogramSnapshot{
+		Count:   count,
+		Sum:     math.Float64frombits(h.sumBits.Load()),
+		Buckets: buckets,
+	}
+}
+
+func (c *DnsController) initDnsMetricsState() {
+	c.dnsMetricsInit.Do(func() {
+		if c.dnsResponseLatency == nil {
+			c.dnsResponseLatency = newDnsLatencyHistogram()
+		}
+	})
+}
+
+func (c *DnsController) getOrCreateDnsUpstreamMetric(upstream string) *dnsUpstreamMetric {
+	c.initDnsMetricsState()
+	if val, ok := c.dnsUpstreamMetrics.Load(upstream); ok {
+		if metric, ok := val.(*dnsUpstreamMetric); ok {
+			return metric
+		}
+	}
+	created := newDnsUpstreamMetric()
+	actual, loaded := c.dnsUpstreamMetrics.LoadOrStore(upstream, created)
+	if loaded {
+		if metric, ok := actual.(*dnsUpstreamMetric); ok {
+			return metric
+		}
+	}
+	return created
+}
+
+func (c *DnsController) observeDnsResponseLatency(latency time.Duration) {
+	c.initDnsMetricsState()
+	c.dnsResponseLatency.Observe(latency.Seconds())
+}
+
+func (c *DnsController) DnsCountersSnapshot() DnsCountersSnapshot {
+	c.initDnsMetricsState()
+	var upstreamQueryTotal uint64
+	var upstreamErrTotal uint64
+	c.dnsUpstreamMetrics.Range(func(_, value interface{}) bool {
+		if metric, ok := value.(*dnsUpstreamMetric); ok {
+			upstreamQueryTotal += metric.queryTotal.Load()
+			upstreamErrTotal += metric.errTotal.Load()
+		}
+		return true
+	})
+	return DnsCountersSnapshot{
+		QueryTotal:         c.dnsQueryTotal.Load(),
+		CacheHitTotal:      c.dnsCacheHitTotal.Load(),
+		CacheLazyHitTotal:  c.dnsCacheLazyHitTotal.Load(),
+		UpstreamQueryTotal: upstreamQueryTotal,
+		UpstreamErrTotal:   upstreamErrTotal,
+		RejectedTotal:      c.dnsRejectedTotal.Load(),
+		RefusedTotal:       c.dnsRefusedTotal.Load(),
+	}
+}
+
+func (c *DnsController) DnsResponseLatencySnapshot() DnsHistogramSnapshot {
+	c.initDnsMetricsState()
+	return c.dnsResponseLatency.Snapshot()
+}
+
+func (c *DnsController) DnsUpstreamSnapshot() map[string]DnsUpstreamMetricsSnapshot {
+	c.initDnsMetricsState()
+	snapshot := make(map[string]DnsUpstreamMetricsSnapshot)
+	c.dnsUpstreamMetrics.Range(func(key, value interface{}) bool {
+		upstream, ok := key.(string)
+		if !ok {
+			return true
+		}
+		metric, ok := value.(*dnsUpstreamMetric)
+		if !ok {
+			return true
+		}
+		snapshot[upstream] = DnsUpstreamMetricsSnapshot{
+			QueryTotal: metric.queryTotal.Load(),
+			ErrTotal:   metric.errTotal.Load(),
+			InFlight:   metric.inFlight.Load(),
+			Latency:    metric.latency.Snapshot(),
+		}
+		return true
+	})
+	return snapshot
+}

--- a/control/dns_metrics_test.go
+++ b/control/dns_metrics_test.go
@@ -1,0 +1,146 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2025, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package control
+
+import (
+	"context"
+	"math"
+	"net"
+	"testing"
+
+	dnsmessage "github.com/miekg/dns"
+	"github.com/sirupsen/logrus"
+)
+
+type noopDNSResponseWriter struct{}
+
+func (w *noopDNSResponseWriter) LocalAddr() net.Addr  { return nil }
+func (w *noopDNSResponseWriter) RemoteAddr() net.Addr { return nil }
+func (w *noopDNSResponseWriter) WriteMsg(*dnsmessage.Msg) error {
+	return nil
+}
+func (w *noopDNSResponseWriter) Write(b []byte) (int, error) { return len(b), nil }
+func (w *noopDNSResponseWriter) Close() error                { return nil }
+func (w *noopDNSResponseWriter) TsigStatus() error           { return nil }
+func (w *noopDNSResponseWriter) TsigTimersOnly(bool)         {}
+func (w *noopDNSResponseWriter) Hijack()                     {}
+
+func TestDnsLatencyHistogramSnapshotMonotonic(t *testing.T) {
+	h := newDnsLatencyHistogram()
+	h.Observe(0.001)
+	h.Observe(0.2)
+	h.Observe(6)
+
+	snapshot := h.Snapshot()
+	if snapshot.Count != 3 {
+		t.Fatalf("unexpected histogram count: got=%d want=3", snapshot.Count)
+	}
+	expectedSum := 6.201
+	if diff := math.Abs(snapshot.Sum - expectedSum); diff > 1e-9 {
+		t.Fatalf("unexpected histogram sum: got=%f want=%f diff=%f", snapshot.Sum, expectedSum, diff)
+	}
+
+	var prev uint64
+	for i, bound := range dnsLatencyHistogramBounds {
+		cur := snapshot.Buckets[bound]
+		if i > 0 && cur < prev {
+			t.Fatalf("histogram cumulative buckets must be monotonic: bound=%f cur=%d prev=%d", bound, cur, prev)
+		}
+		prev = cur
+	}
+	lastBound := dnsLatencyHistogramBounds[len(dnsLatencyHistogramBounds)-1]
+	if got := snapshot.Buckets[lastBound]; got != 2 {
+		t.Fatalf("unexpected last finite bucket count: got=%d want=2", got)
+	}
+}
+
+func TestDnsControllerRejectCounter(t *testing.T) {
+	c := &DnsController{
+		log: logrus.New(),
+		dnsControllerStore: &dnsControllerStore{
+			dnsResponseLatency: newDnsLatencyHistogram(),
+		},
+	}
+	writer := &noopDNSResponseWriter{}
+
+	rejectMsg := new(dnsmessage.Msg)
+	rejectMsg.SetQuestion("reject.example.", dnsmessage.TypeA)
+	if err := c.sendRejectWithResponseWriter_(rejectMsg, nil, writer); err != nil {
+		t.Fatalf("sendRejectWithResponseWriter_: %v", err)
+	}
+
+	counters := c.DnsCountersSnapshot()
+	if counters.RejectedTotal != 1 {
+		t.Fatalf("unexpected rejected counter: got=%d want=1", counters.RejectedTotal)
+	}
+	if counters.CacheLazyHitTotal != 0 {
+		t.Fatalf("unexpected lazy cache hit counter: got=%d want=0", counters.CacheLazyHitTotal)
+	}
+	if counters.RefusedTotal != 0 {
+		t.Fatalf("unexpected refused counter: got=%d want=0", counters.RefusedTotal)
+	}
+}
+
+func TestDnsControllerUpstreamSnapshot(t *testing.T) {
+	c := &DnsController{dnsControllerStore: &dnsControllerStore{dnsResponseLatency: newDnsLatencyHistogram()}}
+	metric := c.getOrCreateDnsUpstreamMetric("udp://1.1.1.1:53")
+	metric.queryTotal.Add(2)
+	metric.errTotal.Add(1)
+	metric.inFlight.Add(3)
+	metric.latency.Observe(0.01)
+	metric.latency.Observe(0.02)
+
+	snapshot := c.DnsUpstreamSnapshot()
+	entry, ok := snapshot["udp://1.1.1.1:53"]
+	if !ok {
+		t.Fatal("missing upstream snapshot")
+	}
+	if entry.QueryTotal != 2 {
+		t.Fatalf("unexpected upstream query total: got=%d want=2", entry.QueryTotal)
+	}
+	if entry.ErrTotal != 1 {
+		t.Fatalf("unexpected upstream err total: got=%d want=1", entry.ErrTotal)
+	}
+	if entry.InFlight != 3 {
+		t.Fatalf("unexpected upstream in-flight: got=%d want=3", entry.InFlight)
+	}
+	if entry.Latency.Count != 2 {
+		t.Fatalf("unexpected upstream latency count: got=%d want=2", entry.Latency.Count)
+	}
+}
+
+func TestDnsControllerHandleWithResponseWriterCountsQuery(t *testing.T) {
+	c := &DnsController{
+		log: logrus.New(),
+		dnsControllerStore: &dnsControllerStore{
+			dnsResponseLatency: newDnsLatencyHistogram(),
+		},
+	}
+	msg := new(dnsmessage.Msg)
+	msg.SetQuestion("query.example.", dnsmessage.TypeA)
+
+	if err := c.HandleWithResponseWriter_(context.Background(), msg, nil, nil); err == nil {
+		t.Fatal("expected error when routing is nil")
+	}
+
+	counters := c.DnsCountersSnapshot()
+	if counters.QueryTotal != 1 {
+		t.Fatalf("unexpected query total: got=%d want=1", counters.QueryTotal)
+	}
+	latency := c.DnsResponseLatencySnapshot()
+	if latency.Count != 1 {
+		t.Fatalf("unexpected response latency count: got=%d want=1", latency.Count)
+	}
+}
+
+func TestDnsControllerConcurrencyInfo(t *testing.T) {
+	c := &DnsController{dnsControllerStore: &dnsControllerStore{}}
+	c.dnsConcurrencyInFlight.Add(2)
+
+	if inUse := c.ConcurrencyInUse(); inUse != 2 {
+		t.Fatalf("unexpected concurrency in-use: got=%d want=2", inUse)
+	}
+}

--- a/control/node_latency.go
+++ b/control/node_latency.go
@@ -15,6 +15,8 @@ import (
 // NodeLatencySnapshot describes the latest observable latency status for one node link.
 type NodeLatencySnapshot struct {
 	Link      string
+	Name      string // human-readable dialer name, e.g. "香港标准 IEPL 专线 1"
+	Group     string // outbound group name, e.g. "FC_HK"
 	LatencyMs *int32
 	Alive     bool
 	Message   string
@@ -68,6 +70,8 @@ func (c *ControlPlane) SnapshotNodeLatencies() []NodeLatencySnapshot {
 			}
 
 			snapshot := bestNodeLatencySnapshotForDialer(d)
+			snapshot.Name = d.Property().Name
+			snapshot.Group = group.Name
 			if existing, ok := latenciesByLink[snapshot.Link]; !ok || preferNodeLatencySnapshot(snapshot, existing) {
 				latenciesByLink[snapshot.Link] = snapshot
 			}

--- a/control/tcp.go
+++ b/control/tcp.go
@@ -248,6 +248,7 @@ func (c *ControlPlane) handleConn(ctx context.Context, lConn net.Conn) (err erro
 		return fmt.Errorf("failed to dial %v: %w", dst, err)
 	}
 	defer func() { _ = rConn.Close() }()
+	c.AddTcpConnectionTotal(res.OrigNetworkTypeObj.StringWithoutDns(), res.Outbound.Name)
 
 	offloaded := false
 	offloadReason := ""
@@ -307,8 +308,13 @@ func (c *ControlPlane) RouteDialTcpContext(ctx context.Context, p *RouteDialPara
 		Mark:        p.Mark,
 		Network:     "tcp",
 	}
-	conn, _, err = c.routeDial(ctx, dialParam)
-	return conn, err
+	var res *proxyDialResult
+	conn, res, err = c.routeDial(ctx, dialParam)
+	if err != nil {
+		return conn, err
+	}
+	c.AddTcpConnectionTotal(res.OrigNetworkTypeObj.StringWithoutDns(), res.Outbound.Name)
+	return conn, nil
 }
 
 type WriteCloser interface {

--- a/control/udp.go
+++ b/control/udp.go
@@ -1063,6 +1063,10 @@ getNew:
 	if lifecycle, ok := newUdpSessionLifecycleContext(ue, ""); ok {
 		lifecycle.reportTrafficSuccess()
 	}
+	RecordUploadTraffic(int64(len(data)))
+	if isNew {
+		c.AddUdpConnectionTotal(networkType.StringWithoutDns(), ue.Outbound.Name)
+	}
 
 	// Print log.
 	// Only print routing for new connection to avoid the log exploded (Quic and BT).

--- a/control/udp_task_pool.go
+++ b/control/udp_task_pool.go
@@ -219,6 +219,15 @@ func NewUdpTaskPool() *UdpTaskPool {
 	}
 }
 
+func (p *UdpTaskPool) Count() int {
+	n := 0
+	p.queues.Range(func(_, _ any) bool {
+		n++
+		return true
+	})
+	return n
+}
+
 // EmitTask makes sure packets with the same UDP flow key are sent in order.
 func (p *UdpTaskPool) EmitTask(key UdpFlowKey, task UdpTask) {
 	q := p.acquireQueue(key)

--- a/example.dae
+++ b/example.dae
@@ -34,6 +34,17 @@ global {
     # Takes effect on fresh eBPF load or restart; same-port reload keeps the live map.
     bpf_conn_state_map_size: 262144
 
+    # Endpoint configuration for metrics and diagnostics.
+    # Set a listen address to enable the endpoint server (disabled by default).
+    #endpoint_listen_address: '0.0.0.0:5556'
+    #endpoint_username: ''
+    #endpoint_password: ''
+    # TLS permission policy: certificate must be 0640 or 0644; private key must be 0600.
+    #endpoint_tls_certificate: ''
+    #endpoint_tls_key: ''
+    #endpoint_prometheus_enabled: true
+    #endpoint_prometheus_path: /metrics
+
     # Socket mark for dae-originated traffic.
     # If omitted, dae auto-selects an internal mark to prevent UDP self-capture.
     # Set a non-zero value to override that mark.

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/okzk/sdnotify v0.0.0-20240725214427-1c1fdd37c5ac
 	github.com/olicesx/quic-go v0.0.0-20260226044315-bb65418d151a
 	github.com/panjf2000/ants/v2 v2.11.5
+	github.com/prometheus/client_golang v1.19.1
 	github.com/safchain/ethtool v0.7.0
 	github.com/shirou/gopsutil/v4 v4.26.1
 	github.com/sirupsen/logrus v1.9.4
@@ -42,6 +43,7 @@ require (
 	github.com/awnumar/fastrand v0.0.0-20210315215012-30ee0990fa2d // indirect
 	github.com/awnumar/memcall v0.5.0 // indirect
 	github.com/awnumar/memguard v0.23.0 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bodgit/plumbing v1.3.0 // indirect
 	github.com/bodgit/sevenzip v1.6.1 // indirect
 	github.com/bodgit/windows v1.0.1 // indirect
@@ -66,6 +68,9 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.25 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
+	github.com/prometheus/client_model v0.5.0 // indirect
+	github.com/prometheus/common v0.48.0 // indirect
+	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/quic-go/qpack v0.5.1 // indirect
 	github.com/sagernet/sing v0.6.0 // indirect
 	github.com/sagernet/sing-shadowtls v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/awnumar/memcall v0.5.0/go.mod h1:5q5zKsL4XfYgqzCQEvUt9Dou4fEXWsn+tNrm
 github.com/awnumar/memguard v0.19.1/go.mod h1:tewJ+MrJ12cFtR5gH5zNJs8A6BjBv8709binaV+1pws=
 github.com/awnumar/memguard v0.23.0 h1:sJ3a1/SWlcuKIQ7MV+R9p0Pvo9CWsMbGZvcZQtmc68A=
 github.com/awnumar/memguard v0.23.0/go.mod h1:olVofBrsPdITtJ2HgxQKrEYEMyIBAIciVG4wNnZhW9M=
+github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
+github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bits-and-blooms/bitset v1.24.2/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
 github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
@@ -250,7 +252,15 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 h1:o4JXh1EVt9k/+g42oCprj/FisM4qX9L3sZB3upGN2ZU=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/prometheus/client_golang v1.19.1 h1:wZWJDwK+NameRJuPGDhlnFgx8e8HN3XHQeLaYJFJBOE=
+github.com/prometheus/client_golang v1.19.1/go.mod h1:mP78NwGzrVks5S2H6ab8+ZZGJLZUq1hoULYBAYBw1Ho=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/prometheus/client_model v0.5.0 h1:VQw1hfvPvk3Uv6Qf29VrPF32JB6rtbgI6cYPYQjL0Qw=
+github.com/prometheus/client_model v0.5.0/go.mod h1:dTiFglRmd66nLR9Pv9f0mZi7B7fk5Pm3gvsjB5tr+kI=
+github.com/prometheus/common v0.48.0 h1:QO8U2CdOzSn1BBsmXJXduaaW+dY/5QLjfB8svtSzKKE=
+github.com/prometheus/common v0.48.0/go.mod h1:0/KsvlIEfPQCQ5I2iNSAWKPZziNCvRs5EC6ILDTlAPc=
+github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
+github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
 github.com/quic-go/qpack v0.5.1 h1:giqksBPnT/HDtZ6VhtFKgoLOWmlyo9Ei6u9PqzIMbhI=
 github.com/quic-go/qpack v0.5.1/go.mod h1:+PC4XFrEskIVkcLzpEkbLqq1uCoxPhQuvK5rH1ZgaEg=
 github.com/refraction-networking/utls v1.8.2 h1:j4Q1gJj0xngdeH+Ox/qND11aEfhpgoEvV+S9iJ2IdQo=
@@ -559,8 +569,9 @@ google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=

--- a/pkg/metrics/collector_conn.go
+++ b/pkg/metrics/collector_conn.go
@@ -1,0 +1,122 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2025, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package metrics
+
+import (
+	"sort"
+
+	"github.com/daeuniverse/dae/control"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type ConnCollector struct {
+	state *State
+
+	tcpConnectionsActive *prometheus.Desc
+	udpEndpointsActive   *prometheus.Desc
+	udpTaskQueuesActive  *prometheus.Desc
+	tcpConnectionsTotal  *prometheus.Desc
+	udpConnectionsTotal  *prometheus.Desc
+}
+
+func NewConnCollector(state *State) *ConnCollector {
+	return &ConnCollector{
+		state: state,
+		tcpConnectionsActive: prometheus.NewDesc(
+			"dae_tcp_connections_active",
+			"The number of currently active TCP connections being proxied",
+			nil,
+			nil,
+		),
+		udpEndpointsActive: prometheus.NewDesc(
+			"dae_udp_endpoints_active",
+			"The number of currently active UDP endpoint associations",
+			nil,
+			nil,
+		),
+		udpTaskQueuesActive: prometheus.NewDesc(
+			"dae_udp_task_queues_active",
+			"The number of currently active UDP task queues",
+			nil,
+			nil,
+		),
+		tcpConnectionsTotal: prometheus.NewDesc(
+			"dae_tcp_connections_total",
+			"Total number of successfully established proxied TCP connections",
+			[]string{"protocol", "group"},
+			nil,
+		),
+		udpConnectionsTotal: prometheus.NewDesc(
+			"dae_udp_connections_total",
+			"Total number of new proxied UDP endpoint associations with successful first packet",
+			[]string{"protocol", "group"},
+			nil,
+		),
+	}
+}
+
+func (c *ConnCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.tcpConnectionsActive
+	ch <- c.udpEndpointsActive
+	ch <- c.udpTaskQueuesActive
+	ch <- c.tcpConnectionsTotal
+	ch <- c.udpConnectionsTotal
+}
+
+func (c *ConnCollector) Collect(ch chan<- prometheus.Metric) {
+	if c.state == nil {
+		return
+	}
+	cp := c.state.GetControlPlane()
+	if cp == nil {
+		return
+	}
+	ch <- prometheus.MustNewConstMetric(c.tcpConnectionsActive, prometheus.GaugeValue, float64(cp.ActiveTCPConnections()))
+	ch <- prometheus.MustNewConstMetric(c.udpEndpointsActive, prometheus.GaugeValue, float64(control.DefaultUdpEndpointPool.Count()))
+	ch <- prometheus.MustNewConstMetric(c.udpTaskQueuesActive, prometheus.GaugeValue, float64(control.DefaultUdpTaskPool.Count()))
+
+	tcpSnapshot := cp.TcpConnectionTotalsSnapshot()
+	tcpKeys := make([]control.ConnMetricKey, 0, len(tcpSnapshot))
+	for key := range tcpSnapshot {
+		tcpKeys = append(tcpKeys, key)
+	}
+	sort.Slice(tcpKeys, func(i, j int) bool {
+		if tcpKeys[i].Protocol == tcpKeys[j].Protocol {
+			return tcpKeys[i].Group < tcpKeys[j].Group
+		}
+		return tcpKeys[i].Protocol < tcpKeys[j].Protocol
+	})
+	for _, key := range tcpKeys {
+		ch <- prometheus.MustNewConstMetric(
+			c.tcpConnectionsTotal,
+			prometheus.CounterValue,
+			float64(tcpSnapshot[key]),
+			key.Protocol,
+			key.Group,
+		)
+	}
+
+	udpSnapshot := cp.UdpConnectionTotalsSnapshot()
+	udpKeys := make([]control.ConnMetricKey, 0, len(udpSnapshot))
+	for key := range udpSnapshot {
+		udpKeys = append(udpKeys, key)
+	}
+	sort.Slice(udpKeys, func(i, j int) bool {
+		if udpKeys[i].Protocol == udpKeys[j].Protocol {
+			return udpKeys[i].Group < udpKeys[j].Group
+		}
+		return udpKeys[i].Protocol < udpKeys[j].Protocol
+	})
+	for _, key := range udpKeys {
+		ch <- prometheus.MustNewConstMetric(
+			c.udpConnectionsTotal,
+			prometheus.CounterValue,
+			float64(udpSnapshot[key]),
+			key.Protocol,
+			key.Group,
+		)
+	}
+}

--- a/pkg/metrics/collector_describe_test.go
+++ b/pkg/metrics/collector_describe_test.go
@@ -1,0 +1,108 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2025, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package metrics
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var descNamePattern = regexp.MustCompile(`fqName: "([^"]+)"`)
+
+func descriptorNames(collector prometheus.Collector) map[string]struct{} {
+	ch := make(chan *prometheus.Desc, 64)
+	collector.Describe(ch)
+	close(ch)
+
+	names := make(map[string]struct{})
+	for desc := range ch {
+		matches := descNamePattern.FindStringSubmatch(desc.String())
+		if len(matches) == 2 {
+			names[matches[1]] = struct{}{}
+		}
+	}
+	return names
+}
+
+func requireDescriptor(t *testing.T, names map[string]struct{}, name string) {
+	t.Helper()
+	if _, ok := names[name]; !ok {
+		t.Fatalf("missing descriptor %q", name)
+	}
+}
+
+func requireNoDescriptor(t *testing.T, names map[string]struct{}, name string) {
+	t.Helper()
+	if _, ok := names[name]; ok {
+		t.Fatalf("unexpected descriptor %q", name)
+	}
+}
+
+func requireDescriptors(t *testing.T, names map[string]struct{}, expected []string) {
+	t.Helper()
+	for _, name := range expected {
+		requireDescriptor(t, names, name)
+	}
+}
+
+func TestDnsCollectorDescribeIncludesPhase2Descriptors(t *testing.T) {
+	names := descriptorNames(NewDnsCollector(nil))
+	requireDescriptors(t, names, []string{
+		"dae_dns_cache_entries",
+		"dae_dns_concurrency_in_use",
+		"dae_dns_forwarder_cache_entries",
+		"dae_dns_forwarder_in_flight",
+		"dae_dns_query_total",
+		"dae_dns_cache_hit_total",
+		"dae_dns_cache_lazy_hit_total",
+		"dae_dns_upstream_query_total",
+		"dae_dns_upstream_err_total",
+		"dae_dns_rejected_total",
+		"dae_dns_refused_total",
+		"dae_dns_response_latency_seconds",
+		"dae_dns_upstream_latency_seconds",
+	})
+	requireNoDescriptor(t, names, "dae_dns_concurrency_limit")
+	requireNoDescriptor(t, names, "dae_dns_cache_miss_total")
+}
+
+func TestDialerCollectorDescribeIncludesPhase2Descriptors(t *testing.T) {
+	names := descriptorNames(NewDialerCollector(nil))
+	requireDescriptors(t, names, []string{
+		"dae_dialer_alive",
+		"dae_dialer_latency_last_seconds",
+		"dae_dialer_latency_avg10_seconds",
+		"dae_dialer_latency_moving_avg_seconds",
+		"dae_health_check_total",
+		"dae_health_check_failure_total",
+		"dae_group_alive_dialers_total",
+	})
+}
+
+func TestConnCollectorDescribeIncludesPhase2Descriptors(t *testing.T) {
+	names := descriptorNames(NewConnCollector(nil))
+	requireDescriptors(t, names, []string{
+		"dae_tcp_connections_active",
+		"dae_udp_endpoints_active",
+		"dae_udp_task_queues_active",
+		"dae_tcp_connections_total",
+		"dae_udp_connections_total",
+	})
+}
+
+func TestRuntimeCollectorDescribeIncludesRuntimeAndNodeDescriptors(t *testing.T) {
+	names := descriptorNames(NewRuntimeCollector(nil))
+	requireDescriptors(t, names, []string{
+		"dae_runtime_upload_bytes_total",
+		"dae_runtime_download_bytes_total",
+		"dae_runtime_upload_rate_bytes_per_second",
+		"dae_runtime_download_rate_bytes_per_second",
+		"dae_node_latency_seconds",
+		"dae_node_alive",
+	})
+}

--- a/pkg/metrics/collector_dialer.go
+++ b/pkg/metrics/collector_dialer.go
@@ -1,0 +1,150 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2025, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package metrics
+
+import (
+	"github.com/daeuniverse/dae/common/consts"
+	"github.com/daeuniverse/dae/component/outbound/dialer"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// dialerMetricNetworkTypes must be indexed by the Idx* constants in
+// component/outbound/dialer (IdxDnsTcp4=0 … IdxUdp6=7) so that
+// AliveDialerSets()[i] and dialerMetricNetworkTypes[i] stay in sync.
+var dialerMetricNetworkTypes = [8]dialer.NetworkType{
+	{L4Proto: consts.L4ProtoStr_TCP, IpVersion: consts.IpVersionStr_4, IsDns: true},                                             // [0] IdxDnsTcp4
+	{L4Proto: consts.L4ProtoStr_TCP, IpVersion: consts.IpVersionStr_6, IsDns: true},                                             // [1] IdxDnsTcp6
+	{L4Proto: consts.L4ProtoStr_UDP, IpVersion: consts.IpVersionStr_4, IsDns: true, UdpHealthDomain: dialer.UdpHealthDomainDns}, // [2] IdxDnsUdp4
+	{L4Proto: consts.L4ProtoStr_UDP, IpVersion: consts.IpVersionStr_6, IsDns: true, UdpHealthDomain: dialer.UdpHealthDomainDns}, // [3] IdxDnsUdp6
+	{L4Proto: consts.L4ProtoStr_TCP, IpVersion: consts.IpVersionStr_4, IsDns: false},                                            // [4] IdxTcp4
+	{L4Proto: consts.L4ProtoStr_TCP, IpVersion: consts.IpVersionStr_6, IsDns: false},                                            // [5] IdxTcp6
+	{L4Proto: consts.L4ProtoStr_UDP, IpVersion: consts.IpVersionStr_4, IsDns: false},                                            // [6] IdxUdp4
+	{L4Proto: consts.L4ProtoStr_UDP, IpVersion: consts.IpVersionStr_6, IsDns: false},                                            // [7] IdxUdp6
+}
+
+type DialerCollector struct {
+	state *State
+
+	dialerAlive            *prometheus.Desc
+	dialerLatencyLast      *prometheus.Desc
+	dialerLatencyAvg10     *prometheus.Desc
+	dialerLatencyMovingAvg *prometheus.Desc
+	healthCheckTotal       *prometheus.Desc
+	healthCheckFailure     *prometheus.Desc
+	groupAliveDialers      *prometheus.Desc
+}
+
+func NewDialerCollector(state *State) *DialerCollector {
+	return &DialerCollector{
+		state: state,
+		dialerAlive: prometheus.NewDesc(
+			"dae_dialer_alive",
+			"Whether the dialer is alive (1 = alive, 0 = dead)",
+			[]string{"group", "dialer", "network"},
+			nil,
+		),
+		dialerLatencyLast: prometheus.NewDesc(
+			"dae_dialer_latency_last_seconds",
+			"Latency of the most recent successful health check in seconds; not emitted when last probe timed out",
+			[]string{"group", "dialer", "network"},
+			nil,
+		),
+		dialerLatencyAvg10: prometheus.NewDesc(
+			"dae_dialer_latency_avg10_seconds",
+			"The average latency of the last 10 health checks in seconds",
+			[]string{"group", "dialer", "network"},
+			nil,
+		),
+		dialerLatencyMovingAvg: prometheus.NewDesc(
+			"dae_dialer_latency_moving_avg_seconds",
+			"The exponentially weighted moving average latency in seconds",
+			[]string{"group", "dialer", "network"},
+			nil,
+		),
+		healthCheckTotal: prometheus.NewDesc(
+			"dae_health_check_total",
+			"Total number of dialer connectivity health checks",
+			[]string{"group", "dialer", "network"},
+			nil,
+		),
+		healthCheckFailure: prometheus.NewDesc(
+			"dae_health_check_failure_total",
+			"Total number of failed dialer connectivity health checks",
+			[]string{"group", "dialer", "network"},
+			nil,
+		),
+		groupAliveDialers: prometheus.NewDesc(
+			"dae_group_alive_dialers_total",
+			"The number of currently alive dialers in the group",
+			[]string{"group", "network"},
+			nil,
+		),
+	}
+}
+
+func (c *DialerCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.dialerAlive
+	ch <- c.dialerLatencyLast
+	ch <- c.dialerLatencyAvg10
+	ch <- c.dialerLatencyMovingAvg
+	ch <- c.healthCheckTotal
+	ch <- c.healthCheckFailure
+	ch <- c.groupAliveDialers
+}
+
+func (c *DialerCollector) Collect(ch chan<- prometheus.Metric) {
+	if c.state == nil {
+		return
+	}
+	cp := c.state.GetControlPlane()
+	if cp == nil {
+		return
+	}
+	for _, group := range cp.Outbounds() {
+		if group == nil {
+			continue
+		}
+		for _, d := range group.Dialers {
+			if d == nil {
+				continue
+			}
+			prop := d.Property()
+			if prop == nil {
+				continue
+			}
+			for i := range dialerMetricNetworkTypes {
+				typ := dialerMetricNetworkTypes[i]
+				alive, lastLatency, avg10, movingAvg, hasLastLatency := d.GetCollectionState(&typ)
+				aliveFloat := 0.0
+				if alive {
+					aliveFloat = 1
+				}
+				labels := []string{group.Name, prop.Name, typ.String()}
+				ch <- prometheus.MustNewConstMetric(c.dialerAlive, prometheus.GaugeValue, aliveFloat, labels...)
+				if hasLastLatency {
+					ch <- prometheus.MustNewConstMetric(c.dialerLatencyLast, prometheus.GaugeValue, lastLatency.Seconds(), labels...)
+				}
+				ch <- prometheus.MustNewConstMetric(c.dialerLatencyAvg10, prometheus.GaugeValue, avg10.Seconds(), labels...)
+				ch <- prometheus.MustNewConstMetric(c.dialerLatencyMovingAvg, prometheus.GaugeValue, movingAvg.Seconds(), labels...)
+				checkTotal, checkFailureTotal := d.GetCollectionCounters(&typ)
+				ch <- prometheus.MustNewConstMetric(c.healthCheckTotal, prometheus.CounterValue, float64(checkTotal), labels...)
+				ch <- prometheus.MustNewConstMetric(c.healthCheckFailure, prometheus.CounterValue, float64(checkFailureTotal), labels...)
+			}
+		}
+		for i, set := range group.AliveDialerSets() {
+			if set == nil {
+				continue
+			}
+			ch <- prometheus.MustNewConstMetric(
+				c.groupAliveDialers,
+				prometheus.GaugeValue,
+				float64(set.AliveCount()),
+				group.Name,
+				dialerMetricNetworkTypes[i].String(),
+			)
+		}
+	}
+}

--- a/pkg/metrics/collector_dns.go
+++ b/pkg/metrics/collector_dns.go
@@ -1,0 +1,180 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2025, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package metrics
+
+import (
+	"sort"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type DnsCollector struct {
+	state *State
+
+	cacheEntries      *prometheus.Desc
+	concurrencyInUse  *prometheus.Desc
+	forwarderCache    *prometheus.Desc
+	forwarderInFlight *prometheus.Desc
+	queryTotal        *prometheus.Desc
+	cacheHitTotal     *prometheus.Desc
+	cacheLazyHitTotal *prometheus.Desc
+	upstreamQuery     *prometheus.Desc
+	upstreamErr       *prometheus.Desc
+	rejectedTotal     *prometheus.Desc
+	refusedTotal      *prometheus.Desc
+	responseLatency   *prometheus.Desc
+	upstreamLatency   *prometheus.Desc
+}
+
+func NewDnsCollector(state *State) *DnsCollector {
+	return &DnsCollector{
+		state: state,
+		cacheEntries: prometheus.NewDesc(
+			"dae_dns_cache_entries",
+			"Current number of entries in the DNS response cache",
+			nil,
+			nil,
+		),
+		concurrencyInUse: prometheus.NewDesc(
+			"dae_dns_concurrency_in_use",
+			"The number of client DNS queries currently being handled by dae",
+			nil,
+			nil,
+		),
+		forwarderCache: prometheus.NewDesc(
+			"dae_dns_forwarder_cache_entries",
+			"Current number of cached DNS forwarder connections",
+			nil,
+			nil,
+		),
+		forwarderInFlight: prometheus.NewDesc(
+			"dae_dns_forwarder_in_flight",
+			"The number of DNS queries currently being forwarded to the upstream",
+			[]string{"upstream"},
+			nil,
+		),
+		queryTotal: prometheus.NewDesc(
+			"dae_dns_query_total",
+			"Total number of DNS queries handled by dae",
+			nil,
+			nil,
+		),
+		cacheHitTotal: prometheus.NewDesc(
+			"dae_dns_cache_hit_total",
+			"Total number of fresh DNS cache hits",
+			nil,
+			nil,
+		),
+		cacheLazyHitTotal: prometheus.NewDesc(
+			"dae_dns_cache_lazy_hit_total",
+			"Total number of stale DNS cache responses served while refreshing in background. Always 0 until stale-while-revalidate is implemented.",
+			nil,
+			nil,
+		),
+		upstreamQuery: prometheus.NewDesc(
+			"dae_dns_upstream_query_total",
+			"Total number of DNS upstream forwarding attempts",
+			[]string{"upstream"},
+			nil,
+		),
+		upstreamErr: prometheus.NewDesc(
+			"dae_dns_upstream_err_total",
+			"Total number of failed DNS upstream forwarding attempts",
+			[]string{"upstream"},
+			nil,
+		),
+		rejectedTotal: prometheus.NewDesc(
+			"dae_dns_rejected_total",
+			"Total number of rejected DNS responses",
+			nil,
+			nil,
+		),
+		refusedTotal: prometheus.NewDesc(
+			"dae_dns_refused_total",
+			"Total number of refused DNS responses due to overload protection",
+			nil,
+			nil,
+		),
+		responseLatency: prometheus.NewDesc(
+			"dae_dns_response_latency_seconds",
+			"End-to-end DNS handling latency in seconds",
+			nil,
+			nil,
+		),
+		upstreamLatency: prometheus.NewDesc(
+			"dae_dns_upstream_latency_seconds",
+			"DNS upstream forwarding latency in seconds",
+			[]string{"upstream"},
+			nil,
+		),
+	}
+}
+
+func (c *DnsCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.cacheEntries
+	ch <- c.concurrencyInUse
+	ch <- c.forwarderCache
+	ch <- c.forwarderInFlight
+	ch <- c.queryTotal
+	ch <- c.cacheHitTotal
+	ch <- c.cacheLazyHitTotal
+	ch <- c.upstreamQuery
+	ch <- c.upstreamErr
+	ch <- c.rejectedTotal
+	ch <- c.refusedTotal
+	ch <- c.responseLatency
+	ch <- c.upstreamLatency
+}
+
+func (c *DnsCollector) Collect(ch chan<- prometheus.Metric) {
+	if c.state == nil {
+		return
+	}
+	cp := c.state.GetControlPlane()
+	if cp == nil {
+		return
+	}
+	dc := cp.ActiveDnsController()
+	if dc == nil {
+		return
+	}
+
+	ch <- prometheus.MustNewConstMetric(c.cacheEntries, prometheus.GaugeValue, float64(dc.CacheSize()))
+	ch <- prometheus.MustNewConstMetric(c.concurrencyInUse, prometheus.GaugeValue, float64(dc.ConcurrencyInUse()))
+
+	forwarderCount := dc.ForwarderCacheInfo()
+	ch <- prometheus.MustNewConstMetric(c.forwarderCache, prometheus.GaugeValue, float64(forwarderCount))
+
+	counters := dc.DnsCountersSnapshot()
+	ch <- prometheus.MustNewConstMetric(c.queryTotal, prometheus.CounterValue, float64(counters.QueryTotal))
+	ch <- prometheus.MustNewConstMetric(c.cacheHitTotal, prometheus.CounterValue, float64(counters.CacheHitTotal))
+	ch <- prometheus.MustNewConstMetric(c.cacheLazyHitTotal, prometheus.CounterValue, float64(counters.CacheLazyHitTotal))
+	ch <- prometheus.MustNewConstMetric(c.rejectedTotal, prometheus.CounterValue, float64(counters.RejectedTotal))
+	ch <- prometheus.MustNewConstMetric(c.refusedTotal, prometheus.CounterValue, float64(counters.RefusedTotal))
+
+	latency := dc.DnsResponseLatencySnapshot()
+	ch <- prometheus.MustNewConstHistogram(c.responseLatency, latency.Count, latency.Sum, latency.Buckets)
+
+	upstreamSnapshot := dc.DnsUpstreamSnapshot()
+	upstreamKeys := make([]string, 0, len(upstreamSnapshot))
+	for upstream := range upstreamSnapshot {
+		upstreamKeys = append(upstreamKeys, upstream)
+	}
+	sort.Strings(upstreamKeys)
+	for _, upstream := range upstreamKeys {
+		snapshot := upstreamSnapshot[upstream]
+		ch <- prometheus.MustNewConstMetric(c.forwarderInFlight, prometheus.GaugeValue, float64(snapshot.InFlight), upstream)
+		ch <- prometheus.MustNewConstMetric(c.upstreamQuery, prometheus.CounterValue, float64(snapshot.QueryTotal), upstream)
+		ch <- prometheus.MustNewConstMetric(c.upstreamErr, prometheus.CounterValue, float64(snapshot.ErrTotal), upstream)
+		ch <- prometheus.MustNewConstHistogram(
+			c.upstreamLatency,
+			snapshot.Latency.Count,
+			snapshot.Latency.Sum,
+			snapshot.Latency.Buckets,
+			upstream,
+		)
+	}
+}

--- a/pkg/metrics/collector_runtime.go
+++ b/pkg/metrics/collector_runtime.go
@@ -1,0 +1,102 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2025, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type RuntimeCollector struct {
+	state *State
+
+	uploadBytesTotal           *prometheus.Desc
+	downloadBytesTotal         *prometheus.Desc
+	uploadRateBytesPerSecond   *prometheus.Desc
+	downloadRateBytesPerSecond *prometheus.Desc
+	nodeLatencySeconds         *prometheus.Desc
+	nodeAlive                  *prometheus.Desc
+}
+
+func NewRuntimeCollector(state *State) *RuntimeCollector {
+	return &RuntimeCollector{
+		state: state,
+		uploadBytesTotal: prometheus.NewDesc(
+			"dae_runtime_upload_bytes_total",
+			"Total uploaded bytes observed by runtime traffic statistics",
+			nil,
+			nil,
+		),
+		downloadBytesTotal: prometheus.NewDesc(
+			"dae_runtime_download_bytes_total",
+			"Total downloaded bytes observed by runtime traffic statistics",
+			nil,
+			nil,
+		),
+		uploadRateBytesPerSecond: prometheus.NewDesc(
+			"dae_runtime_upload_rate_bytes_per_second",
+			"Current upload throughput observed by runtime traffic statistics",
+			nil,
+			nil,
+		),
+		downloadRateBytesPerSecond: prometheus.NewDesc(
+			"dae_runtime_download_rate_bytes_per_second",
+			"Current download throughput observed by runtime traffic statistics",
+			nil,
+			nil,
+		),
+		nodeLatencySeconds: prometheus.NewDesc(
+			"dae_node_latency_seconds",
+			"Best known per-node latency snapshot exported from runtime latency probing",
+			[]string{"group", "name", "link"},
+			nil,
+		),
+		nodeAlive: prometheus.NewDesc(
+			"dae_node_alive",
+			"Whether the node is currently considered alive by runtime latency probing",
+			[]string{"group", "name", "link"},
+			nil,
+		),
+	}
+}
+
+func (c *RuntimeCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.uploadBytesTotal
+	ch <- c.downloadBytesTotal
+	ch <- c.uploadRateBytesPerSecond
+	ch <- c.downloadRateBytesPerSecond
+	ch <- c.nodeLatencySeconds
+	ch <- c.nodeAlive
+}
+
+func (c *RuntimeCollector) Collect(ch chan<- prometheus.Metric) {
+	if c.state == nil {
+		return
+	}
+	cp := c.state.GetControlPlane()
+	if cp == nil {
+		return
+	}
+
+	snapshot := cp.SnapshotRuntimeStats(0, 0)
+	ch <- prometheus.MustNewConstMetric(c.uploadBytesTotal, prometheus.CounterValue, float64(snapshot.UploadTotal))
+	ch <- prometheus.MustNewConstMetric(c.downloadBytesTotal, prometheus.CounterValue, float64(snapshot.DownloadTotal))
+	ch <- prometheus.MustNewConstMetric(c.uploadRateBytesPerSecond, prometheus.GaugeValue, float64(snapshot.UploadRate))
+	ch <- prometheus.MustNewConstMetric(c.downloadRateBytesPerSecond, prometheus.GaugeValue, float64(snapshot.DownloadRate))
+
+	for _, node := range cp.SnapshotNodeLatencies() {
+		if node.Link == "" {
+			continue
+		}
+		alive := 0.0
+		if node.Alive {
+			alive = 1
+		}
+		ch <- prometheus.MustNewConstMetric(c.nodeAlive, prometheus.GaugeValue, alive, node.Group, node.Name, node.Link)
+		if node.LatencyMs != nil {
+			ch <- prometheus.MustNewConstMetric(c.nodeLatencySeconds, prometheus.GaugeValue, float64(*node.LatencyMs)/1000.0, node.Group, node.Name, node.Link)
+		}
+	}
+}

--- a/pkg/metrics/registry.go
+++ b/pkg/metrics/registry.go
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2025, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+)
+
+func NewRegistry(state *State) *prometheus.Registry {
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(
+		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
+		collectors.NewGoCollector(),
+		NewDialerCollector(state),
+		NewDnsCollector(state),
+		NewConnCollector(state),
+		NewRuntimeCollector(state),
+	)
+	return reg
+}

--- a/pkg/metrics/state.go
+++ b/pkg/metrics/state.go
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2025, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package metrics
+
+import (
+	"sync/atomic"
+
+	"github.com/daeuniverse/dae/control"
+)
+
+type State struct {
+	cp atomic.Pointer[control.ControlPlane]
+}
+
+func NewState() *State {
+	return &State{}
+}
+
+func (s *State) SetControlPlane(cp *control.ControlPlane) {
+	s.cp.Store(cp)
+}
+
+func (s *State) GetControlPlane() *control.ControlPlane {
+	return s.cp.Load()
+}

--- a/pkg/metricshttp/auth.go
+++ b/pkg/metricshttp/auth.go
@@ -1,0 +1,28 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2025, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package metricshttp
+
+import (
+	"crypto/subtle"
+	"net/http"
+)
+
+func BasicAuthMiddleware(handler http.Handler, username, password string) http.Handler {
+	if username == "" {
+		return handler
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok := r.BasicAuth()
+		if !ok ||
+			subtle.ConstantTimeCompare([]byte(user), []byte(username)) != 1 ||
+			subtle.ConstantTimeCompare([]byte(pass), []byte(password)) != 1 {
+			w.Header().Set("WWW-Authenticate", `Basic realm="dae endpoint"`)
+			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+			return
+		}
+		handler.ServeHTTP(w, r)
+	})
+}

--- a/pkg/metricshttp/endpoint_server_test.go
+++ b/pkg/metricshttp/endpoint_server_test.go
@@ -1,0 +1,100 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2025, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package metricshttp
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func basicAuthValue(user, pass string) string {
+	token := base64.StdEncoding.EncodeToString([]byte(user + ":" + pass))
+	return "Basic " + token
+}
+
+func TestNormalizePrometheusPath(t *testing.T) {
+	if got := NormalizePrometheusPath(""); got != "/metrics" {
+		t.Fatalf("unexpected default path: got=%q want=%q", got, "/metrics")
+	}
+	if got := NormalizePrometheusPath("custom"); got != "/custom" {
+		t.Fatalf("unexpected relative path normalization: got=%q want=%q", got, "/custom")
+	}
+	if got := NormalizePrometheusPath("/custom"); got != "/custom" {
+		t.Fatalf("unexpected absolute path normalization: got=%q want=%q", got, "/custom")
+	}
+}
+
+func TestBasicAuthMiddlewareRejectsMissingCredentials(t *testing.T) {
+	handler := BasicAuthMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}), "dae", "secret")
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("unexpected status without credentials: got=%d want=%d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestBasicAuthMiddlewareAllowsValidCredentials(t *testing.T) {
+	handler := BasicAuthMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}), "dae", "secret")
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	req.Header.Set("Authorization", basicAuthValue("dae", "secret"))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("unexpected status with valid credentials: got=%d want=%d", rec.Code, http.StatusNoContent)
+	}
+}
+
+func TestNewEndpointServerServesPrometheusAndPprofWithAuth(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	counter := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "dae_test_metric_total",
+		Help: "test metric",
+	})
+	reg.MustRegister(counter)
+	counter.Inc()
+
+	server := NewEndpointServer(EndpointConfig{
+		ListenAddress:     "127.0.0.1:0",
+		Username:          "dae",
+		Password:          "secret",
+		PrometheusEnabled: true,
+		PrometheusPath:    "/custom-metrics",
+		PprofEnabled:      true,
+	}, reg)
+
+	metricsReq := httptest.NewRequest(http.MethodGet, "/custom-metrics", nil)
+	metricsReq.Header.Set("Authorization", basicAuthValue("dae", "secret"))
+	metricsRec := httptest.NewRecorder()
+	server.Handler.ServeHTTP(metricsRec, metricsReq)
+	if metricsRec.Code != http.StatusOK {
+		t.Fatalf("unexpected metrics status: got=%d want=%d", metricsRec.Code, http.StatusOK)
+	}
+	if body := metricsRec.Body.String(); !strings.Contains(body, "dae_test_metric_total") {
+		t.Fatalf("expected Prometheus response body to contain test metric, got=%q", body)
+	}
+
+	pprofReq := httptest.NewRequest(http.MethodGet, "/debug/pprof/", nil)
+	pprofReq.Header.Set("Authorization", basicAuthValue("dae", "secret"))
+	pprofRec := httptest.NewRecorder()
+	server.Handler.ServeHTTP(pprofRec, pprofReq)
+	if pprofRec.Code != http.StatusOK {
+		t.Fatalf("unexpected pprof status: got=%d want=%d", pprofRec.Code, http.StatusOK)
+	}
+}

--- a/pkg/metricshttp/server.go
+++ b/pkg/metricshttp/server.go
@@ -1,0 +1,71 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2025, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package metricshttp
+
+import (
+	"net/http"
+	"net/http/pprof"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+type EndpointConfig struct {
+	ListenAddress     string
+	Username          string
+	Password          string
+	TlsCertificate    string
+	TlsKey            string
+	PrometheusEnabled bool
+	PrometheusPath    string
+	PprofEnabled      bool
+}
+
+func NormalizePrometheusPath(path string) string {
+	if path == "" {
+		return "/metrics"
+	}
+	if !strings.HasPrefix(path, "/") {
+		return "/" + path
+	}
+	return path
+}
+
+func NewEndpointServer(cfg EndpointConfig, registry *prometheus.Registry) *http.Server {
+	mux := http.NewServeMux()
+	if cfg.PrometheusEnabled && registry != nil {
+		mux.Handle(NormalizePrometheusPath(cfg.PrometheusPath),
+			BasicAuthMiddleware(
+				promhttp.HandlerFor(registry, promhttp.HandlerOpts{}),
+				cfg.Username, cfg.Password,
+			),
+		)
+	}
+	if cfg.PprofEnabled {
+		mux.Handle("/debug/pprof/", BasicAuthMiddleware(http.HandlerFunc(pprof.Index), cfg.Username, cfg.Password))
+		mux.Handle("/debug/pprof/cmdline", BasicAuthMiddleware(http.HandlerFunc(pprof.Cmdline), cfg.Username, cfg.Password))
+		mux.Handle("/debug/pprof/profile", BasicAuthMiddleware(http.HandlerFunc(pprof.Profile), cfg.Username, cfg.Password))
+		mux.Handle("/debug/pprof/symbol", BasicAuthMiddleware(http.HandlerFunc(pprof.Symbol), cfg.Username, cfg.Password))
+		mux.Handle("/debug/pprof/trace", BasicAuthMiddleware(http.HandlerFunc(pprof.Trace), cfg.Username, cfg.Password))
+	}
+	return &http.Server{
+		Addr:              cfg.ListenAddress,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+}
+
+func StartEndpointServer(server *http.Server, cfg EndpointConfig) error {
+	if server == nil {
+		return nil
+	}
+	if cfg.TlsCertificate != "" && cfg.TlsKey != "" {
+		return server.ListenAndServeTLS(cfg.TlsCertificate, cfg.TlsKey)
+	}
+	return server.ListenAndServe()
+}


### PR DESCRIPTION
## Summary

- Adds a full Prometheus `/metrics` HTTP endpoint to dae, gated behind `endpoint_listen_address` in `global {}` (disabled by default)
- Exposes DNS, dialer health, connection pool, and runtime/node metrics via a custom registry with per-collector isolation
- Wires the three previously-stub upstream DNS metrics (`inFlight`, `latency`, `errTotal`) in `dialSend`
- Includes BasicAuth + TLS support, hot-reload safety via `atomic.Pointer[ControlPlane]`, and pprof co-hosting
- Ships a Grafana dashboard (`.plan/metrics/dae_Transparent_Proxy-Grafana_dashboard.json`) covering all exposed metric families

## What's in this PR

### Infrastructure (`pkg/metrics/`, `pkg/metricshttp/`)
- `state.go` — `metrics.State` holding `atomic.Pointer[control.ControlPlane]` for reload-safe scraping
- `registry.go` — `NewRegistry`: registers 4 collectors + `process_*` + `go_*`
- `metricshttp/auth.go` — BasicAuth middleware
- `metricshttp/server.go` — `NewEndpointServer` / `StartEndpointServer` with optional TLS

### Collectors
- `collector_dialer.go` — dialer/health-check metrics (alive, latency, moving avg, health check totals)
- `collector_dns.go` — DNS metrics (cache, concurrency, forwarder, upstream counters + histograms)
- `collector_conn.go` — connection metrics (TCP active/total, UDP endpoints/queues/total)
- `collector_runtime.go` — runtime/node metrics (`SnapshotRuntimeStats`, `SnapshotNodeLatencies`), labeled with dialer group/name

### DNS write-side wiring (`control/dns_control.go`)
Three upstream metrics were structurally present but had no write side. Now instrumented in `dialSend` around the `forwardWithFallback` call, with `inFlight` released immediately after network I/O (not deferred) so the gauge stays scoped to actual upstream wait time.

### Config (`config/config.go`, `example.dae`)
New `endpoint_*` fields in `global {}`:
```
endpoint_listen_address   (default: "" = disabled)
endpoint_username / endpoint_password
endpoint_tls_certificate / endpoint_tls_key
endpoint_prometheus_enabled / endpoint_prometheus_path
```
TLS file permission policy enforced at startup and reload (cert: 0640/0644, key: 0600).

### Hot-reload (`cmd/run.go`)
- New ControlPlane → `metricsState.SetControlPlane(newC)` (atomic)
- Endpoint config change → `endpointServer.Shutdown()` → new server

## Test plan

- [ ] `go test ./pkg/metrics/... ./pkg/metricshttp/...` — descriptor tests + endpoint server tests PASS
- [ ] `go test ./control/... ./cmd/... ./common/...` PASS
- [ ] `go vet ./...` CLEAN
- [ ] Manual scrape: `curl http://localhost:5556/metrics` → all metric families present
- [ ] `dae_dns_forwarder_in_flight{upstream=...} > 0` under concurrent DNS load
- [ ] `dae_dns_upstream_err_total` increments on upstream error
- [ ] `dae_dns_upstream_latency_seconds` has non-zero bucket data
- [ ] BasicAuth: `curl` without credentials → 401; with credentials → 200
- [ ] SIGUSR1 reload: endpoint survives, gauges reflect new ControlPlane
- [ ] SIGUSR1 with address change: old port stops, new port responds
- [ ] Import the included Grafana dashboard and confirm all panels populate