### PR TITLE
ci(release): fix missing '=' in pkg_arch assignment for i486/pacman

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -171,7 +171,7 @@ jobs:
                 case $pkg_mgr in
                   'deb') pkg_arch='i386' ;;
                   'rpm') pkg_arch='x86' ;;
-                  'pacman') pkg_arch'i486' ;;
+                  'pacman') pkg_arch='i486' ;;
                 esac ;;
               'arm64')
                 if [ $pkg_mgr == 'deb' ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,7 +171,7 @@ jobs:
                 case $pkg_mgr in
                   'deb') pkg_arch='i386' ;;
                   'rpm') pkg_arch='x86' ;;
-                  'pacman') pkg_arch'i486' ;;
+                  'pacman') pkg_arch='i486' ;;
                 esac ;;
               'arm64')
                 if [ $pkg_mgr == 'deb' ]; then


### PR DESCRIPTION
Closes #1041

## Summary
In the `'386'` arch case of the package-build step, the `pacman` branch wrote `pkg_arch'i486'` **without the `=` sign**, so the shell parsed it as a command named `pkg_arch` with argument `i486` instead of an assignment. The pacman target architecture was therefore never set, and i486/386 (`pkg_arch='i486'`) packages would be built with a wrong/empty arch.

Restore the missing `=` so the assignment takes effect.

This is an upstream bug present in v2.0.0 final (`fee4c866`); both `release.yml` and `prerelease.yml` are fixed.

## Test plan
- `grep -n "pkg_arch'i486'" .github/workflows/release.yml .github/workflows/prerelease.yml` now returns nothing.
- Only affects 386 Arch/pacman packaging (we do not build 386 in daily CI), so no runtime impact on other arches.