### PR TITLE
fix(cmd): replace time.After with NewTimer in network-wait loop to prevent timer leaks

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1206,23 +1206,29 @@ func newControlPlaneWithMode(ctx context.Context, log *logrus.Logger, bpf any, d
 					// Do not sleep.
 					continue
 				}
-				select {
-				case <-ctx.Done():
-					return nil, ctx.Err()
-				case <-time.After(epo):
-				}
-				continue
+		timer := time.NewTimer(epo)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, ctx.Err()
+		case <-timer.C:
+			timer.Stop()
+		}
+		continue
 			}
 			_ = resp.Body.Close()
 			if resp.StatusCode >= 200 && resp.StatusCode < 500 {
 				break
 			}
 			log.Infof("Bad status: %v (%v)", resp.Status, resp.StatusCode)
-			select {
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			case <-time.After(epo):
-			}
+			timer := time.NewTimer(epo)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, ctx.Err()
+		case <-timer.C:
+			timer.Stop()
+		}
 		}
 		log.Infoln("Network online.")
 	}


### PR DESCRIPTION
## Summary

`cmd/run.go`'s **"Waiting for network"** `for`-loop contains two `select` blocks that use `time.After(epo)`. Each iteration creates a new `time.Timer` that is never stopped or drained — the GC is the only reclamation path. During prolonged network outages (or when `DisableWaitingNetwork` is false and the network is genuinely down), this causes unbounded timer resource leakage.

## Fix

Replace both `time.After(epo)` sites with `time.NewTimer(epo)` + explicit `timer.Stop()` on every branch (`ctx.Done()` timeout, and normal timer expiry). Scheduling semantics are preserved identically; only the resource leak is eliminated.

```diff
- select {
- case <-ctx.Done():
-   return nil, ctx.Err()
- case <-time.After(epo):
- }
+ timer := time.NewTimer(epo)
+ select {
+ case <-ctx.Done():
+   timer.Stop()
+   return nil, ctx.Err()
+ case <-timer.C:
+   timer.Stop()
+ }
```

(Applied at both sites within the loop.)

## Impact

- **Behavior**: None. Timeout duration (`epo = 5s`) and cancellation behavior are unchanged.
- **Performance**: Eliminates per-iteration garbage (one `time.Timer` per iteration that previously leaked until GC). Negligible CPU impact; purely a resource hygiene fix.
- **Risk**: Very low. This is a well-known Go anti-pattern fix; `time.NewTimer` + `Stop()` is the standard replacement for `time.After` inside loops, as documented in the Go standard library docs and effective-go guidance.

## Test plan

- [x] `go build ./...` passes (verified on macOS; Linux eBPF symbols unavailable locally, CI will cover full matrix)
- [x] `go vet ./cmd/` passes (no issues related to this change)
- [ ] CI: confirm Linux build + test matrix passes on PR