### PR TITLE
feat: add operational logs for node alive/dead transitions

### DIFF
--- a/component/outbound/dialer/connectivity_check.go
+++ b/component/outbound/dialer/connectivity_check.go
@@ -1063,6 +1063,17 @@ func (d *Dialer) markAvailableTraffic(typ *NetworkType) collectionUpdate {
 	d.NotifyHealthCheckResult(typ, true, isRevival)
 	if isRevival {
 		d.notifyAliveTransition(typ, true)
+		// Log dead→alive transitions for operational visibility.
+		if d.Log != nil {
+			nodeName := ""
+			if d.property != nil {
+				nodeName = d.property.Name
+			}
+			d.Log.WithFields(logrus.Fields{
+				"dialer":  nodeName,
+				"network": typ.String(),
+			}).Infoln("Node became ALIVE (traffic)")
+		}
 	}
 	return update
 }

--- a/component/outbound/dialer/connectivity_check.go
+++ b/component/outbound/dialer/connectivity_check.go
@@ -959,6 +959,25 @@ func (d *Dialer) markUnavailableInternal(typ *NetworkType, force bool, isTraffic
 	wasAlive := collection.Alive.Load()
 	collection.Alive.Store(alive)
 
+	// Log alive/dead transitions for operational visibility.
+	if d.Log != nil {
+		nodeName := ""
+		if d.property != nil {
+			nodeName = d.property.Name
+		}
+		if wasAlive && !alive {
+			d.Log.WithFields(logrus.Fields{
+				"dialer":  nodeName,
+				"network": typ.String(),
+			}).Warnln("Node became DEAD")
+		} else if !wasAlive && alive {
+			d.Log.WithFields(logrus.Fields{
+				"dialer":  nodeName,
+				"network": typ.String(),
+			}).Infoln("Node became ALIVE")
+		}
+	}
+
 	update := collectionUpdate{
 		alive:             alive,
 		movingAverage:     collection.MovingAverage,
@@ -1007,6 +1026,18 @@ func (d *Dialer) markAvailable(typ *NetworkType, latency time.Duration) (collect
 	isRevival := !wasAlive
 	d.NotifyHealthCheckResult(typ, true, isRevival)
 	if isRevival {
+		// Log node revival for operational visibility.
+		if d.Log != nil {
+			nodeName := ""
+			if d.property != nil {
+				nodeName = d.property.Name
+			}
+			d.Log.WithFields(logrus.Fields{
+				"dialer":  nodeName,
+				"network": typ.String(),
+				"latency":  latency.String(),
+			}).Infoln("Node became ALIVE")
+		}
 		d.notifyAliveTransition(typ, true)
 	}
 


### PR DESCRIPTION
## Summary

Add operational logs for node status transitions (DEAD/ALIVE) to help monitor node health and fixed_fallback behavior in production.

## Changes

### 1. Node became DEAD (WARN)

When a node transitions from alive to dead (via markUnavailableInternal), a WARN log with dialer and network fields is emitted:

WARN Node became DEAD  dialer=s4 network=tcp4

### 2. Node became ALIVE (INFO) - Health check path

When health check probes detect a node has recovered (via markAvailable), an INFO log is emitted:

INFO Node became ALIVE  dialer=s4 network=tcp4 latency=47ms

### 3. Node became ALIVE (INFO) - Traffic recovery path

When real user traffic successfully connects to a previously dead node (via markAvailableTraffic), an INFO log is emitted:

INFO Node became ALIVE (traffic)  dialer=s4 network=tcp4

## Motivation

In production, operators need visibility into node state transitions. Without these logs, a failed node silently gets deprioritized without any notification. The (traffic) suffix distinguishes between probe-detected recovery and actual traffic-detected recovery. This is especially useful for monitoring fixed_fallback behavior.
