### PR TITLE
fix(control): guard core.Close() in closeTail with recover()

### DIFF
--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -3578,11 +3578,26 @@ func (c *ControlPlane) closeTail() error {
 
 	// Note: inConnections is cleared by AbortConnections() which should be called before Close()
 
-	// Combine defer errors with core.Close error
+	// Combine defer errors with core.Close error.
+	//
+	// Guard core.Close() with recover(): it performs netlink/BPF teardown and
+	// can panic on rare kernel/state edge cases. closeTail() is invoked from an
+	// async goroutine (see the `go func() { done <- c.closeTail() }()` caller
+	// with a 5s timeout), so an unrecovered panic there would crash that
+	// goroutine and surface only as an opaque timeout — losing the root cause.
+	// Recovering here keeps the shutdown/cleanup path best-effort and logs the
+	// actual panic for diagnosis.
 	if c.core != nil {
-		if coreErr := c.core.Close(); coreErr != nil {
-			errs = append(errs, coreErr)
-		}
+		func() {
+			defer func() {
+				if r := recover(); r != nil && c.log != nil {
+					c.log.Errorf("[Close] core.Close panicked (recovered): %v", r)
+				}
+			}()
+			if coreErr := c.core.Close(); coreErr != nil {
+				errs = append(errs, coreErr)
+			}
+		}()
 	}
 
 	// Note: ResetGlobalUdpState() is intentionally NOT called here.


### PR DESCRIPTION
## Summary
`closeTail()` is invoked from an async goroutine — the `go func() { done <- c.closeTail() }()` caller in `shutdownAfterSignalWithHandoff`, which enforces a 5s `controlPlaneDeferredCleanupTimeout`.

`core.Close()` performs netlink/BPF teardown and can panic on rare kernel/state edge cases. Because `closeTail()` runs inside that goroutine, an **unrecovered panic** there crashes the goroutine silently and only surfaces as an opaque 5s timeout — the real root cause is lost, making shutdown/reload failures hard to diagnose.

## Change
Wrap `core.Close()` in a `recover()` so the cleanup path stays best-effort: on panic we log `[Close] core.Close panicked (recovered): <reason>` and continue, instead of crashing the goroutine.

## Scope / notes
- Minimal, self-contained change to `closeTail()` only.
- No behavior change on the happy path; only affects the (rare) panic path.
- Targets the synchronous `core.Close()` call already on `main`; does not depend on any staged-handoff refactor.

## Test plan
- [ ] `go build ./...` (existing CI)
- Manual: trigger a reload and confirm no regression in shutdown logs; the recovered-panic branch is exercised only on an actual `core.Close()` panic (hard to trigger intentionally, defensive only).