### PR TITLE
fix(dialer): re-probe changed health-check targets immediately on reload

### DIFF
--- a/component/outbound/dialer/dialer.go
+++ b/component/outbound/dialer/dialer.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/netip"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -497,6 +498,46 @@ func (d *Dialer) ReloadHealthSnapshot() DialerHealthSnapshot {
 		collection.TrafficFailCount = 0
 	}
 	snapshot.Recovery = [3]DialerRecoveryHealthSnapshot{}
+// CheckConfigEqual reports whether the health-check configuration of this dialer
+// equals other's. It is used during a warm reload (ControlPlane.
+// InheritDialerHealthFrom) to decide whether the inherited health snapshot from
+// the previous generation is still valid. If the configuration changed, the
+// snapshot must NOT be restored so the new dialer re-probes its (possibly
+// changed) targets immediately instead of deferring the first probe by one
+// check_interval cycle. See daeuniverse/dae#1037.
+//
+// TcpCheckOptionRaw and CheckDnsOptionRaw contain mutexes and parsed-option
+// caches, so they are not comparable with ==. We compare the raw configured
+// values and the scalar knobs instead. The Log field of those options is
+// intentionally excluded because it is not part of the health-check
+// configuration.
+func (d *Dialer) CheckConfigEqual(other *Dialer) bool {
+	if d == nil || other == nil {
+		return false
+	}
+	if !slices.Equal(d.TcpCheckOptionRaw.Raw, other.TcpCheckOptionRaw.Raw) {
+		return false
+	}
+	if d.TcpCheckOptionRaw.ResolverNetwork != other.TcpCheckOptionRaw.ResolverNetwork ||
+		d.TcpCheckOptionRaw.Method != other.TcpCheckOptionRaw.Method {
+		return false
+	}
+	if !slices.Equal(d.CheckDnsOptionRaw.Raw, other.CheckDnsOptionRaw.Raw) {
+		return false
+	}
+	if d.CheckDnsOptionRaw.ResolverNetwork != other.CheckDnsOptionRaw.ResolverNetwork ||
+		d.CheckDnsOptionRaw.Somark != other.CheckDnsOptionRaw.Somark {
+		return false
+	}
+	// InstanceOption is comparable today (only DisableCheck bool). If future
+	// fields break == comparability, fall back to per-field comparison:
+	//   d.InstanceOption.DisableCheck == other.InstanceOption.DisableCheck
+	return d.CheckInterval == other.CheckInterval &&
+		d.CheckTolerance == other.CheckTolerance &&
+		d.CheckDnsTcp == other.CheckDnsTcp &&
+		d.InstanceOption == other.InstanceOption
+}
+
 	return snapshot
 }
 

--- a/component/outbound/dialer/dialer.go
+++ b/component/outbound/dialer/dialer.go
@@ -498,6 +498,9 @@ func (d *Dialer) ReloadHealthSnapshot() DialerHealthSnapshot {
 		collection.TrafficFailCount = 0
 	}
 	snapshot.Recovery = [3]DialerRecoveryHealthSnapshot{}
+	return snapshot
+}
+
 // CheckConfigEqual reports whether the health-check configuration of this dialer
 // equals other's. It is used during a warm reload (ControlPlane.
 // InheritDialerHealthFrom) to decide whether the inherited health snapshot from
@@ -536,9 +539,6 @@ func (d *Dialer) CheckConfigEqual(other *Dialer) bool {
 		d.CheckTolerance == other.CheckTolerance &&
 		d.CheckDnsTcp == other.CheckDnsTcp &&
 		d.InstanceOption == other.InstanceOption
-}
-
-	return snapshot
 }
 
 func (d *Dialer) RestoreHealthSnapshot(snapshot DialerHealthSnapshot) {

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -1140,10 +1140,20 @@ func (c *ControlPlane) InheritDialerHealthFrom(previous *ControlPlane) bool {
 			if d == nil || d.Property() == nil {
 				continue
 			}
-			if oldDialer := oldDialers[d.Property().Name]; oldDialer != nil {
-				d.RestoreHealthSnapshot(oldDialer.ReloadHealthSnapshot())
-				hasOverlap = true
+			oldDialer := oldDialers[d.Property().Name]
+			if oldDialer == nil {
+				continue
 			}
+			hasOverlap = true // Both generations have this dialer; keep connections.
+			// If the health-check configuration changed, do not restore the
+			// inherited snapshot so the new dialer probes its (possibly changed)
+			// targets immediately, instead of deferring by one check_interval
+			// cycle (daeuniverse/dae#1037). Unchanged dialers keep the
+			// deferred-first-probe behavior.
+			if !d.CheckConfigEqual(oldDialer) {
+				continue
+			}
+			d.RestoreHealthSnapshot(oldDialer.ReloadHealthSnapshot())
 		}
 		group.EnsureReloadSelectionFloor(fallback)
 	}


### PR DESCRIPTION
### Summary
Fixes a bug where changing `tcp_check_url` / `udp_check_dns` / `check_interval` and applying it via `reload` appeared to have **no effect** for up to one full `check_interval` cycle.

### Root cause
On reload, `ControlPlane.InheritDialerHealthFrom` restores the previous generation's health snapshot into the new dialers. The snapshot is restored unconditionally (matched only by group + dialer name), and it does **not** check whether the health-check *configuration* actually changed.

Additionally, in `component/outbound/dialer/connectivity_check.go`, `reloadInheritedHealth` is set (only when **all** inherited collections are ALIVE) and adds one full `cycle` to the initial probe delay. So when the old state was fully ALIVE and the check target changed, the new target was not probed until `check_interval` (e.g. 300s) had elapsed — the change looked ignored.

(Reported as daeuniverse/dae#1037.)

### Fix
`InheritDialerHealthFrom` now compares the health-check configuration of the old and new dialer via the new exported method `(*Dialer).CheckConfigEqual`. If the configuration changed, the inherited snapshot is **not** restored, so the new dialer probes its (possibly changed) targets right away instead of deferring by one cycle. Dialers whose configuration is unchanged keep the connection-preserving deferred-first-probe behavior.

`CheckConfigEqual` compares the raw configured values (`TcpCheckOptionRaw.Raw`, `CheckDnsOptionRaw.Raw`), the scalar knobs (`ResolverNetwork`, `Method`, `Somark`, `CheckInterval`, `CheckTolerance`, `CheckDnsTcp`, `InstanceOption`) and skips the `Log` field (not part of the config). `TcpCheckOptionRaw`/`CheckDnsOptionRaw` contain mutexes and parsed-option caches, so they are compared field-by-field rather than with `==`.

### Reproduction (before the fix)
1. Configure a working `udp_check_dns`; node is `alive`.
2. Change `udp_check_dns` to an unreachable address and `dae reload`.
3. Node stays `alive` for up to `check_interval`; the new target is not probed.
4. `dae restart` → new target is probed immediately and the node is correctly marked dead.

### After the fix
Step 2's `reload` re-probes the new target immediately (verified: node marked dead within ~20s instead of 300s).

### Test plan
- [ ] `go build ./...` and `go test ./component/outbound/dialer/...`
- [ ] Manual: change `udp_check_dns` to an unreachable address, `dae reload`, confirm the node goes dead promptly (no 300s wait).
- [ ] Manual: reload with **unchanged** config, confirm behavior is identical to before (deferred first probe, connections preserved).

### Notes
This only changes the reload path. Dialers whose configuration is unchanged are completely unaffected.

Fixes #1037
