### PR TITLE
fix(control): delete stale flipped TC filter on reload (make-before-break)

### DIFF
--- a/control/control_plane_core.go
+++ b/control/control_plane_core.go
@@ -495,6 +495,16 @@ func (c *controlPlaneCore) _bindLan(ifname string) error {
 	if err := netlink.FilterAdd(filterIngress); err != nil && !errors.Is(err, unix.EEXIST) {
 		return fmt.Errorf("cannot attach ebpf object to filter ingress: %w", err)
 	}
+	if c.isReload {
+		// make-before-break: the new generation's filter is attached above;
+		// because reload reuses the same BPF program, both flip handles point
+		// at the same program, so deleting the previous generation's flipped
+		// filter now leaves no datapath gap. Doing it eagerly (instead of
+		// waiting for the retiring generation's async teardown) prevents a
+		// stale TC handle from lingering on the interface and black-holing
+		// the datapath.
+		tryDeleteFlippedFilter(filterIngress)
+	}
 	detachFunc := func() error {
 		if err := netlink.FilterDel(filterIngress); err != nil && !os.IsNotExist(err) && !errors.Is(err, unix.ENODEV) {
 			return fmt.Errorf("FilterDel(%v:%v): %w", ifname, filterIngress.Name, err)
@@ -530,6 +540,16 @@ func (c *controlPlaneCore) _bindLan(ifname string) error {
 	}
 	if err := netlink.FilterAdd(filterEgress); err != nil && !errors.Is(err, unix.EEXIST) {
 		return fmt.Errorf("cannot attach ebpf object to filter egress: %w", err)
+	}
+	if c.isReload {
+		// make-before-break: the new generation's filter is attached above;
+		// because reload reuses the same BPF program, both flip handles point
+		// at the same program, so deleting the previous generation's flipped
+		// filter now leaves no datapath gap. Doing it eagerly (instead of
+		// waiting for the retiring generation's async teardown) prevents a
+		// stale TC handle from lingering on the interface and black-holing
+		// the datapath.
+		tryDeleteFlippedFilter(filterEgress)
 	}
 	egressDetachFunc := func() error {
 		if err := netlink.FilterDel(filterEgress); err != nil && !os.IsNotExist(err) && !errors.Is(err, unix.ENODEV) {
@@ -707,6 +727,16 @@ func (c *controlPlaneCore) _bindWan(ifname string) error {
 	if err := netlink.FilterAdd(filterEgress); err != nil && !errors.Is(err, unix.EEXIST) {
 		return fmt.Errorf("cannot attach ebpf object to filter egress: %w", err)
 	}
+	if c.isReload {
+		// make-before-break: the new generation's filter is attached above;
+		// because reload reuses the same BPF program, both flip handles point
+		// at the same program, so deleting the previous generation's flipped
+		// filter now leaves no datapath gap. Doing it eagerly (instead of
+		// waiting for the retiring generation's async teardown) prevents a
+		// stale TC handle from lingering on the interface and black-holing
+		// the datapath.
+		tryDeleteFlippedFilter(filterEgress)
+	}
 	egressDetachFunc := func() error {
 		if err := netlink.FilterDel(filterEgress); err != nil && !os.IsNotExist(err) && !errors.Is(err, unix.ENODEV) {
 			return fmt.Errorf("FilterDel(%v:%v): %w", ifname, filterEgress.Name, err)
@@ -740,6 +770,16 @@ func (c *controlPlaneCore) _bindWan(ifname string) error {
 	}
 	if err := netlink.FilterAdd(filterIngress); err != nil && !errors.Is(err, unix.EEXIST) {
 		return fmt.Errorf("cannot attach ebpf object to filter ingress: %w", err)
+	}
+	if c.isReload {
+		// make-before-break: the new generation's filter is attached above;
+		// because reload reuses the same BPF program, both flip handles point
+		// at the same program, so deleting the previous generation's flipped
+		// filter now leaves no datapath gap. Doing it eagerly (instead of
+		// waiting for the retiring generation's async teardown) prevents a
+		// stale TC handle from lingering on the interface and black-holing
+		// the datapath.
+		tryDeleteFlippedFilter(filterIngress)
 	}
 	ingressDetachFunc := func() error {
 		if err := netlink.FilterDel(filterIngress); err != nil && !os.IsNotExist(err) && !errors.Is(err, unix.ENODEV) {
@@ -806,6 +846,21 @@ func (c *controlPlaneCore) bindDaens() (err error) {
 	}); err != nil {
 		return fmt.Errorf("cannot attach ebpf object to filter ingress: %w", err)
 	}
+	if c.isReload {
+		// make-before-break: delete the previous generation's flipped filter
+		// now that the new one is attached (reload shares the BPF program, so
+		// there is no datapath gap). Prevents a stale TC handle from
+		// black-holing the datapath. Mirrors the non-reload branch above.
+		filterIngressFlippedReload := deepcopy.Copy(filterDae0peerIngress).(*netlink.BpfFilter)
+		filterIngressFlippedReload.Handle ^= 1
+		daens.WithBestEffort("delete flipped dae0peer ingress filter (reload)", func() error {
+			err := netlink.FilterDel(filterIngressFlippedReload)
+			if errors.Is(err, unix.ENOENT) || errors.Is(err, unix.ESRCH) {
+				return nil
+			}
+			return err
+		})
+	}
 	detachFunc := func() error {
 		return daens.WithRequired("delete dae0peer ingress filter", func() error {
 			if err := netlink.FilterDel(filterDae0peerIngress); err != nil && !os.IsNotExist(err) && !errors.Is(err, unix.ENODEV) {
@@ -839,6 +894,16 @@ func (c *controlPlaneCore) bindDaens() (err error) {
 	}
 	if err := netlink.FilterAdd(filterDae0Ingress); err != nil && !errors.Is(err, unix.EEXIST) {
 		return fmt.Errorf("cannot attach ebpf object to filter ingress: %w", err)
+	}
+	if c.isReload {
+		// make-before-break: the new generation's filter is attached above;
+		// because reload reuses the same BPF program, both flip handles point
+		// at the same program, so deleting the previous generation's flipped
+		// filter now leaves no datapath gap. Doing it eagerly (instead of
+		// waiting for the retiring generation's async teardown) prevents a
+		// stale TC handle from lingering on the interface and black-holing
+		// the datapath.
+		tryDeleteFlippedFilter(filterDae0Ingress)
 	}
 	dae0DetachFunc := func() error {
 		if err := netlink.FilterDel(filterDae0Ingress); err != nil && !os.IsNotExist(err) && !errors.Is(err, unix.ENODEV) {


### PR DESCRIPTION
### Background

On reload, dae keeps the process alive (SIGUSR1 -> staged handoff) and re-binds the datapath with the flip bit toggled. The new generation attaches its TC filters at the opposite low-bit handle, while the **previous generation's flipped filters are left on the interface** until that generation is torn down asynchronously.

During (and after) that window the interface ends up with **two BPF filters per hook** at the same priority. Observed on a bypass-router (tc/veth datapath) after a single `dae reload <pid>`:

```
# eth0 ingress after reload (before this fix)
handle 0x20230003 dae_wan_ingress_l2 ... id 827
handle 0x20230002 dae_wan_ingress_l2 ... id 827   <-- stale flipped filter, never removed
handle 0x20230005 dae_lan_ingress_l2 ... id 815
handle 0x20230004 dae_lan_ingress_l2 ... id 815   <-- stale flipped filter, never removed
```

The stale handle keeps referencing a program view from the retiring generation. Under the tc/veth datapath this can turn the client-forwarding datapath into a black hole until a full `restart` re-purges and re-attaches fresh filters. The existing cleanup that removes the flipped filter (`tryDeleteFlippedFilter`) is gated behind `!c.isReload`, so it never runs on the reload path.

This is complementary to #1039: #1039 self-heals **missing** filters; this PR removes **stale duplicate** filters left behind on reload.

### Fix

Because reload reuses the same BPF program (`sharedBpfReload`), the new and old flip handles reference the *same* program. So the new generation can bind its filter first and then immediately delete the previous generation's flipped filter **without opening a datapath gap** (make-before-break).

After `FilterAdd` on the reload path, delete the flipped filter at every TC binding point: LAN ingress/egress, WAN egress/ingress, dae0peer ingress, dae0 ingress. Non-reload startup behaviour is unchanged (it still pre-deletes the flipped filter before add).

### Validation

Built with the real BPF objects (CI) and deployed to a bypass router running the veth datapath (`DAE_DISABLE_NETKIT=1`).

```
# eth0 ingress after reload (with this fix)
handle 0x20230003 dae_wan_ingress_l2 ... id 849   <-- single filter per hook
handle 0x20230005 dae_lan_ingress_l2 ... id 837   <-- stale 0x...0002/0x...0004 removed
```

- Before: reload -> 2 filters per hook (stale flipped lingers).
- After: reload -> exactly 1 filter per hook across repeated reloads; traffic (verified with proxied `curl`, HTTP 200) survives every reload; process PID stays stable (in-place reload confirmed).

### Notes

- `checkVersionRequirement`, priorities and handles are untouched; the only behavioural change is *when* the flipped-filter delete runs (also on reload, after the new filter is attached).
- Signed-off in the commit.
