### PR TITLE
fix(udp): treat only n < len(b) as a short write (#1029)

### DIFF
--- a/control/udp_endpoint_pool.go
+++ b/control/udp_endpoint_pool.go
@@ -839,7 +839,11 @@ func (ue *UdpEndpoint) WriteTo(b []byte, addr string) (int, error) {
 		return n, err
 	}
 	ue.hasSent.Store(true)
-	if n != len(b) {
+	// A proxy WriteTo may report the on-wire byte count, which includes the
+	// protocol's encapsulation overhead (e.g. shadowsocks AES-128-GCM + IPv4 adds
+	// 39 bytes), so n can legitimately exceed len(b). UDP datagrams are atomic, so
+	// only n < len(b) is a genuine short write worth retiring the endpoint over.
+	if n < len(b) {
 		ue.retire()
 		return n, fmt.Errorf("%w: udp endpoint wrote %d/%d bytes to %s", io.ErrShortWrite, n, len(b), addr)
 	}

--- a/control/udp_endpoint_pool_test.go
+++ b/control/udp_endpoint_pool_test.go
@@ -1978,3 +1978,56 @@ func TestUdpEndpointPoolGetOrCreate_NoReplyTimeoutReleasesPrewarmedAnyfrom(t *te
 		return countPooledAnyfromConns(DefaultAnyfromPool) == 0
 	})
 }
+
+// #1029: a proxy WriteTo may return the on-wire byte count (payload plus the
+// protocol's encapsulation overhead, e.g. shadowsocks AES-128-GCM + IPv4 = +39),
+// which is strictly greater than len(b). That is a SUCCESSFUL write, not a short
+// write, and must not retire the endpoint.
+func TestUdpEndpointWriteTo_AcceptsProxyOverheadBytes(t *testing.T) {
+	const shadowsocksIPv4Overhead = 39 // SaltLen 16 + ATYP/IPv4/port 7 + TagLen 16
+	payload := make([]byte, 1250)
+	conn := &scriptedPacketConn{
+		closeCh:     make(chan struct{}),
+		forceWriteN: true,
+		writeN:      len(payload) + shadowsocksIPv4Overhead,
+	}
+	ue := &UdpEndpoint{
+		conn:       conn,
+		NatTimeout: QuicNatTimeout,
+	}
+
+	n, err := ue.WriteTo(payload, "104.18.32.47:443")
+	if err != nil {
+		t.Fatalf("WriteTo returned error for wire-byte overhead write: %v", err)
+	}
+	if n != len(payload)+shadowsocksIPv4Overhead {
+		t.Fatalf("WriteTo n = %d, want %d", n, len(payload)+shadowsocksIPv4Overhead)
+	}
+	if ue.IsDead() {
+		t.Fatal("endpoint retired on a successful (overhead) write; expected it to stay alive")
+	}
+}
+
+// #1029 regression guard: a genuine partial write (n < len(b)) must still retire
+// the endpoint and report io.ErrShortWrite, so the loosened check does not hide
+// real transport failures.
+func TestUdpEndpointWriteTo_StillRetiresOnTruePartialWrite(t *testing.T) {
+	payload := make([]byte, 1250)
+	conn := &scriptedPacketConn{
+		closeCh:     make(chan struct{}),
+		forceWriteN: true,
+		writeN:      len(payload) - 1,
+	}
+	ue := &UdpEndpoint{
+		conn:       conn,
+		NatTimeout: QuicNatTimeout,
+	}
+
+	_, err := ue.WriteTo(payload, "104.18.32.47:443")
+	if !stderrors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("WriteTo error = %v, want io.ErrShortWrite on true partial write", err)
+	}
+	if !ue.IsDead() {
+		t.Fatal("endpoint not retired after a genuine partial write")
+	}
+}


### PR DESCRIPTION
## Problem

On the UDP data path, `UdpEndpoint.WriteTo` (`control/udp_endpoint_pool.go:839`) treated any `n != len(b)` as a short write — retiring the endpoint and returning `io.ErrShortWrite`. But a proxy `WriteTo` reports the **on-wire** byte count, which includes the outbound protocol's encapsulation overhead (e.g. shadowsocks AES-128-GCM + IPv4 = +39 bytes), so `n` can legitimately exceed `len(b)` on a fully successful write. UDP datagrams are atomic; only `n < len(b)` is a genuine short write.

The over-count was misclassified as a short write, retiring healthy endpoints and exhausting the retry limit — surfacing as the `Touch max retry limit.` warnings reported in #1029. This `n != len(b)` line is present in upstream `dae/main` (this change is a clean cherry-pick onto it).

## Evidence

This was found by instrumenting the (previously debug-level) `WriteTo` errors that #1029 noted were "not captured at the time." With diagnostics enabled, **10655/10655** retry-exhaustion drops were exactly `n = len(b)+39` over-writes — datagrams delivered on the wire — with **zero** genuine under-writes and no `err != nil` failures. An over-count, not an error return, is the signature of a falsely-retired healthy endpoint rather than a down node.

After deploying `n < len(b)`, a 22.3h production window logged **zero** `Touch max retry limit.` events.

## Scope

Correctness fix only, plus two regression tests:

- `TestUdpEndpointWriteTo_AcceptsProxyOverheadBytes` — a `+39` over-write stays alive.
- `TestUdpEndpointWriteTo_StillRetiresOnTruePartialWrite` — a genuine `n < len(b)` still retires the endpoint and returns `io.ErrShortWrite`.

This addresses the **retry-limit-warning** aspect of #1029. The issue's design question (data-UDP alive defaults to `true` + 50-failure traffic threshold; whether to actively probe the data-UDP path) concerns the genuinely-down-node path (`err != nil`, evaluated *before* this check) and remains open. The observability improvement (#1029 suggestion 1) is intentionally kept out of this PR to keep it minimal.
