### PR TITLE
feat(config): add global.netkit_mode to choose capture device (auto/netkit/veth)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -48,6 +48,7 @@ type Global struct {
 	TlsFragmentInterval    string        `mapstructure:"tls_fragment_interval" default:"10-20"`
 	PprofPort              uint16        `mapstructure:"pprof_port" default:"0"`
 	Mptcp                  bool          `mapstructure:"mptcp" default:"false"`
+	NetkitMode             string        `mapstructure:"netkit_mode" default:"auto"`
 	BootstrapResolver      string        `mapstructure:"bootstrap_resolver"`
 	FallbackResolver       string        `mapstructure:"fallback_resolver" default:"8.8.8.8:53"`
 	BandwidthMaxTx         string        `mapstructure:"bandwidth_max_tx" default:"0"`

--- a/config/desc.go
+++ b/config/desc.go
@@ -52,8 +52,13 @@ var GlobalDesc = Desc{
 2. "domain". Dial proxy using the domain from sniffing. This will relieve DNS pollution problem to a great extent if have impure DNS environment. Generally, this mode brings faster proxy response time because proxy will re-resolve the domain in remote, thus get better IP result to connect. This policy does not impact routing. That is to say, domain rewrite will be after traffic split of routing and dae will not re-route it.
 3. "domain+". Based on domain mode but do not check the reality of sniffed domain. It is useful for users whose DNS requests do not go through dae but want faster proxy response time. Notice that, if DNS requests do not go through dae, dae cannot split traffic by domain.
 4. "domain++". Based on domain+ mode but force to re-route traffic using sniffed domain to partially recover domain based traffic split ability. It doesn't work for direct traffic and consumes more CPU resources.`,
-	"disable_waiting_network":      "Disable waiting for network before pulling subscriptions.",
-	"disable_thp":                  "Disable transparent huge pages for the dae process. This reduces RSS inflation for dae userspace memory without changing system-wide THP settings.",
+	"disable_waiting_network": "Disable waiting for network before pulling subscriptions.",
+	"disable_thp":             "Disable transparent huge pages for the dae process. This reduces RSS inflation for dae userspace memory without changing system-wide THP settings.",
+	"netkit_mode": `Capture device mode for the dae0<->dae0peer pair. Optional values:
+1. "auto" (default). Use Netkit on kernels 6.7+ (preserves skb->mark across the device boundary for better firewall-mark handling) and fall back to veth on older kernels or when Netkit creation fails.
+2. "netkit". Force Netkit (performance mode). dae fails to start if the kernel does not support Netkit (requires 6.7+ with CONFIG_NETKIT).
+3. "veth". Force veth (compatibility mode). Use this to work around Netkit issues such as #1024 (interface index drift causing silent redirect failures).
+You can also set the DAE_DISABLE_NETKIT=1 environment variable to force veth in "auto" mode, which is handy for container/immutable deployments where editing the config file is inconvenient.`,
 	"auto_config_kernel_parameter": "Automatically configure Linux kernel parameters like ip_forward and send_redirects. Check out https://github.com/daeuniverse/dae/blob/main/docs/en/user-guide/kernel-parameters.md to see what will dae do.",
 	"sniffing_timeout":             "Timeout to waiting for first data sending for sniffing. It is always 0 if dial_mode is ip. Default 30ms is suitable for most networks. Increase to 100-300ms for high-latency networks.",
 	"tls_implementation":           "TLS implementation. \"tls\" is to use Go's crypto/tls. \"utls\" is to use uTLS, which can imitate browser's Client Hello.",

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -431,7 +431,7 @@ func newControlPlaneWithContextOptions(
 		return nil, fmt.Errorf("rlimit.RemoveMemlock:%v", err)
 	}
 
-	InitDaeNetns(log)
+	InitDaeNetns(log, global.NetkitMode)
 	if err = InitSysctlManager(log); err != nil {
 		return nil, err
 	}

--- a/control/netns_utils.go
+++ b/control/netns_utils.go
@@ -43,7 +43,8 @@ var (
 type DaeNetns struct {
 	log           *logrus.Logger
 	kernelVersion *internal.Version
-	useNetkit     bool // Whether Netkit device is being used
+	useNetkit     bool   // Whether Netkit device is being used
+	netkitMode    string // Capture device mode from global.netkit_mode: auto, netkit, veth
 
 	setupDone atomic.Bool
 	mu        sync.Mutex
@@ -52,11 +53,12 @@ type DaeNetns struct {
 	hostNs, daeNs  netns.NsHandle
 }
 
-func InitDaeNetns(log *logrus.Logger) {
+func InitDaeNetns(log *logrus.Logger, netkitMode string) {
 	once.Do(func() {
 		daeNetns = &DaeNetns{}
 	})
 	daeNetns.log = log
+	daeNetns.netkitMode = netkitMode
 	// Initialize kernel version for Netkit support detection
 	kernelVersion, err := internal.KernelVersion()
 	if err != nil {
@@ -170,40 +172,66 @@ func (ns *DaeNetns) supportsNetkit() bool {
 	return !ns.kernelVersion.Less(consts.NetkitFeatureVersion)
 }
 
-// setupVethOrNetkit creates a veth or Netkit device pair based on kernel support.
-// It tries Netkit first (kernel 6.7+) and falls back to veth if Netkit fails.
+// setupVethOrNetkit creates a veth or Netkit device pair according to global.netkit_mode.
+//
+//   - "veth":   force veth (compatibility mode).
+//   - "netkit": force Netkit; fails to start if the kernel does not support it.
+//   - "auto" (or empty): try Netkit on kernels 6.7+ and fall back to veth on
+//     failure. DAE_DISABLE_NETKIT=1 forces veth in auto mode (handy for
+//     container/immutable deployments).
 func (ns *DaeNetns) setupVethOrNetkit() (err error) {
-	// Try Netkit first if kernel supports it
-	if ns.supportsNetkit() {
-		ns.log.Infof("Kernel %s supports Netkit, attempting to create Netkit device pair",
-			ns.kernelVersion.String())
-		err := ns.tryCreateNetkit()
-		if err == nil {
-			ns.useNetkit = true
-			ns.log.Infof("Successfully created Netkit device pair (performance mode)")
-			return nil
+	switch ns.netkitMode {
+	case "veth":
+		ns.log.Info("netkit_mode=veth: forcing veth device creation (compatibility mode)")
+		ns.useNetkit = false
+		if err = ns.setupVeth(); err != nil {
+			return fmt.Errorf("failed to create veth device: %w", err)
 		}
-		// Netkit failed, fall back to veth
-		ns.log.WithFields(logrus.Fields{
-			"error":  err.Error(),
-			"kernel": ns.kernelVersion.String(),
-		}).Warn("Failed to create Netkit device, falling back to veth")
+		ns.log.Info("Created veth device pair (compatibility mode)")
+		return nil
+	case "netkit":
+		if !ns.supportsNetkit() {
+			return fmt.Errorf("netkit_mode=netkit requires kernel %s+ with CONFIG_NETKIT, but current kernel is %s; use netkit_mode=veth or upgrade the kernel",
+				consts.NetkitFeatureVersion.String(), ns.kernelVersion.String())
+		}
+		ns.useNetkit = true
+		if err = ns.tryCreateNetkit(); err != nil {
+			return fmt.Errorf("netkit_mode=netkit: failed to create Netkit device: %w", err)
+		}
+		ns.log.Info("Successfully created Netkit device pair (performance mode)")
+		return nil
+	case "auto", "":
+		// Default: try Netkit on supported kernels, fall back to veth.
+		if os.Getenv("DAE_DISABLE_NETKIT") == "1" {
+			ns.log.Warn("Netkit disabled (DAE_DISABLE_NETKIT=1 set); falling back to veth")
+		} else if ns.supportsNetkit() {
+			ns.log.Infof("Kernel %s supports Netkit, attempting to create Netkit device pair",
+				ns.kernelVersion.String())
+			if err = ns.tryCreateNetkit(); err == nil {
+				ns.useNetkit = true
+				ns.log.Info("Successfully created Netkit device pair (performance mode)")
+				return nil
+			}
+			ns.log.WithFields(logrus.Fields{
+				"error":  err.Error(),
+				"kernel": ns.kernelVersion.String(),
+			}).Warn("Failed to create Netkit device, falling back to veth")
+		}
+		ns.log.Info("Falling back to veth device creation")
+		ns.useNetkit = false
+		if err = ns.setupVeth(); err != nil {
+			return fmt.Errorf("failed to create veth device: %w", err)
+		}
+		if ns.supportsNetkit() {
+			ns.log.Info("Created veth device pair (compatibility mode; Netkit was attempted but failed)")
+		} else {
+			ns.log.Infof("Created veth device pair (kernel %s does not support Netkit)",
+				ns.kernelVersion.String())
+		}
+		return nil
+	default:
+		return fmt.Errorf("invalid global.netkit_mode %q: want auto, netkit or veth", ns.netkitMode)
 	}
-
-	// Fall back to veth
-	ns.log.Info("Falling back to veth device creation")
-	ns.useNetkit = false
-	if err := ns.setupVeth(); err != nil {
-		return fmt.Errorf("failed to create veth device: %w", err)
-	}
-
-	if ns.supportsNetkit() {
-		ns.log.Infof("Created veth device pair (compatibility mode; Netkit was attempted but failed)")
-	} else {
-		ns.log.Infof("Created veth device pair (kernel %s does not support Netkit)",
-			ns.kernelVersion.String())
-	}
-	return nil
 }
 
 // tryCreateNetkit attempts to create a Netkit device pair.


### PR DESCRIPTION
## Summary

Previously the capture device mode (Netkit vs veth for the `dae0<->dae0peer` pair) was decided **only** by kernel version — Netkit on 6.7+, otherwise veth — with no user-facing way to override it. This PR exposes it as a first-class config option in the `global` section.

```dae
global {
  log_level: info
  netkit_mode: auto   # auto (default) | netkit | veth
}
```

### Modes
- `auto` (default): try Netkit on kernels 6.7+, fall back to veth on failure — **identical to today's behavior**.
- `netkit`: force Netkit (performance mode, preserves `skb->mark` across the device boundary); fails to start if the kernel does not support it (requires 6.7+ with `CONFIG_NETKIT`).
- `veth`: force veth (compatibility mode). This is the escape hatch for Netkit issues such as #1024 (interface index drift causing silent eBPF redirect failures after hours of uptime).

### Deployment convenience
`DAE_DISABLE_NETKIT=1` is still honored in `auto` mode, so container/immutable deployments can force veth without editing the config file.

## Why

Some users need explicit control over the capture device:
- Kernels < 6.7 can only use veth anyway, but making the choice explicit is clearer.
- #1024 shows Netkit can silently break on certain setups; a first-class `veth` option lets users opt out of performance mode without kernel downgrades or hidden env vars.

## Backward compatibility

Omitting `netkit_mode` defaults to `auto`, so existing configs are unaffected.

## Test plan

- [x] `go build ./config/...` passes.
- [x] gofmt clean.
- [ ] Full `make` (eBPF objects) is built by CI; the change only touches config parsing and the netns device-selection logic.

Closes #1024 (provides a config-level workaround; the root-cause ifindex-drift heal is tracked separately).