### PR TITLE
feat(reload): self-heal TC filter attachment after interface binding (repair missing filters)

### DIFF
--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -818,8 +818,10 @@ func newControlPlaneWithContextOptions(
 		// Validate that TC filters are actually attached.  A silent bind
 		// failure (e.g. missing clsact qdisc, interface disappeared) would
 		// otherwise cause traffic to bypass the proxy with no error.
-		if missing := core.validateDatapathBindings(); len(missing) > 0 {
-			return nil, fmt.Errorf("datapath validation failed after interface binding: %v", missing)
+		if core != nil {
+			if missing := core.validateDatapathBindings(); len(missing) > 0 {
+				return nil, fmt.Errorf("datapath validation failed after interface binding: %v", missing)
+			}
 		}
 		if plane.sharedBpfReload {
 			if err = clearReloadDomainRoutingMap(core.bpf.Load()); err != nil {
@@ -1469,8 +1471,10 @@ func (c *ControlPlane) CommitPreparedDatapath() error {
 	// Validate that TC filters are actually attached.  Catches silent failures
 	// in bindLan/bindWan/bindDaens that would otherwise cause traffic to bypass
 	// the proxy with no error logged.
-	if missing := c.core.validateDatapathBindings(); len(missing) > 0 {
-		return fmt.Errorf("datapath validation failed after interface binding: %v", missing)
+	if c.core != nil {
+		if missing := c.core.validateDatapathBindings(); len(missing) > 0 {
+			return fmt.Errorf("datapath validation failed after interface binding: %v", missing)
+		}
 	}
 	if c.routingKernspaceSnapshot != nil {
 		c.log.Infoln("Loading routing rules into kernel space (BPF)...")

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -815,12 +815,13 @@ func newControlPlaneWithContextOptions(
 		if err = plane.commitInterfaceBindings(); err != nil {
 			return nil, err
 		}
-		// Validate that TC filters are actually attached.  A silent bind
-		// failure (e.g. missing clsact qdisc, interface disappeared) would
-		// otherwise cause traffic to bypass the proxy with no error.
+		// Confirm TC filters are actually attached. A silent bind failure
+		// (e.g. missing clsact qdisc, interface disappeared) would otherwise
+		// cause traffic to bypass the proxy with no error. Missing LAN/WAN
+		// filters are auto re-attached (self-heal); a missing dae0 aborts.
 		if core != nil {
-			if missing, fatal := core.validateDatapathBindings(); len(missing) > 0 {
-				msg := fmt.Sprintf("datapath validation failed after interface binding: %v", missing)
+			if missing, fatal := core.repairDatapathBindings(); len(missing) > 0 {
+				msg := fmt.Sprintf("datapath validation failed after interface binding (self-heal could not recover): %v", missing)
 				if fatal {
 					return nil, fmt.Errorf("%s", msg)
 				}
@@ -1472,12 +1473,13 @@ func (c *ControlPlane) CommitPreparedDatapath() error {
 	if err := c.commitInterfaceBindings(); err != nil {
 		return err
 	}
-	// Validate that TC filters are actually attached.  Catches silent failures
-	// in bindLan/bindWan/bindDaens that would otherwise cause traffic to bypass
-	// the proxy with no error logged.
+	// Confirm TC filters are actually attached. Catches silent failures in
+	// bindLan/bindWan/bindDaens that would otherwise cause traffic to bypass
+	// the proxy with no error logged. Missing LAN/WAN filters are auto
+	// re-attached (self-heal); a missing dae0 aborts.
 	if c.core != nil {
-		if missing, fatal := c.core.validateDatapathBindings(); len(missing) > 0 {
-			msg := fmt.Sprintf("datapath validation failed after interface binding: %v", missing)
+		if missing, fatal := c.core.repairDatapathBindings(); len(missing) > 0 {
+			msg := fmt.Sprintf("datapath validation failed after interface binding (self-heal could not recover): %v", missing)
 			if fatal {
 				return fmt.Errorf("%s", msg)
 			}

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -818,7 +818,7 @@ func newControlPlaneWithContextOptions(
 		// Validate that TC filters are actually attached.  A silent bind
 		// failure (e.g. missing clsact qdisc, interface disappeared) would
 		// otherwise cause traffic to bypass the proxy with no error.
-		if missing := core.validateDatapathBindings(plane.lanInterface, plane.wanInterface); len(missing) > 0 {
+		if missing := core.validateDatapathBindings(); len(missing) > 0 {
 			return nil, fmt.Errorf("datapath validation failed after interface binding: %v", missing)
 		}
 		if plane.sharedBpfReload {
@@ -1375,6 +1375,10 @@ func (c *ControlPlane) commitInterfaceBindings() error {
 	if c == nil || c.core == nil {
 		return nil
 	}
+	// Start each commit with a clean slate so validation only checks the
+	// interfaces bound during this run (e.g. after a reload with a changed
+	// LAN/WAN set).
+	c.core.resetBoundIfaces()
 
 	if len(c.lanInterface) > 0 {
 		if c.autoConfigKernelParameter {
@@ -1465,7 +1469,7 @@ func (c *ControlPlane) CommitPreparedDatapath() error {
 	// Validate that TC filters are actually attached.  Catches silent failures
 	// in bindLan/bindWan/bindDaens that would otherwise cause traffic to bypass
 	// the proxy with no error logged.
-	if missing := c.core.validateDatapathBindings(c.lanInterface, c.wanInterface); len(missing) > 0 {
+	if missing := c.core.validateDatapathBindings(); len(missing) > 0 {
 		return fmt.Errorf("datapath validation failed after interface binding: %v", missing)
 	}
 	if c.routingKernspaceSnapshot != nil {

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -815,6 +815,12 @@ func newControlPlaneWithContextOptions(
 		if err = plane.commitInterfaceBindings(); err != nil {
 			return nil, err
 		}
+		// Validate that TC filters are actually attached.  A silent bind
+		// failure (e.g. missing clsact qdisc, interface disappeared) would
+		// otherwise cause traffic to bypass the proxy with no error.
+		if missing := core.validateDatapathBindings(plane.lanInterface, plane.wanInterface); len(missing) > 0 {
+			return nil, fmt.Errorf("datapath validation failed after interface binding: %v", missing)
+		}
 		if plane.sharedBpfReload {
 			if err = clearReloadDomainRoutingMap(core.bpf.Load()); err != nil {
 				return nil, fmt.Errorf("clearReloadDomainRoutingMap: %w", err)
@@ -1455,6 +1461,12 @@ func (c *ControlPlane) CommitPreparedDatapath() error {
 	}
 	if err := c.commitInterfaceBindings(); err != nil {
 		return err
+	}
+	// Validate that TC filters are actually attached.  Catches silent failures
+	// in bindLan/bindWan/bindDaens that would otherwise cause traffic to bypass
+	// the proxy with no error logged.
+	if missing := c.core.validateDatapathBindings(c.lanInterface, c.wanInterface); len(missing) > 0 {
+		return fmt.Errorf("datapath validation failed after interface binding: %v", missing)
 	}
 	if c.routingKernspaceSnapshot != nil {
 		c.log.Infoln("Loading routing rules into kernel space (BPF)...")

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -819,8 +819,12 @@ func newControlPlaneWithContextOptions(
 		// failure (e.g. missing clsact qdisc, interface disappeared) would
 		// otherwise cause traffic to bypass the proxy with no error.
 		if core != nil {
-			if missing := core.validateDatapathBindings(); len(missing) > 0 {
-				return nil, fmt.Errorf("datapath validation failed after interface binding: %v", missing)
+			if missing, fatal := core.validateDatapathBindings(); len(missing) > 0 {
+				msg := fmt.Sprintf("datapath validation failed after interface binding: %v", missing)
+				if fatal {
+					return nil, fmt.Errorf("%s", msg)
+				}
+				core.log.Warnf("%s", msg)
 			}
 		}
 		if plane.sharedBpfReload {
@@ -1472,8 +1476,12 @@ func (c *ControlPlane) CommitPreparedDatapath() error {
 	// in bindLan/bindWan/bindDaens that would otherwise cause traffic to bypass
 	// the proxy with no error logged.
 	if c.core != nil {
-		if missing := c.core.validateDatapathBindings(); len(missing) > 0 {
-			return fmt.Errorf("datapath validation failed after interface binding: %v", missing)
+		if missing, fatal := c.core.validateDatapathBindings(); len(missing) > 0 {
+			msg := fmt.Sprintf("datapath validation failed after interface binding: %v", missing)
+			if fatal {
+				return fmt.Errorf("%s", msg)
+			}
+			c.log.Warnf("%s", msg)
 		}
 	}
 	if c.routingKernspaceSnapshot != nil {

--- a/control/control_plane_core.go
+++ b/control/control_plane_core.go
@@ -885,10 +885,17 @@ var linkByName = netlink.LinkByName
 
 // recordBoundIface records a successfully bound interface so that a later
 // validateDatapathBindings call can confirm its TC filter is attached.
+// Duplicate (name+label+major) entries are ignored, which keeps the recorded
+// set stable when an interface is re-bound during self-heal.
 func (c *controlPlaneCore) recordBoundIface(name, label string, major uint16) {
 	c.datapathMu.Lock()
+	defer c.datapathMu.Unlock()
+	for _, b := range c.datapathIfaces {
+		if b.name == name && b.label == label && b.major == major {
+			return
+		}
+	}
 	c.datapathIfaces = append(c.datapathIfaces, boundIface{name: name, label: label, major: major})
-	c.datapathMu.Unlock()
 }
 
 // resetBoundIfaces clears the recorded bindings so each commitInterfaceBindings
@@ -917,29 +924,101 @@ func (c *controlPlaneCore) resetBoundIfaces() {
 // does not abort — it is surfaced as a warning so operators still get
 // visibility into silent datapath breakage without breaking environments
 // where such filters legitimately cannot be attached.
-func (c *controlPlaneCore) validateDatapathBindings() (missing []string, fatal bool) {
+// checkBinding reports whether the TC filter for bi is actually attached,
+// returning a human-readable reason when it is not.
+func (c *controlPlaneCore) checkBinding(bi boundIface) (ok bool, reason string) {
+	link, err := linkByName(bi.name)
+	if err != nil {
+		return false, fmt.Sprintf("%s (%s, link not found)", bi.name, bi.label)
+	}
+	if !hasDaeTcFilter(link, bi.major) {
+		return false, fmt.Sprintf("%s (%s, handle 0x%x missing)", bi.name, bi.label, bi.major)
+	}
+	return true, ""
+}
+
+// missingBindings returns the recorded interfaces whose TC filter is not
+// actually attached, plus whether a *fatal* binding (dae0) is among them.
+// dae0 is created and fully controlled by dae, so a missing dae0 filter means
+// the transparent proxy cannot function at all; LAN/WAN depend on the host
+// environment (e.g. clsact availability) and are not fatal.
+func (c *controlPlaneCore) missingBindings() (missing []boundIface, fatal bool) {
 	c.datapathMu.Lock()
 	ifaces := make([]boundIface, len(c.datapathIfaces))
 	copy(ifaces, c.datapathIfaces)
 	c.datapathMu.Unlock()
 
 	for _, bi := range ifaces {
-		link, err := linkByName(bi.name)
-		if err != nil {
-			missing = append(missing, fmt.Sprintf("%s (%s, link not found)", bi.name, bi.label))
-			if bi.label == "dae0" {
-				fatal = true
-			}
-			continue
-		}
-		if !hasDaeTcFilter(link, bi.major) {
-			missing = append(missing, fmt.Sprintf("%s (%s, handle 0x%x missing)", bi.name, bi.label, bi.major))
+		if ok, _ := c.checkBinding(bi); !ok {
+			missing = append(missing, bi)
 			if bi.label == "dae0" {
 				fatal = true
 			}
 		}
 	}
 	return missing, fatal
+}
+
+func (c *controlPlaneCore) validateDatapathBindings() (missing []string, fatal bool) {
+	bad, fatal := c.missingBindings()
+	for _, bi := range bad {
+		_, reason := c.checkBinding(bi)
+		missing = append(missing, reason)
+	}
+	return missing, fatal
+}
+
+// rebindLanFn / rebindWanFn are package-level indirection over the actual bind
+// functions so unit tests can substitute stubs without touching the real
+// netlink stack. In production they call _bindLan / _bindWan directly (which
+// ensure the clsact qdisc and re-attach the filter, both idempotent).
+var rebindLanFn = func(c *controlPlaneCore, name string) error { return c._bindLan(name) }
+var rebindWanFn = func(c *controlPlaneCore, name string) error { return c._bindWan(name) }
+
+// repairDatapathBindings detects missing TC filters and attempts to re-attach
+// them automatically (self-heal) for LAN/WAN interfaces, then re-validates
+// once. dae0 is intentionally never self-healed: a missing dae0 filter is a
+// fatal, deep failure and is reported so the caller can abort.
+//
+// It returns the interfaces that are *still* missing after the re-attach
+// attempt, plus fatal (true only when dae0 is among the still-missing), so
+// callers keep the existing fatal/warning policy unchanged:
+//   - dae0 missing  -> fatal -> caller aborts startup/reload
+//   - LAN/WAN missing but re-attached -> silently recovered (Infof)
+//   - LAN/WAN missing and re-attach failed -> warning, proxy keeps running
+func (c *controlPlaneCore) repairDatapathBindings() (stillMissing []string, fatal bool) {
+	bad, _ := c.missingBindings()
+	if len(bad) == 0 {
+		return nil, false
+	}
+	repaired := false
+	for _, bi := range bad {
+		switch bi.label {
+		case "LAN":
+			if err := rebindLanFn(c, bi.name); err != nil {
+				c.log.Warnf("datapath self-heal: failed to re-bind LAN %s: %v", bi.name, err)
+			} else {
+				repaired = true
+			}
+		case "WAN":
+			if err := rebindWanFn(c, bi.name); err != nil {
+				c.log.Warnf("datapath self-heal: failed to re-bind WAN %s: %v", bi.name, err)
+			} else {
+				repaired = true
+			}
+		}
+		// dae0: not self-healed.
+	}
+	// Re-check once (single pass, no retry loop to avoid livelock).
+	stillBad, fatal := c.missingBindings()
+	for _, bi := range stillBad {
+		_, reason := c.checkBinding(bi)
+		stillMissing = append(stillMissing, reason)
+	}
+	if repaired && len(stillMissing) == 0 {
+		c.log.Infof("datapath self-heal: re-attached missing LAN/WAN TC filters")
+	}
+	return stillMissing, fatal
 }
 
 // filterLister lists TC filters attached to link on the given parent. It is a

--- a/control/control_plane_core.go
+++ b/control/control_plane_core.go
@@ -984,7 +984,7 @@ var rebindWanFn = func(c *controlPlaneCore, name string) error { return c._bindW
 // attempt, plus fatal (true only when dae0 is among the still-missing), so
 // callers keep the existing fatal/warning policy unchanged:
 //   - dae0 missing  -> fatal -> caller aborts startup/reload
-//   - LAN/WAN missing but re-attached -> silently recovered (Infof)
+//   - LAN/WAN missing but re-attached -> silently recovered (Debugf)
 //   - LAN/WAN missing and re-attach failed -> warning, proxy keeps running
 func (c *controlPlaneCore) repairDatapathBindings() (stillMissing []string, fatal bool) {
 	bad, _ := c.missingBindings()
@@ -1016,7 +1016,7 @@ func (c *controlPlaneCore) repairDatapathBindings() (stillMissing []string, fata
 		stillMissing = append(stillMissing, reason)
 	}
 	if repaired && len(stillMissing) == 0 {
-		c.log.Infof("datapath self-heal: re-attached missing LAN/WAN TC filters")
+		c.log.Debugf("datapath self-heal: re-attached missing LAN/WAN TC filters")
 	}
 	return stillMissing, fatal
 }

--- a/control/control_plane_core.go
+++ b/control/control_plane_core.go
@@ -888,9 +888,7 @@ func (c *controlPlaneCore) bindDaens() (err error) {
 // rollback (reload) or abort (startup).
 // linkByName looks up a network interface by name. It is a package-level
 // variable (defaulting to netlink.LinkByName) so tests can substitute a mock.
-var linkByName = func(name string) (netlink.Link, error) {
-	return netlink.LinkByName(name)
-}
+var linkByName = netlink.LinkByName
 
 // recordBoundIface records a successfully bound interface so that a later
 // validateDatapathBindings call can confirm its TC filter is attached.
@@ -940,9 +938,7 @@ func (c *controlPlaneCore) validateDatapathBindings() []string {
 // filterLister lists TC filters attached to link on the given parent. It is a
 // package-level variable (defaulting to netlink.FilterList) so tests can swap
 // in a mock without touching the real netlink stack.
-var filterLister = func(link netlink.Link, parent uint32) ([]netlink.Filter, error) {
-	return netlink.FilterList(link, parent)
-}
+var filterLister = netlink.FilterList
 
 // hasDaeTcFilter reports whether any TC filter with the given major handle
 // (e.g. 0x2022 for dae0, 0x2023 for LAN/WAN) exists on link in either the

--- a/control/control_plane_core.go
+++ b/control/control_plane_core.go
@@ -123,6 +123,25 @@ type controlPlaneCore struct {
 	domainRouting       *domainRoutingTracker
 	lpmTrieIndices      []uint32
 	bpfOwned            bool
+
+	// datapathIfaces records the interfaces that were successfully bound,
+	// together with the expected TC filter major handle, so that
+	// validateDatapathBindings can verify the filters are actually attached
+	// after commitInterfaceBindings. It is populated by bindDaens (dae0 host
+	// side, 0x2022) and _bindLan/_bindWan (LAN/WAN, 0x2023) using the *resolved*
+	// interface name. A configured "auto" LAN/WAN is therefore expanded to the
+	// real NIC, and dae0 is only checked when it was actually created — which
+	// keeps validation correct in both unit-test and production settings.
+	datapathIfaces []boundIface
+	datapathMu     sync.Mutex
+}
+
+// boundIface is an interface that was successfully bound, paired with the TC
+// filter major handle (0x2022 for dae0, 0x2023 for LAN/WAN) we expect on it.
+type boundIface struct {
+	name  string
+	label string
+	major uint16
 }
 
 func newControlPlaneCore(log *logrus.Logger,
@@ -440,6 +459,10 @@ func (c *controlPlaneCore) _bindLan(ifname string) error {
 	default:
 	}
 	c.log.Infof("Bind to LAN: %v", ifname)
+	// Record the intended binding up-front so validation still catches a
+	// swallowed bind failure (e.g. FilterAdd error logged but not propagated by
+	// the interface-manager callback).
+	c.recordBoundIface(ifname, "LAN", 0x2023)
 
 	link, err := netlink.LinkByName(ifname)
 	if err != nil {
@@ -656,6 +679,11 @@ func (c *controlPlaneCore) _bindWan(ifname string) error {
 	default:
 	}
 	c.log.Infof("Bind to WAN: %v", ifname)
+	// Record the intended binding up-front so validation still catches a
+	// swallowed bind failure (e.g. FilterAdd error logged but not propagated by
+	// the interface-manager callback).
+	c.recordBoundIface(ifname, "WAN", 0x2023)
+
 	link, err := netlink.LinkByName(ifname)
 	if err != nil {
 		return err
@@ -840,6 +868,7 @@ func (c *controlPlaneCore) bindDaens() (err error) {
 	if err := netlink.FilterAdd(filterDae0Ingress); err != nil && !errors.Is(err, unix.EEXIST) {
 		return fmt.Errorf("cannot attach ebpf object to filter ingress: %w", err)
 	}
+	c.recordBoundIface(daens.Dae0().Attrs().Name, "dae0", 0x2022)
 	dae0DetachFunc := func() error {
 		if err := netlink.FilterDel(filterDae0Ingress); err != nil && !os.IsNotExist(err) && !errors.Is(err, unix.ENODEV) {
 			return fmt.Errorf("FilterDel(%v:%v): %w", daens.Dae0().Attrs().Name, filterDae0Ingress.Name, err)
@@ -863,25 +892,47 @@ var linkByName = func(name string) (netlink.Link, error) {
 	return netlink.LinkByName(name)
 }
 
-func (c *controlPlaneCore) validateDatapathBindings(lanIfaces, wanIfaces []string) []string {
-	var missing []string
-	check := func(ifname string, label string, major uint16) {
-		link, err := linkByName(ifname)
-		if err != nil {
-			missing = append(missing, fmt.Sprintf("%s (%s, link not found)", ifname, label))
-			return
-		}
-		if !hasDaeTcFilter(link, major) {
-			missing = append(missing, fmt.Sprintf("%s (%s, handle 0x%x missing)", ifname, label, major))
-		}
-	}
+// recordBoundIface records a successfully bound interface so that a later
+// validateDatapathBindings call can confirm its TC filter is attached.
+func (c *controlPlaneCore) recordBoundIface(name, label string, major uint16) {
+	c.datapathMu.Lock()
+	c.datapathIfaces = append(c.datapathIfaces, boundIface{name: name, label: label, major: major})
+	c.datapathMu.Unlock()
+}
 
-	check(HostVethName, "dae0", 0x2022)
-	for _, iface := range lanIfaces {
-		check(iface, "LAN", 0x2023)
-	}
-	for _, iface := range wanIfaces {
-		check(iface, "WAN", 0x2023)
+// resetBoundIfaces clears the recorded bindings so each commitInterfaceBindings
+// run validates only the interfaces bound during that run.
+func (c *controlPlaneCore) resetBoundIfaces() {
+	c.datapathMu.Lock()
+	c.datapathIfaces = nil
+	c.datapathMu.Unlock()
+}
+
+// validateDatapathBindings verifies that TC filters are actually attached on
+// every interface that was successfully bound during commitInterfaceBindings.
+// This catches silent failures where bindLan/bindWan/bindDaens partially
+// succeed (e.g. qdisc missing → FilterAdd silently fails, or the interface
+// disappeared between lookup and attach). It validates only the *resolved*
+// interface names recorded by the bind functions (so a configured "auto" LAN
+// is expanded to the real NIC, and dae0 is only checked when it was actually
+// created), which keeps it correct in both unit-test and production settings.
+// Returns an empty slice when all required filters are present.
+func (c *controlPlaneCore) validateDatapathBindings() []string {
+	c.datapathMu.Lock()
+	ifaces := make([]boundIface, len(c.datapathIfaces))
+	copy(ifaces, c.datapathIfaces)
+	c.datapathMu.Unlock()
+
+	var missing []string
+	for _, bi := range ifaces {
+		link, err := linkByName(bi.name)
+		if err != nil {
+			missing = append(missing, fmt.Sprintf("%s (%s, link not found)", bi.name, bi.label))
+			continue
+		}
+		if !hasDaeTcFilter(link, bi.major) {
+			missing = append(missing, fmt.Sprintf("%s (%s, handle 0x%x missing)", bi.name, bi.label, bi.major))
+		}
 	}
 	return missing
 }
@@ -903,14 +954,13 @@ func hasDaeTcFilter(link netlink.Link, major uint16) bool {
 			continue // no clsact qdisc attached
 		}
 		for _, f := range filters {
-			if uint16(f.Attrs().Handle >> 16) == major {
+			if uint16(f.Attrs().Handle>>16) == major {
 				return true
 			}
 		}
 	}
 	return false
 }
-
 
 // tryDeleteFlippedFilter deletes the TC filter obtained by flipping the
 // low bit of the handle. Used during non-reload startup to remove any

--- a/control/control_plane_core.go
+++ b/control/control_plane_core.go
@@ -850,6 +850,68 @@ func (c *controlPlaneCore) bindDaens() (err error) {
 	return
 }
 
+// validateDatapathBindings verifies that TC filters are actually attached on
+// the expected interfaces after commitInterfaceBindings.  This catches silent
+// failures where bindLan/bindWan/bindDaens partially succeed (e.g. qdisc
+// missing → FilterAdd silently fails, or the interface disappeared between
+// lookup and attach).  Returns nil when all required filters are present;
+// returns an error listing every missing binding so callers can decide to
+// rollback (reload) or abort (startup).
+// linkByName looks up a network interface by name. It is a package-level
+// variable (defaulting to netlink.LinkByName) so tests can substitute a mock.
+var linkByName = func(name string) (netlink.Link, error) {
+	return netlink.LinkByName(name)
+}
+
+func (c *controlPlaneCore) validateDatapathBindings(lanIfaces, wanIfaces []string) []string {
+	var missing []string
+	check := func(ifname string, label string, major uint16) {
+		link, err := linkByName(ifname)
+		if err != nil {
+			missing = append(missing, fmt.Sprintf("%s (%s, link not found)", ifname, label))
+			return
+		}
+		if !hasDaeTcFilter(link, major) {
+			missing = append(missing, fmt.Sprintf("%s (%s, handle 0x%x missing)", ifname, label, major))
+		}
+	}
+
+	check(HostVethName, "dae0", 0x2022)
+	for _, iface := range lanIfaces {
+		check(iface, "LAN", 0x2023)
+	}
+	for _, iface := range wanIfaces {
+		check(iface, "WAN", 0x2023)
+	}
+	return missing
+}
+
+// filterLister lists TC filters attached to link on the given parent. It is a
+// package-level variable (defaulting to netlink.FilterList) so tests can swap
+// in a mock without touching the real netlink stack.
+var filterLister = func(link netlink.Link, parent uint32) ([]netlink.Filter, error) {
+	return netlink.FilterList(link, parent)
+}
+
+// hasDaeTcFilter reports whether any TC filter with the given major handle
+// (e.g. 0x2022 for dae0, 0x2023 for LAN/WAN) exists on link in either the
+// ingress or egress parent.  Mirrors the detection logic in bpf_purge.go.
+func hasDaeTcFilter(link netlink.Link, major uint16) bool {
+	for _, parent := range []uint32{netlink.HANDLE_MIN_INGRESS, netlink.HANDLE_MIN_EGRESS} {
+		filters, err := filterLister(link, parent)
+		if err != nil {
+			continue // no clsact qdisc attached
+		}
+		for _, f := range filters {
+			if uint16(f.Attrs().Handle >> 16) == major {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+
 // tryDeleteFlippedFilter deletes the TC filter obtained by flipping the
 // low bit of the handle. Used during non-reload startup to remove any
 // stale filter from a previous run that used the opposite flip value.

--- a/control/control_plane_core.go
+++ b/control/control_plane_core.go
@@ -879,13 +879,6 @@ func (c *controlPlaneCore) bindDaens() (err error) {
 	return
 }
 
-// validateDatapathBindings verifies that TC filters are actually attached on
-// the expected interfaces after commitInterfaceBindings.  This catches silent
-// failures where bindLan/bindWan/bindDaens partially succeed (e.g. qdisc
-// missing → FilterAdd silently fails, or the interface disappeared between
-// lookup and attach).  Returns nil when all required filters are present;
-// returns an error listing every missing binding so callers can decide to
-// rollback (reload) or abort (startup).
 // linkByName looks up a network interface by name. It is a package-level
 // variable (defaulting to netlink.LinkByName) so tests can substitute a mock.
 var linkByName = netlink.LinkByName
@@ -914,25 +907,39 @@ func (c *controlPlaneCore) resetBoundIfaces() {
 // interface names recorded by the bind functions (so a configured "auto" LAN
 // is expanded to the real NIC, and dae0 is only checked when it was actually
 // created), which keeps it correct in both unit-test and production settings.
-// Returns an empty slice when all required filters are present.
-func (c *controlPlaneCore) validateDatapathBindings() []string {
+//
+// The returned bool reports whether a *fatal* binding is missing — currently
+// only the dae0 host veth, which dae itself creates and fully controls. A
+// missing dae0 filter means the transparent proxy cannot function at all, so
+// it aborts startup/reload. LAN/WAN filters depend on the host environment
+// (e.g. clsact availability on user interfaces, which can be unavailable when
+// dae runs inside a container), so a missing LAN/WAN filter is reported but
+// does not abort — it is surfaced as a warning so operators still get
+// visibility into silent datapath breakage without breaking environments
+// where such filters legitimately cannot be attached.
+func (c *controlPlaneCore) validateDatapathBindings() (missing []string, fatal bool) {
 	c.datapathMu.Lock()
 	ifaces := make([]boundIface, len(c.datapathIfaces))
 	copy(ifaces, c.datapathIfaces)
 	c.datapathMu.Unlock()
 
-	var missing []string
 	for _, bi := range ifaces {
 		link, err := linkByName(bi.name)
 		if err != nil {
 			missing = append(missing, fmt.Sprintf("%s (%s, link not found)", bi.name, bi.label))
+			if bi.label == "dae0" {
+				fatal = true
+			}
 			continue
 		}
 		if !hasDaeTcFilter(link, bi.major) {
 			missing = append(missing, fmt.Sprintf("%s (%s, handle 0x%x missing)", bi.name, bi.label, bi.major))
+			if bi.label == "dae0" {
+				fatal = true
+			}
 		}
 	}
-	return missing
+	return missing, fatal
 }
 
 // filterLister lists TC filters attached to link on the given parent. It is a

--- a/control/control_plane_core_test.go
+++ b/control/control_plane_core_test.go
@@ -2,191 +2,170 @@ package control
 
 import (
 	"fmt"
-	"io"
-	"sync"
-	"sync/atomic"
 	"testing"
 
-	"github.com/cilium/ebpf"
-	ciliumLink "github.com/cilium/ebpf/link"
-	"github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
 )
 
-func TestControlPlaneCore_Flip_Race(t *testing.T) {
-	// coreFlip is global in package control.
-	// Reset it to 0 for deterministic test.
-	atomic.StoreInt32(&coreFlip, 0)
+// mkLink returns a minimal netlink.Link (a *netlink.Dummy) without touching the
+// real kernel. Dummy implements the Link interface and its Attrs().Name is what
+// our mocked filterLister keys on.
+func mkLink(name string) netlink.Link {
+	return &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: name}}
+}
 
-	// Since Flip() doesn't access any struct fields, we can use an empty struct.
-	c := &controlPlaneCore{}
-
-	var wg sync.WaitGroup
-	iterations := 1000 // Must be even
-
-	for range iterations {
-		wg.Go(func() {
-			c.Flip()
-		})
-	}
-
-	wg.Wait()
-
-	val := atomic.LoadInt32(&coreFlip)
-	// If atomic operations are correct, flipping 0 an even number of times should result in 0.
-	// If a race occurred (e.g. lost update), the result might be 1.
-	if val != 0 {
-		t.Errorf("Expected coreFlip to be 0 after %d flips, got %d. Race condition detected.", iterations, val)
+// mkFilters wraps a single handle (major<<16) into a netlink.Filter list.
+func mkFilters(major uint16) []netlink.Filter {
+	return []netlink.Filter{
+		&netlink.GenericFilter{FilterAttrs: netlink.FilterAttrs{Handle: uint32(major) << 16}},
 	}
 }
 
-func TestControlPlaneCore_EjectBpfKeepsHookCleanupForClose(t *testing.T) {
-	logger := logrus.New()
-	logger.SetOutput(io.Discard)
-
-	core := newControlPlaneCore(logger, nil, nil, nil, false)
-	calls := 0
-	core.addManagedBpfHookCleanup(func() error {
-		calls++
-		return nil
+func TestValidateDatapathBindings(t *testing.T) {
+	// Swap out the kernel-touching helpers for mocks.
+	origLinkByName := linkByName
+	origFilterLister := filterLister
+	t.Cleanup(func() {
+		linkByName = origLinkByName
+		filterLister = origFilterLister
 	})
 
-	core.EjectBpf()
-	if core.bpfOwned {
-		t.Fatal("expected EjectBpf to transfer BPF ownership")
-	}
+	dae0 := mkLink("dae0")
+	eth0 := mkLink("eth0")
+	eth1 := mkLink("eth1")
 
-	if err := core.Close(); err != nil {
-		t.Fatalf("Close() error = %v, want nil", err)
-	}
-	if calls != 1 {
-		t.Fatalf("expected hook cleanup to run once after EjectBpf, got %d", calls)
-	}
-}
-
-func TestControlPlaneCore_InjectBpfClaimsOwnershipForReloadGeneration(t *testing.T) {
-	logger := logrus.New()
-	logger.SetOutput(io.Discard)
-
-	core := newControlPlaneCore(logger, nil, nil, nil, true)
-	if core.bpfOwned {
-		t.Fatal("expected reload generation to start without BPF ownership")
-	}
-
-	core.InjectBpf(nil)
-
-	if !core.bpfOwned {
-		t.Fatal("expected InjectBpf to claim BPF ownership")
-	}
-	if core.bpfEjected {
-		t.Fatal("expected InjectBpf to clear the ejected state")
-	}
-}
-
-func TestControlPlaneCore_InheritLpmIndicesSkipsReusedSlots(t *testing.T) {
-	logger := logrus.New()
-	logger.SetOutput(io.Discard)
-
-	core := newControlPlaneCore(logger, nil, nil, nil, true)
-	core.lpmTrieIndices = []uint32{4, 5}
-
-	core.InheritLpmIndices([]uint32{1, 4, 7})
-
-	got := make(map[uint32]struct{}, len(core.lpmTrieIndices))
-	for _, idx := range core.lpmTrieIndices {
-		got[idx] = struct{}{}
-	}
-
-	for _, want := range []uint32{1, 4, 5, 7} {
-		if _, ok := got[want]; !ok {
-			t.Fatalf("expected inherited index set to contain %d, got %#v", want, core.lpmTrieIndices)
-		}
-	}
-	if len(got) != 4 {
-		t.Fatalf("expected no duplicate inherited indices, got %#v", core.lpmTrieIndices)
-	}
-}
-
-func TestControlPlaneCore_EjectLpmIndicesTransfersOwnership(t *testing.T) {
-	logger := logrus.New()
-	logger.SetOutput(io.Discard)
-
-	core := newControlPlaneCore(logger, nil, nil, nil, false)
-	core.lpmTrieIndices = []uint32{2, 3, 5}
-
-	indices := core.EjectLpmIndices()
-
-	if len(core.lpmTrieIndices) != 0 {
-		t.Fatalf("expected core LPM indices to be cleared after ejection, got %#v", core.lpmTrieIndices)
-	}
-	if len(indices) != 3 {
-		t.Fatalf("expected 3 ejected LPM indices, got %#v", indices)
-	}
-}
-
-func TestControlPlaneCore_ReplaceLpmIndicesReplacesTrackedSet(t *testing.T) {
-	logger := logrus.New()
-	logger.SetOutput(io.Discard)
-
-	core := newControlPlaneCore(logger, nil, nil, nil, false)
-	core.lpmTrieIndices = []uint32{2, 3, 5}
-
-	core.ReplaceLpmIndices([]uint32{7, 11})
-
-	if got := core.lpmTrieIndices; len(got) != 2 || got[0] != 7 || got[1] != 11 {
-		t.Fatalf("expected replaced LPM indices [7 11], got %#v", got)
-	}
-}
-
-type fakeCgroupAttachment struct {
-	closeCalls atomic.Int32
-}
-
-func (f *fakeCgroupAttachment) Close() error {
-	f.closeCalls.Add(1)
-	return nil
-}
-
-func TestControlPlaneCore_SetupSkPidMonitorRollsBackPartialAttach(t *testing.T) {
-	oldDetect := detectCgroupPathFunc
-	oldAttach := attachCgroupFunc
-	detectCgroupPathFunc = func() (string, error) { return "/sys/fs/cgroup", nil }
-	var attachments []*fakeCgroupAttachment
-	attachCgroupFunc = func(ciliumLink.CgroupOptions) (cgroupAttachment, error) {
-		attachment := &fakeCgroupAttachment{}
-		attachments = append(attachments, attachment)
-		if len(attachments) == 3 {
-			return nil, fmt.Errorf("boom")
-		}
-		return attachment, nil
-	}
-	defer func() {
-		detectCgroupPathFunc = oldDetect
-		attachCgroupFunc = oldAttach
-	}()
-
-	logger := logrus.New()
-	logger.SetOutput(io.Discard)
-	core := newControlPlaneCore(logger, &bpfObjects{
-		bpfPrograms: bpfPrograms{
-			TproxyWanCgSockCreate:  &ebpf.Program{},
-			TproxyWanCgSockRelease: &ebpf.Program{},
-			TproxyWanCgConnect4:    &ebpf.Program{},
-			TproxyWanCgConnect6:    &ebpf.Program{},
-			TproxyWanCgSendmsg4:    &ebpf.Program{},
-			TproxyWanCgSendmsg6:    &ebpf.Program{},
+	tests := []struct {
+		name         string
+		known        map[string]netlink.Link
+		filters      map[string][]netlink.Filter
+		lan          []string
+		wan          []string
+		wantEmpty    bool
+		wantContains []string
+	}{
+		{
+			name:      "all bindings present",
+			known:     map[string]netlink.Link{"dae0": dae0, "eth0": eth0},
+			filters:   map[string][]netlink.Filter{"dae0": mkFilters(0x2022), "eth0": mkFilters(0x2023)},
+			lan:       []string{"eth0"},
+			wan:       nil,
+			wantEmpty: true,
 		},
-	}, nil, nil, false)
+		{
+			name:         "dae0 filter missing",
+			known:        map[string]netlink.Link{"dae0": dae0, "eth0": eth0},
+			filters:      map[string][]netlink.Filter{"eth0": mkFilters(0x2023)},
+			lan:          []string{"eth0"},
+			wan:          nil,
+			wantEmpty:    false,
+			wantContains: []string{"dae0 (dae0, handle 0x2022 missing)"},
+		},
+		{
+			name:         "lan filter missing",
+			known:        map[string]netlink.Link{"dae0": dae0, "eth0": eth0},
+			filters:      map[string][]netlink.Filter{"dae0": mkFilters(0x2022)},
+			lan:          []string{"eth0"},
+			wan:          nil,
+			wantEmpty:    false,
+			wantContains: []string{"eth0 (LAN, handle 0x2023 missing)"},
+		},
+		{
+			name:         "wan filter missing",
+			known:        map[string]netlink.Link{"dae0": dae0, "eth1": eth1},
+			filters:      map[string][]netlink.Filter{"dae0": mkFilters(0x2022)},
+			lan:          nil,
+			wan:          []string{"eth1"},
+			wantEmpty:    false,
+			wantContains: []string{"eth1 (WAN, handle 0x2023 missing)"},
+		},
+		{
+			name:         "interface not found",
+			known:        map[string]netlink.Link{"dae0": dae0},
+			filters:      map[string][]netlink.Filter{"dae0": mkFilters(0x2022)},
+			lan:          []string{"eth0"},
+			wan:          nil,
+			wantEmpty:    false,
+			wantContains: []string{"eth0 (LAN, link not found)"},
+		},
+		{
+			name:      "handles from egress parent only",
+			known:     map[string]netlink.Link{"dae0": dae0, "eth0": eth0},
+			filters:   map[string][]netlink.Filter{"dae0": mkFilters(0x2022), "eth0": mkFilters(0x2023)},
+			lan:       []string{"eth0"},
+			wan:       nil,
+			wantEmpty: true,
+		},
+	}
 
-	if err := core.setupSkPidMonitor(); err == nil {
-		t.Fatal("setupSkPidMonitor() error = nil, want failure")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			linkByName = func(name string) (netlink.Link, error) {
+				if l, ok := tt.known[name]; ok {
+					return l, nil
+				}
+				return nil, fmt.Errorf("link %s not found", name)
+			}
+			filterLister = func(link netlink.Link, parent uint32) ([]netlink.Filter, error) {
+				if fs, ok := tt.filters[link.Attrs().Name]; ok {
+					return fs, nil
+				}
+				return nil, nil
+			}
+
+			c := &controlPlaneCore{}
+			missing := c.validateDatapathBindings(tt.lan, tt.wan)
+
+			if tt.wantEmpty {
+				if len(missing) != 0 {
+					t.Fatalf("expected no missing bindings, got %v", missing)
+				}
+				return
+			}
+			if len(missing) == 0 {
+				t.Fatalf("expected missing bindings %v, got none", tt.wantContains)
+			}
+			for _, want := range tt.wantContains {
+				found := false
+				for _, m := range missing {
+					if m == want {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("missing binding %q not found in %v", want, missing)
+				}
+			}
+		})
 	}
-	if got := len(core.bpfHookDetachFuncs); got != 0 {
-		t.Fatalf("len(bpfHookDetachFuncs) = %d, want 0 after rollback", got)
+}
+
+func TestHasDaeTcFilter(t *testing.T) {
+	origFilterLister := filterLister
+	t.Cleanup(func() { filterLister = origFilterLister })
+
+	link := mkLink("eth0")
+
+	tests := []struct {
+		name    string
+		filters []netlink.Filter
+		major   uint16
+		want    bool
+	}{
+		{"matching major", mkFilters(0x2023), 0x2023, true},
+		{"non-matching major", mkFilters(0x2022), 0x2023, false},
+		{"no filters", nil, 0x2023, false},
+		{"dae0 major", mkFilters(0x2022), 0x2022, true},
 	}
-	if got := attachments[0].closeCalls.Load(); got != 1 {
-		t.Fatalf("first attachment Close() calls = %d, want 1", got)
-	}
-	if got := attachments[1].closeCalls.Load(); got != 1 {
-		t.Fatalf("second attachment Close() calls = %d, want 1", got)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filterLister = func(link netlink.Link, parent uint32) ([]netlink.Filter, error) {
+				return tt.filters, nil
+			}
+			if got := hasDaeTcFilter(link, tt.major); got != tt.want {
+				t.Errorf("hasDaeTcFilter(%#x) = %v, want %v", tt.major, got, tt.want)
+			}
+		})
 	}
 }

--- a/control/control_plane_core_test.go
+++ b/control/control_plane_core_test.go
@@ -118,7 +118,7 @@ func TestValidateDatapathBindings(t *testing.T) {
 			}
 
 			c := &controlPlaneCore{datapathIfaces: tt.bound}
-			missing := c.validateDatapathBindings()
+			missing, _ := c.validateDatapathBindings()
 
 			if tt.wantEmpty {
 				if len(missing) != 0 {

--- a/control/control_plane_core_test.go
+++ b/control/control_plane_core_test.go
@@ -34,12 +34,16 @@ func TestValidateDatapathBindings(t *testing.T) {
 	eth0 := mkLink("eth0")
 	eth1 := mkLink("eth1")
 
+	// boundIfaces mimics what bindDaens/_bindLan/_bindWan record after a
+	// successful bind: the *resolved* interface name plus the expected handle.
+	// A configured "auto" LAN/WAN is expanded to the real NIC here, and dae0 is
+	// only present when bindDaens actually created it — which is exactly why the
+	// production validation no longer hard-codes dae0 or the raw "auto" name.
 	tests := []struct {
 		name         string
 		known        map[string]netlink.Link
 		filters      map[string][]netlink.Filter
-		lan          []string
-		wan          []string
+		bound        []boundIface
 		wantEmpty    bool
 		wantContains []string
 	}{
@@ -47,16 +51,14 @@ func TestValidateDatapathBindings(t *testing.T) {
 			name:      "all bindings present",
 			known:     map[string]netlink.Link{"dae0": dae0, "eth0": eth0},
 			filters:   map[string][]netlink.Filter{"dae0": mkFilters(0x2022), "eth0": mkFilters(0x2023)},
-			lan:       []string{"eth0"},
-			wan:       nil,
+			bound:     []boundIface{{"dae0", "dae0", 0x2022}, {"eth0", "LAN", 0x2023}},
 			wantEmpty: true,
 		},
 		{
 			name:         "dae0 filter missing",
 			known:        map[string]netlink.Link{"dae0": dae0, "eth0": eth0},
 			filters:      map[string][]netlink.Filter{"eth0": mkFilters(0x2023)},
-			lan:          []string{"eth0"},
-			wan:          nil,
+			bound:        []boundIface{{"dae0", "dae0", 0x2022}, {"eth0", "LAN", 0x2023}},
 			wantEmpty:    false,
 			wantContains: []string{"dae0 (dae0, handle 0x2022 missing)"},
 		},
@@ -64,8 +66,7 @@ func TestValidateDatapathBindings(t *testing.T) {
 			name:         "lan filter missing",
 			known:        map[string]netlink.Link{"dae0": dae0, "eth0": eth0},
 			filters:      map[string][]netlink.Filter{"dae0": mkFilters(0x2022)},
-			lan:          []string{"eth0"},
-			wan:          nil,
+			bound:        []boundIface{{"dae0", "dae0", 0x2022}, {"eth0", "LAN", 0x2023}},
 			wantEmpty:    false,
 			wantContains: []string{"eth0 (LAN, handle 0x2023 missing)"},
 		},
@@ -73,8 +74,7 @@ func TestValidateDatapathBindings(t *testing.T) {
 			name:         "wan filter missing",
 			known:        map[string]netlink.Link{"dae0": dae0, "eth1": eth1},
 			filters:      map[string][]netlink.Filter{"dae0": mkFilters(0x2022)},
-			lan:          nil,
-			wan:          []string{"eth1"},
+			bound:        []boundIface{{"dae0", "dae0", 0x2022}, {"eth1", "WAN", 0x2023}},
 			wantEmpty:    false,
 			wantContains: []string{"eth1 (WAN, handle 0x2023 missing)"},
 		},
@@ -82,17 +82,22 @@ func TestValidateDatapathBindings(t *testing.T) {
 			name:         "interface not found",
 			known:        map[string]netlink.Link{"dae0": dae0},
 			filters:      map[string][]netlink.Filter{"dae0": mkFilters(0x2022)},
-			lan:          []string{"eth0"},
-			wan:          nil,
+			bound:        []boundIface{{"dae0", "dae0", 0x2022}, {"eth0", "LAN", 0x2023}},
 			wantEmpty:    false,
 			wantContains: []string{"eth0 (LAN, link not found)"},
 		},
 		{
-			name:      "handles from egress parent only",
+			name:      "auto-resolved lan (resolved name only)",
 			known:     map[string]netlink.Link{"dae0": dae0, "eth0": eth0},
 			filters:   map[string][]netlink.Filter{"dae0": mkFilters(0x2022), "eth0": mkFilters(0x2023)},
-			lan:       []string{"eth0"},
-			wan:       nil,
+			bound:     []boundIface{{"dae0", "dae0", 0x2022}, {"eth0", "LAN", 0x2023}},
+			wantEmpty: true,
+		},
+		{
+			name:      "no bindings recorded (e.g. unit test without a real bind)",
+			known:     map[string]netlink.Link{},
+			filters:   map[string][]netlink.Filter{},
+			bound:     nil,
 			wantEmpty: true,
 		},
 	}
@@ -112,8 +117,8 @@ func TestValidateDatapathBindings(t *testing.T) {
 				return nil, nil
 			}
 
-			c := &controlPlaneCore{}
-			missing := c.validateDatapathBindings(tt.lan, tt.wan)
+			c := &controlPlaneCore{datapathIfaces: tt.bound}
+			missing := c.validateDatapathBindings()
 
 			if tt.wantEmpty {
 				if len(missing) != 0 {

--- a/control/control_plane_core_test.go
+++ b/control/control_plane_core_test.go
@@ -2,8 +2,10 @@ package control
 
 import (
 	"fmt"
+	"io"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 )
 
@@ -139,6 +141,138 @@ func TestValidateDatapathBindings(t *testing.T) {
 				}
 				if !found {
 					t.Errorf("missing binding %q not found in %v", want, missing)
+				}
+			}
+		})
+	}
+}
+
+func TestRepairDatapathBindings(t *testing.T) {
+	origLinkByName := linkByName
+	origFilterLister := filterLister
+	origRebindLan := rebindLanFn
+	origRebindWan := rebindWanFn
+	t.Cleanup(func() {
+		linkByName = origLinkByName
+		filterLister = origFilterLister
+		rebindLanFn = origRebindLan
+		rebindWanFn = origRebindWan
+	})
+
+	dae0 := mkLink("dae0")
+	eth0 := mkLink("eth0")
+	eth1 := mkLink("eth1")
+
+	tests := []struct {
+		name string
+		// initial state
+		known map[string]netlink.Link
+		// lanRebindFixes / wanRebindFixes: a successful rebind "adds" the
+		// missing filter to the mock, simulating a real re-attach.
+		filters          map[string][]netlink.Filter
+		bound            []boundIface
+		lanRebindErr     error
+		wanRebindErr     error
+		lanRebindFixes   bool
+		wanRebindFixes   bool
+		wantStillMissing []string
+		wantFatal        bool
+	}{
+		{
+			name:             "LAN missing then self-healed",
+			known:            map[string]netlink.Link{"dae0": dae0, "eth0": eth0},
+			filters:          map[string][]netlink.Filter{"dae0": mkFilters(0x2022)},
+			bound:            []boundIface{{"dae0", "dae0", 0x2022}, {"eth0", "LAN", 0x2023}},
+			lanRebindFixes:   true,
+			wantStillMissing: nil,
+			wantFatal:        false,
+		},
+		{
+			name:             "WAN missing but rebind fails (warn only)",
+			known:            map[string]netlink.Link{"dae0": dae0, "eth1": eth1},
+			filters:          map[string][]netlink.Filter{"dae0": mkFilters(0x2022)},
+			bound:            []boundIface{{"dae0", "dae0", 0x2022}, {"eth1", "WAN", 0x2023}},
+			wanRebindErr:     fmt.Errorf("simulated clsact unavailable"),
+			wantStillMissing: []string{"eth1 (WAN, handle 0x2023 missing)"},
+			wantFatal:        false,
+		},
+		{
+			name:             "dae0 missing is fatal and not self-healed",
+			known:            map[string]netlink.Link{"dae0": dae0, "eth0": eth0},
+			filters:          map[string][]netlink.Filter{"eth0": mkFilters(0x2023)},
+			bound:            []boundIface{{"dae0", "dae0", 0x2022}, {"eth0", "LAN", 0x2023}},
+			wantStillMissing: []string{"dae0 (dae0, handle 0x2022 missing)"},
+			wantFatal:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// filters is a mutable copy so a successful rebind can "add" the
+			// missing filter, mirroring a real re-attach.
+			filters := map[string][]netlink.Filter{}
+			for k, v := range tt.filters {
+				filters[k] = v
+			}
+			linkByName = func(name string) (netlink.Link, error) {
+				if l, ok := tt.known[name]; ok {
+					return l, nil
+				}
+				return nil, fmt.Errorf("link %s not found", name)
+			}
+			filterLister = func(link netlink.Link, parent uint32) ([]netlink.Filter, error) {
+				if fs, ok := filters[link.Attrs().Name]; ok {
+					return fs, nil
+				}
+				return nil, nil
+			}
+			rebindLanFn = func(c *controlPlaneCore, name string) error {
+				if tt.lanRebindErr != nil {
+					return tt.lanRebindErr
+				}
+				if tt.lanRebindFixes {
+					filters[name] = mkFilters(0x2023)
+				}
+				return nil
+			}
+			rebindWanFn = func(c *controlPlaneCore, name string) error {
+				if tt.wanRebindErr != nil {
+					return tt.wanRebindErr
+				}
+				if tt.wanRebindFixes {
+					filters[name] = mkFilters(0x2023)
+				}
+				return nil
+			}
+
+			c := &controlPlaneCore{datapathIfaces: tt.bound}
+			c.log = logrus.New()
+			c.log.SetOutput(io.Discard)
+
+			stillMissing, fatal := c.repairDatapathBindings()
+
+			if fatal != tt.wantFatal {
+				t.Errorf("fatal = %v, want %v", fatal, tt.wantFatal)
+			}
+			if len(tt.wantStillMissing) == 0 {
+				if len(stillMissing) != 0 {
+					t.Fatalf("expected no still-missing, got %v", stillMissing)
+				}
+				return
+			}
+			if len(stillMissing) == 0 {
+				t.Fatalf("expected still-missing %v, got none", tt.wantStillMissing)
+			}
+			for _, want := range tt.wantStillMissing {
+				found := false
+				for _, m := range stillMissing {
+					if m == want {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("still-missing %q not found in %v", want, stillMissing)
 				}
 			}
 		})

--- a/control/control_plane_core_test.go
+++ b/control/control_plane_core_test.go
@@ -3,8 +3,12 @@ package control
 import (
 	"fmt"
 	"io"
+	"sync"
+	"sync/atomic"
 	"testing"
 
+	"github.com/cilium/ebpf"
+	ciliumLink "github.com/cilium/ebpf/link"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 )
@@ -306,5 +310,184 @@ func TestHasDaeTcFilter(t *testing.T) {
 				t.Errorf("hasDaeTcFilter(%#x) = %v, want %v", tt.major, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestControlPlaneCore_Flip_Race(t *testing.T) {
+	// coreFlip is global in package control.
+	// Reset it to 0 for deterministic test.
+	atomic.StoreInt32(&coreFlip, 0)
+
+	// Since Flip() doesn't access any struct fields, we can use an empty struct.
+	c := &controlPlaneCore{}
+
+	var wg sync.WaitGroup
+	iterations := 1000 // Must be even
+
+	for range iterations {
+		wg.Go(func() {
+			c.Flip()
+		})
+	}
+
+	wg.Wait()
+
+	val := atomic.LoadInt32(&coreFlip)
+	// If atomic operations are correct, flipping 0 an even number of times should result in 0.
+	// If a race occurred (e.g. lost update), the result might be 1.
+	if val != 0 {
+		t.Errorf("Expected coreFlip to be 0 after %d flips, got %d. Race condition detected.", iterations, val)
+	}
+}
+
+func TestControlPlaneCore_EjectBpfKeepsHookCleanupForClose(t *testing.T) {
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+
+	core := newControlPlaneCore(logger, nil, nil, nil, false)
+	calls := 0
+	core.addManagedBpfHookCleanup(func() error {
+		calls++
+		return nil
+	})
+
+	core.EjectBpf()
+	if core.bpfOwned {
+		t.Fatal("expected EjectBpf to transfer BPF ownership")
+	}
+
+	if err := core.Close(); err != nil {
+		t.Fatalf("Close() error = %v, want nil", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected hook cleanup to run once after EjectBpf, got %d", calls)
+	}
+}
+
+func TestControlPlaneCore_InjectBpfClaimsOwnershipForReloadGeneration(t *testing.T) {
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+
+	core := newControlPlaneCore(logger, nil, nil, nil, true)
+	if core.bpfOwned {
+		t.Fatal("expected reload generation to start without BPF ownership")
+	}
+
+	core.InjectBpf(nil)
+
+	if !core.bpfOwned {
+		t.Fatal("expected InjectBpf to claim BPF ownership")
+	}
+	if core.bpfEjected {
+		t.Fatal("expected InjectBpf to clear the ejected state")
+	}
+}
+
+func TestControlPlaneCore_InheritLpmIndicesSkipsReusedSlots(t *testing.T) {
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+
+	core := newControlPlaneCore(logger, nil, nil, nil, true)
+	core.lpmTrieIndices = []uint32{4, 5}
+
+	core.InheritLpmIndices([]uint32{1, 4, 7})
+
+	got := make(map[uint32]struct{}, len(core.lpmTrieIndices))
+	for _, idx := range core.lpmTrieIndices {
+		got[idx] = struct{}{}
+	}
+
+	for _, want := range []uint32{1, 4, 5, 7} {
+		if _, ok := got[want]; !ok {
+			t.Fatalf("expected inherited index set to contain %d, got %#v", want, core.lpmTrieIndices)
+		}
+	}
+	if len(got) != 4 {
+		t.Fatalf("expected no duplicate inherited indices, got %#v", core.lpmTrieIndices)
+	}
+}
+
+func TestControlPlaneCore_EjectLpmIndicesTransfersOwnership(t *testing.T) {
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+
+	core := newControlPlaneCore(logger, nil, nil, nil, false)
+	core.lpmTrieIndices = []uint32{2, 3, 5}
+
+	indices := core.EjectLpmIndices()
+
+	if len(core.lpmTrieIndices) != 0 {
+		t.Fatalf("expected core LPM indices to be cleared after ejection, got %#v", core.lpmTrieIndices)
+	}
+	if len(indices) != 3 {
+		t.Fatalf("expected 3 ejected LPM indices, got %#v", indices)
+	}
+}
+
+func TestControlPlaneCore_ReplaceLpmIndicesReplacesTrackedSet(t *testing.T) {
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+
+	core := newControlPlaneCore(logger, nil, nil, nil, false)
+	core.lpmTrieIndices = []uint32{2, 3, 5}
+
+	core.ReplaceLpmIndices([]uint32{7, 11})
+
+	if got := core.lpmTrieIndices; len(got) != 2 || got[0] != 7 || got[1] != 11 {
+		t.Fatalf("expected replaced LPM indices [7 11], got %#v", got)
+	}
+}
+
+type fakeCgroupAttachment struct {
+	closeCalls atomic.Int32
+}
+
+func (f *fakeCgroupAttachment) Close() error {
+	f.closeCalls.Add(1)
+	return nil
+}
+
+func TestControlPlaneCore_SetupSkPidMonitorRollsBackPartialAttach(t *testing.T) {
+	oldDetect := detectCgroupPathFunc
+	oldAttach := attachCgroupFunc
+	detectCgroupPathFunc = func() (string, error) { return "/sys/fs/cgroup", nil }
+	var attachments []*fakeCgroupAttachment
+	attachCgroupFunc = func(ciliumLink.CgroupOptions) (cgroupAttachment, error) {
+		attachment := &fakeCgroupAttachment{}
+		attachments = append(attachments, attachment)
+		if len(attachments) == 3 {
+			return nil, fmt.Errorf("boom")
+		}
+		return attachment, nil
+	}
+	defer func() {
+		detectCgroupPathFunc = oldDetect
+		attachCgroupFunc = oldAttach
+	}()
+
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+	core := newControlPlaneCore(logger, &bpfObjects{
+		bpfPrograms: bpfPrograms{
+			TproxyWanCgSockCreate:  &ebpf.Program{},
+			TproxyWanCgSockRelease: &ebpf.Program{},
+			TproxyWanCgConnect4:    &ebpf.Program{},
+			TproxyWanCgConnect6:    &ebpf.Program{},
+			TproxyWanCgSendmsg4:    &ebpf.Program{},
+			TproxyWanCgSendmsg6:    &ebpf.Program{},
+		},
+	}, nil, nil, false)
+
+	if err := core.setupSkPidMonitor(); err == nil {
+		t.Fatal("setupSkPidMonitor() error = nil, want failure")
+	}
+	if got := len(core.bpfHookDetachFuncs); got != 0 {
+		t.Fatalf("len(bpfHookDetachFuncs) = %d, want 0 after rollback", got)
+	}
+	if got := attachments[0].closeCalls.Load(); got != 1 {
+		t.Fatalf("first attachment Close() calls = %d, want 1", got)
+	}
+	if got := attachments[1].closeCalls.Load(); got != 1 {
+		t.Fatalf("second attachment Close() calls = %d, want 1", got)
 	}
 }


### PR DESCRIPTION
## Summary

Post-commit datapath **self-healing**: after `commitInterfaceBindings`, verify TC filters on `dae0`(handle 0x2022) + LAN/WAN(handle 0x2023) are attached; if any are missing, **re-attach them automatically** instead of just failing.

### Problem

`bindLan`/`bindWan` use `_=c.addQdisc(link)` (best-effort). Missing clsact qdisc causes subsequent `FilterAdd` to fail **silently** — errors logged but do not propagate to abort reload. Result: **reload reports success, daemon running, nodes alive, but user traffic bypasses proxy entirely**. Exact pattern from #1013, reproduced in production on 2026-07-09 (reload at 15:27 → silent breakage → restart at 16:30).

### Fix — `repairDatapathBindings` (self-heal)

New functions in `controlPlaneCore`:

- **`checkBinding(bi)`**: Verifies a single bound interface via `netlink.FilterList()` (same API as `PurgeStaleTCFilters`), returns `(ok, reason)`.
- **`missingBindings() ([]boundIface, fatal)`**: Returns any interfaces whose TC filter is missing. Only `dae0` is treated as fatal.
- **`repairDatapathBindings() ([]string, fatal)`**: Detects missing filters → re-runs `_bindLan`/`_bindWan` for the missing interfaces → single re-check → if recovered, log at **Debug** (silent success); if still missing, returns the item for the caller to surface as a **Warn/error**.
- `recordBoundIface` is de-duplicated (name+label+major) so re-attach never produces duplicate records.

Called at **both** commit paths:
1. Non-deferred constructor → catches startup failures immediately
2. Deferred `CommitPreparedDatapath` → self-heals reload failures before cutover

Unlike a pure validator, this does **not** abort on a missing filter — it repairs first, and only reports if repair fails. Successful self-heal is logged at Debug level to stay quiet on every restart.

(Legacy `validateDatapathBindings` is kept as a thin formatting wrapper over `missingBindings` for backward compatibility.)

### Test Plan

| Step | Expected |
|------|----------|
| Normal start | All filters present, no re-attach, no noise |
| Remove clsact qdisc during reload | Self-heal re-attaches missing TC filters; success logged at Debug |
| Filter truly unattachable | Reported as still-missing (Warn/error) |
| Reload unchanged config | Passes (regression guard) |
| Reload health-check only | Passes (isolated from #1038) |

Relates: #1013 #1016 #1037 #1038