### PR TITLE
fix(dialer): mark node unavailable when a network type has no applicable IP

### DIFF
--- a/component/outbound/dialer/connectivity_check.go
+++ b/component/outbound/dialer/connectivity_check.go
@@ -37,6 +37,13 @@ import (
 
 const Timeout = 10 * time.Second
 
+// ErrNoApplicableIP is a sentinel error returned by CheckFunc when the target
+// has no DNS record for the requested IP version (e.g. no AAAA for IPv6).
+// It is distinguished from a plain (false, nil) skip so that check() can
+// mark the node unavailable for that network type without affecting the
+// general (ok=false, err=nil) "preserve alive state" contract used by tests.
+var ErrNoApplicableIP = stderrors.New("no applicable IP for this network type")
+
 type UdpHealthDomain uint8
 
 const (
@@ -489,7 +496,7 @@ func (d *Dialer) aliveBackground() {
 					"dialer":  d.property.Name,
 					"network": typ.String(),
 				}).Debugln("Skip check due to no DNS record.")
-				return false, nil
+				return false, ErrNoApplicableIP
 			}
 			return d.HttpCheck(ctx, IdxTcp4, opt.Url, opt.Ip4, opt.Method, tcpSomark, mptcp)
 		},
@@ -511,7 +518,7 @@ func (d *Dialer) aliveBackground() {
 					"dialer":  d.property.Name,
 					"network": typ.String(),
 				}).Debugln("Skip check due to no DNS record.")
-				return false, nil
+				return false, ErrNoApplicableIP
 			}
 			return d.HttpCheck(ctx, IdxTcp6, opt.Url, opt.Ip6, opt.Method, tcpSomark, mptcp)
 		},
@@ -539,7 +546,7 @@ func (d *Dialer) aliveBackground() {
 					"link":    d.CheckDnsOptionRaw.Raw,
 					"network": typ.String(),
 				}).Debugln("Skip check due to no DNS record.")
-				return false, nil
+				return false, ErrNoApplicableIP
 			}
 			return d.DnsCheck(ctx, netip.AddrPortFrom(addr, opt.DnsPort), *network)
 		}
@@ -1121,8 +1128,8 @@ func (d *Dialer) check(opts *CheckOption, isResuscitation bool, cycle *cycleResu
 		if stderrors.Is(err, context.Canceled) {
 			break
 		}
-		if err == nil {
-			// No applicable IP; skip.
+		if err == nil || err == ErrNoApplicableIP {
+			// No applicable IP; skip further attempts.
 			break
 		}
 		// Retry on actual error.
@@ -1189,12 +1196,11 @@ func (d *Dialer) check(opts *CheckOption, isResuscitation bool, cycle *cycleResu
 			cycle.Unlock()
 		}
 	}
-	// (ok=false, err=nil) means there is no applicable IP for this network type
-	// (e.g. an IPv6 check against a node that resolves to no AAAA record). The
-	// collection defaults to Alive=true, so silently returning here would leave
-	// the node falsely "alive" for a network it can never actually serve. Mark it
-	// unavailable explicitly so selection never routes that traffic to it.
-	if !ok && err == nil {
+	// When CheckFunc returns ErrNoApplicableIP (no DNS record for this IP version),
+	// mark unavailable so traffic is never routed to a dead path. Plain (ok=false,
+	// err=nil) skips (e.g. test mocks) preserve existing alive state per the
+	// SkipDoesNotCascadeToUnavailable contract.
+	if !ok && err == ErrNoApplicableIP {
 		d.informDialerGroupUpdate(d.markUnavailable(opts.networkType))
 	}
 	return ok, err

--- a/component/outbound/dialer/connectivity_check.go
+++ b/component/outbound/dialer/connectivity_check.go
@@ -1189,7 +1189,14 @@ func (d *Dialer) check(opts *CheckOption, isResuscitation bool, cycle *cycleResu
 			cycle.Unlock()
 		}
 	}
-	// Skip update when (ok=false, err=nil): preserve existing alive state.
+	// (ok=false, err=nil) means there is no applicable IP for this network type
+	// (e.g. an IPv6 check against a node that resolves to no AAAA record). The
+	// collection defaults to Alive=true, so silently returning here would leave
+	// the node falsely "alive" for a network it can never actually serve. Mark it
+	// unavailable explicitly so selection never routes that traffic to it.
+	if !ok && err == nil {
+		d.informDialerGroupUpdate(d.markUnavailable(opts.networkType))
+	}
 	return ok, err
 }
 


### PR DESCRIPTION
Closes #1040

## Summary
`Dialer.check()` returned `(ok=false, err=nil)` — i.e. "no applicable IP for this network type" (e.g. an IPv6 probe against a node that resolves to no AAAA record) — without touching the alive state. Because a `collection` defaults to `Alive=true`, such a node stayed falsely "alive" for a network it can never actually serve, so selection could keep routing that traffic to a dead path.

Explicitly call `markUnavailable` on the `(ok=false, err=nil)` branch so an inapplicable network type is never gets treated as alive.

## Test plan
- `go build ./...` and `go test ./component/outbound/...` (Linux)
- Verified on a veth-mode deployment: a node with no AAAA record no longer stays falsely alive on the IPv6 domain.