### PR TITLE
control: program-aware datapath self-heal (supersedes #1039)

### DIFF
--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -815,6 +815,19 @@ func newControlPlaneWithContextOptions(
 		if err = plane.commitInterfaceBindings(); err != nil {
 			return nil, err
 		}
+		// Confirm TC filters are actually attached. A silent bind failure
+		// (e.g. missing clsact qdisc, interface disappeared) would otherwise
+		// cause traffic to bypass the proxy with no error. Missing LAN/WAN
+		// filters are auto re-attached (self-heal); a missing dae0 aborts.
+		if plane.core != nil {
+			if missing, fatal := plane.core.repairDatapathBindings(); len(missing) > 0 {
+				msg := fmt.Sprintf("datapath validation failed after interface binding (self-heal could not recover): %v", missing)
+				if fatal {
+					return nil, fmt.Errorf("%s", msg)
+				}
+				plane.log.Warnf("%s", msg)
+			}
+		}
 		if plane.sharedBpfReload {
 			if err = clearReloadDomainRoutingMap(core.bpf.Load()); err != nil {
 				return nil, fmt.Errorf("clearReloadDomainRoutingMap: %w", err)
@@ -1369,6 +1382,10 @@ func (c *ControlPlane) commitInterfaceBindings() error {
 	if c == nil || c.core == nil {
 		return nil
 	}
+	// Start each commit with a clean slate so validation only checks the
+	// interfaces bound during this run (e.g. after a reload with a changed
+	// LAN/WAN set).
+	c.core.resetBoundIfaces()
 
 	if len(c.lanInterface) > 0 {
 		if c.autoConfigKernelParameter {
@@ -1455,6 +1472,19 @@ func (c *ControlPlane) CommitPreparedDatapath() error {
 	}
 	if err := c.commitInterfaceBindings(); err != nil {
 		return err
+	}
+	// Confirm TC filters are actually attached (mirrors NewControlPlane). A
+	// silent bind failure would let traffic bypass the proxy with no error.
+	// Missing LAN/WAN filters are auto re-attached (self-heal); a missing dae0
+	// aborts.
+	if c.core != nil {
+		if missing, fatal := c.core.repairDatapathBindings(); len(missing) > 0 {
+			msg := fmt.Sprintf("datapath validation failed after interface binding (self-heal could not recover): %v", missing)
+			if fatal {
+				return fmt.Errorf("%s", msg)
+			}
+			c.log.Warnf("%s", msg)
+		}
 	}
 	if c.routingKernspaceSnapshot != nil {
 		c.log.Infoln("Loading routing rules into kernel space (BPF)...")

--- a/control/control_plane_core.go
+++ b/control/control_plane_core.go
@@ -123,6 +123,17 @@ type controlPlaneCore struct {
 	domainRouting       *domainRoutingTracker
 	lpmTrieIndices      []uint32
 	bpfOwned            bool
+
+	// datapathIfaces records the interfaces successfully bound during the last
+	// commitInterfaceBindings run, paired with the full TC filter handle(s) and
+	// the BPF program each filter is expected to attach. validateDatapathBindings
+	// / repairDatapathBindings use it to confirm the dataplane is actually
+	// attached and healthy after startup/reload, catching silent bind failures
+	// (e.g. a missing clsact qdisc) that would otherwise let traffic bypass the
+	// proxy with no error.
+	datapathIfaces []boundIface
+	// datapathMu protects datapathIfaces from concurrent reads during validation.
+	datapathMu sync.Mutex
 }
 
 func newControlPlaneCore(log *logrus.Logger,
@@ -539,6 +550,22 @@ func (c *controlPlaneCore) _bindLan(ifname string) error {
 	}
 	c.addManagedBpfHookCleanup(egressDetachFunc)
 
+	// Record the LAN binding (ingress + egress) with the expected BPF program
+	// so validateDatapathBindings / repairDatapathBindings can confirm the
+	// dataplane is actually attached and points to the live program.
+	var lanIngressProg, lanEgressProg *ebpf.Program
+	if linkHdrLen > 0 {
+		lanIngressProg = bpf.TproxyLanIngressL2
+		lanEgressProg = bpf.TproxyLanEgressL2
+	} else {
+		lanIngressProg = bpf.TproxyLanIngressL3
+		lanEgressProg = bpf.TproxyLanEgressL3
+	}
+	c.recordBoundIface(ifname, "LAN",
+		boundFilter{handle: netlink.MakeHandle(0x2023, 0b100+uint16(c.flip)), prog: lanIngressProg},
+		boundFilter{handle: netlink.MakeHandle(0x2023, 0b010+uint16(c.flip)), prog: lanEgressProg},
+	)
+
 	return nil
 }
 
@@ -749,6 +776,20 @@ func (c *controlPlaneCore) _bindWan(ifname string) error {
 	}
 	c.addManagedBpfHookCleanup(ingressDetachFunc)
 
+	// Record the WAN binding (egress + ingress) with the expected BPF program.
+	var wanEgressProg, wanIngressProg *ebpf.Program
+	if linkHdrLen > 0 {
+		wanEgressProg = bpf.TproxyWanEgressL2
+		wanIngressProg = bpf.TproxyWanIngressL2
+	} else {
+		wanEgressProg = bpf.TproxyWanEgressL3
+		wanIngressProg = bpf.TproxyWanIngressL3
+	}
+	c.recordBoundIface(ifname, "WAN",
+		boundFilter{handle: netlink.MakeHandle(0x2023, 0b100+uint16(c.flip)), prog: wanEgressProg},
+		boundFilter{handle: netlink.MakeHandle(0x2023, 0b010+uint16(c.flip)), prog: wanIngressProg},
+	)
+
 	return nil
 }
 
@@ -847,6 +888,14 @@ func (c *controlPlaneCore) bindDaens() (err error) {
 		return nil
 	}
 	c.addManagedBpfHookCleanup(dae0DetachFunc)
+
+	// Record the dae0 peer (in the dae netns) and dae0 (host netns) bindings
+	// with the expected BPF program so validateDatapathBindings can confirm
+	// they are actually attached and healthy.
+	c.recordBoundIface(daens.Dae0Peer().Attrs().Name, "dae0peer",
+		boundFilter{handle: netlink.MakeHandle(0x2022, 0b010+uint16(c.flip)), prog: bpf.TproxyDae0peerIngress})
+	c.recordBoundIface(daens.Dae0().Attrs().Name, "dae0",
+		boundFilter{handle: netlink.MakeHandle(0x2022, 0b010+uint16(c.flip)), prog: bpf.TproxyDae0Ingress})
 	return
 }
 
@@ -857,6 +906,294 @@ func tryDeleteFlippedFilter(f *netlink.BpfFilter) {
 	flipped := deepcopy.Copy(f).(*netlink.BpfFilter)
 	flipped.Handle ^= 1
 	_ = netlink.FilterDel(flipped)
+}
+
+// boundFilter pairs a TC filter handle with the BPF program that filter is
+// expected to attach. Recording the program lets validation detect "zombie"
+// filters — a filter whose handle is present but which points to a different /
+// stale / unloaded BPF program (e.g. after a BPF reload swapped the program
+// under a persistently-attached handle), which a handle-only check would miss.
+type boundFilter struct {
+	handle uint32
+	prog   *ebpf.Program
+}
+
+// boundIface is an interface that was successfully bound, paired with the full
+// TC filter handle(s) and the expected BPF program(s) for each. LAN/WAN carry
+// two filters (ingress + egress) under the same major but different minor, so
+// filters is a slice: every listed filter must be present AND point to the
+// expected program for the binding to be considered healthy.
+type boundIface struct {
+	name    string
+	label   string
+	filters []boundFilter
+}
+
+// linkByName looks up a network interface by name. It is a package-level
+// variable (defaulting to netlink.LinkByName) so tests can substitute a mock.
+var linkByName = netlink.LinkByName
+
+// recordBoundIface records a successfully bound interface so that a later
+// validateDatapathBindings call can confirm its TC filter(s) are attached and
+// point to the expected program. Duplicate (name+label+filters) entries are
+// ignored, which keeps the recorded set stable when an interface is re-bound
+// during self-heal.
+func (c *controlPlaneCore) recordBoundIface(name, label string, filters ...boundFilter) {
+	c.datapathMu.Lock()
+	defer c.datapathMu.Unlock()
+	for _, b := range c.datapathIfaces {
+		if b.name == name && b.label == label && equalBoundFilters(b.filters, filters) {
+			return
+		}
+	}
+	c.datapathIfaces = append(c.datapathIfaces, boundIface{name: name, label: label, filters: filters})
+}
+
+// equalBoundFilters reports whether two boundFilter slices contain the same
+// handle+program pairs in the same order.
+func equalBoundFilters(a, b []boundFilter) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].handle != b[i].handle || a[i].prog != b[i].prog {
+			return false
+		}
+	}
+	return true
+}
+
+// resetBoundIfaces clears the recorded bindings so each commitInterfaceBindings
+// run validates only the interfaces bound during that run.
+func (c *controlPlaneCore) resetBoundIfaces() {
+	c.datapathMu.Lock()
+	c.datapathIfaces = nil
+	c.datapathMu.Unlock()
+}
+
+// checkBindingInNetns performs the actual link lookup and TC-filter check for
+// bi in whatever network namespace the caller is currently executing in. Every
+// filter recorded for bi must be attached AND (when a program is expected) must
+// point to that program; the first one that fails is reported. It is separated
+// from checkBinding so the dae0peer case can run it inside the dae netns (via
+// GetDaeNetns().WithRequired), while all host-netns interfaces run it directly.
+func (c *controlPlaneCore) checkBindingInNetns(bi boundIface) (ok bool, reason string) {
+	link, err := linkByName(bi.name)
+	if err != nil {
+		return false, fmt.Sprintf("%s (%s, link not found)", bi.name, bi.label)
+	}
+	// dae0/dae0peer attach only an ingress filter; LAN/WAN attach both ingress
+	// and egress. Scope the enumeration accordingly to skip a wasted FilterList.
+	parents := []uint32{netlink.HANDLE_MIN_INGRESS, netlink.HANDLE_MIN_EGRESS}
+	if bi.label == "dae0" || bi.label == "dae0peer" {
+		parents = []uint32{netlink.HANDLE_MIN_INGRESS}
+	}
+	for _, f := range bi.filters {
+		if !hasDaeTcFilter(link, f.handle, parents, f.prog) {
+			return false, fmt.Sprintf("%s (%s, handle 0x%x missing or program mismatch)", bi.name, bi.label, f.handle)
+		}
+	}
+	return true, ""
+}
+
+// checkBinding reports whether the TC filter(s) for bi are actually attached
+// and healthy, returning a human-readable reason when not. dae0peer lives
+// inside the dae netns (host-netns linkByName cannot see it), so its check is
+// executed there; all other interfaces are resolved in the host netns.
+func (c *controlPlaneCore) checkBinding(bi boundIface) (ok bool, reason string) {
+	if bi.label == "dae0peer" {
+		ns := GetDaeNetns()
+		if ns == nil {
+			// Defensive: the dae netns must exist by the time bindings are
+			// validated, but a nil receiver here would panic the whole check.
+			return false, fmt.Sprintf("%s (%s): dae netns not yet initialised", bi.name, bi.label)
+		}
+		var innerOk bool
+		var innerReason string
+		if err := ns.WithRequired("check dae0peer binding", func() error {
+			innerOk, innerReason = c.checkBindingInNetns(bi)
+			return nil
+		}); err != nil {
+			return false, fmt.Sprintf("%s (%s, dae netns error: %v)", bi.name, bi.label, err)
+		}
+		return innerOk, innerReason
+	}
+	return c.checkBindingInNetns(bi)
+}
+
+// missingBindings returns the recorded interfaces whose TC filter is not
+// actually attached/healthy, plus whether a *fatal* binding (dae0) is among
+// them. dae0 is created and fully controlled by dae, so a missing or zombie
+// dae0 filter means the transparent proxy cannot function at all; LAN/WAN
+// depend on the host environment (e.g. clsact availability) and are not fatal.
+func (c *controlPlaneCore) missingBindings() (missing []boundIface, fatal bool) {
+	c.datapathMu.Lock()
+	ifaces := make([]boundIface, len(c.datapathIfaces))
+	copy(ifaces, c.datapathIfaces)
+	c.datapathMu.Unlock()
+
+	for _, bi := range ifaces {
+		if ok, _ := c.checkBinding(bi); !ok {
+			missing = append(missing, bi)
+			if bi.label == "dae0" {
+				fatal = true
+			}
+		}
+	}
+	return missing, fatal
+}
+
+// validateDatapathBindings is a diagnostic entry point used by unit tests to
+// assert that all recorded TC filters are attached and healthy. In production
+// the bind path uses missingBindings()/repairDatapathBindings() instead; this
+// helper is intentionally not part of the live startup/reload flow.
+func (c *controlPlaneCore) validateDatapathBindings() (missing []string, fatal bool) {
+	bad, fatal := c.missingBindings()
+	for _, bi := range bad {
+		_, reason := c.checkBinding(bi)
+		missing = append(missing, reason)
+	}
+	return missing, fatal
+}
+
+// rebindLanFn / rebindWanFn are package-level indirection over the actual bind
+// functions so unit tests can substitute stubs without touching the real
+// netlink stack. In production they call _bindLan / _bindWan directly (which
+// ensure the clsact qdisc and re-attach the filter, both idempotent).
+var rebindLanFn = func(c *controlPlaneCore, name string) error { return c._bindLan(name) }
+var rebindWanFn = func(c *controlPlaneCore, name string) error { return c._bindWan(name) }
+
+// repairDatapathBindings detects missing/unhealthy TC filters and attempts to
+// re-attach them automatically (self-heal) for LAN/WAN interfaces, then
+// re-validates once. dae0/dae0peer are intentionally never self-healed: a
+// missing or zombie dae0 filter is a fatal, deep failure and is reported so the
+// caller can abort; dae0peer is surfaced as a (non-fatal) warning so operators
+// keep visibility.
+//
+// It returns the interfaces that are *still* missing/unhealthy after the
+// re-attach attempt, plus fatal (true only when dae0 is among the
+// still-missing), so callers keep the existing fatal/warning policy unchanged:
+//   - dae0 missing/zombie -> fatal -> caller aborts startup/reload
+//   - LAN/WAN missing but re-attached -> silently recovered
+//   - LAN/WAN missing and re-attach failed -> warning, proxy keeps running
+func (c *controlPlaneCore) repairDatapathBindings() (stillMissing []string, fatal bool) {
+	bad, _ := c.missingBindings()
+	if len(bad) == 0 {
+		return nil, false
+	}
+	repairedCount := 0
+	for _, bi := range bad {
+		switch bi.label {
+		case "LAN":
+			if err := rebindLanFn(c, bi.name); err != nil {
+				c.log.Warnf("datapath self-heal: failed to re-bind LAN %s: %v", bi.name, err)
+			} else {
+				repairedCount++
+			}
+		case "WAN":
+			if err := rebindWanFn(c, bi.name); err != nil {
+				c.log.Warnf("datapath self-heal: failed to re-bind WAN %s: %v", bi.name, err)
+			} else {
+				repairedCount++
+			}
+		case "dae0peer":
+			// dae0peer lives in the dae netns and is created/controlled by dae,
+			// like dae0. It is not self-healed here; a missing/zombie dae0peer
+			// filter is surfaced as a (non-fatal) warning so operators keep
+			// visibility.
+		}
+		// dae0: not self-healed.
+	}
+	// Re-check once (single pass, no retry loop to avoid livelock).
+	stillBad, fatal := c.missingBindings()
+	for _, bi := range stillBad {
+		_, reason := c.checkBinding(bi)
+		stillMissing = append(stillMissing, reason)
+	}
+	if len(stillMissing) == 0 {
+		if repairedCount > 0 {
+			c.log.Infof("datapath self-heal: recovered %d missing TC filter(s)", repairedCount)
+		}
+	} else {
+		c.log.Warnf("datapath self-heal: %d filter(s) still missing after self-heal: %v", len(stillMissing), stillMissing)
+	}
+	return stillMissing, fatal
+}
+
+// filterLister lists TC filters attached to link on the given parent. It is a
+// package-level variable (defaulting to netlink.FilterList) so tests can swap
+// in a mock without touching the real netlink stack.
+var filterLister = netlink.FilterList
+
+// hasDaeTcFilter reports whether a TC filter with the exact given full handle
+// (major<<16 | minor, e.g. 0x20220002 for dae0, 0x20230004/0x20230002 for the
+// LAN/WAN ingress/egress pair) is attached on link within the given parents,
+// and — when expectProg is non-nil — that the filter's attached BPF program
+// matches expectProg.
+//
+// Comparing the full handle (not just the major) lets validateDatapathBindings
+// distinguish the two filters LAN/WAN carry under the same major. The program
+// check catches "zombie" filters: a handle that is present but points to a
+// different/stale/unloaded BPF program (e.g. after a BPF reload swapped the
+// program under a persistently-attached handle). If the expected program's id
+// cannot be resolved (prog Info unavailable) or the kernel does not report the
+// attached program id, we degrade to a handle-only check so validation never
+// regresses into a false negative.
+//
+// parents scopes the netlink enumeration: dae0/dae0peer carry only an ingress
+// filter, so callers pass [HANDLE_MIN_INGRESS] for them; LAN/WAN carry both an
+// ingress and an egress filter, so callers pass both. This avoids one wasted
+// FilterList call per binding on interfaces that never have an egress filter.
+func hasDaeTcFilter(link netlink.Link, handle uint32, parents []uint32, expectProg *ebpf.Program) bool {
+	wantID, wantOK := expectedProgID(expectProg)
+	for _, parent := range parents {
+		filters, err := filterLister(link, parent)
+		if err != nil {
+			continue // no clsact qdisc attached
+		}
+		for _, f := range filters {
+			if f.Attrs().Handle != handle {
+				continue
+			}
+			// Handle matches. If we cannot resolve the expected program id,
+			// accept on handle alone (graceful degradation).
+			if !wantOK {
+				return true
+			}
+			bf, isBpf := f.(*netlink.BpfFilter)
+			if !isBpf {
+				// Not a BPF filter (unexpected); treat handle match as enough.
+				return true
+			}
+			if bf.Id == 0 {
+				// Kernel did not report the attached program id; accept on
+				// handle alone rather than risk a false negative.
+				return true
+			}
+			if uint32(bf.Id) == wantID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// expectedProgID returns the kernel program id for prog, and whether it could
+// be resolved. A nil prog yields (0, false) so callers degrade to a handle-only
+// check. A zero id (which the kernel never assigns) is treated as unresolvable.
+func expectedProgID(prog *ebpf.Program) (uint32, bool) {
+	if prog == nil {
+		return 0, false
+	}
+	info, err := prog.Info()
+	if err != nil {
+		return 0, false
+	}
+	id, ok := info.ID()
+	if !ok || id == 0 {
+		return 0, false
+	}
+	return uint32(id), true
 }
 
 // extractIpsFromDnsCache returns the unique, valid non-unspecified IP addresses

--- a/control/control_plane_core_selfheal_test.go
+++ b/control/control_plane_core_selfheal_test.go
@@ -1,0 +1,431 @@
+package control
+
+import (
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
+)
+
+// mkLink returns a minimal netlink.Link (a *netlink.Dummy) without touching the
+// real kernel. Dummy implements the Link interface and its Attrs().Name is what
+// our mocked filterLister keys on.
+func mkLink(name string) netlink.Link {
+	return &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: name}}
+}
+
+// mkFilters wraps the given full handles into a netlink.Filter list using
+// GenericFilter (handle-only) so they exercise the handle-matching path.
+// The program-aware path is covered by mkBpfFilters.
+func mkFilters(handles ...uint32) []netlink.Filter {
+	var fs []netlink.Filter
+	for _, h := range handles {
+		fs = append(fs, &netlink.GenericFilter{FilterAttrs: netlink.FilterAttrs{Handle: h}})
+	}
+	return fs
+}
+
+// mkBpfFilters wraps handles into *netlink.BpfFilter with the given attached
+// program ids, so the program-aware path of hasDaeTcFilter can be exercised.
+func mkBpfFilters(handles []uint32, ids []int) []netlink.Filter {
+	var fs []netlink.Filter
+	for i, h := range handles {
+		id := 0
+		if ids != nil && i < len(ids) {
+			id = ids[i]
+		}
+		fs = append(fs, &netlink.BpfFilter{
+			FilterAttrs:  netlink.FilterAttrs{Handle: h},
+			DirectAction: true,
+			Id:           id,
+		})
+	}
+	return fs
+}
+
+// Full TC handles used by the datapath (flip=0 here to keep tests deterministic).
+const (
+	handleDae0  = uint32(0x20220002)
+	handleLanIn = uint32(0x20230004)
+	handleLanEg = uint32(0x20230002)
+	handleWanIn = uint32(0x20230002)
+	handleWanEg = uint32(0x20230004)
+)
+
+// mkTestProg loads a trivial eBPF program so the program-aware validation path
+// can be exercised against a real, kernel-assigned program id. It skips the
+// test when the kernel cannot load eBPF programs (e.g. CI without CAP_BPF).
+func mkTestProg(t *testing.T) *ebpf.Program {
+	t.Helper()
+	spec := &ebpf.ProgramSpec{
+		Type: ebpf.SchedCLS,
+		Instructions: asm.Instructions{
+			asm.Mov.Imm(asm.R0, 0),
+			asm.Return(),
+		},
+	}
+	prog, err := ebpf.NewProgram(spec)
+	if err != nil {
+		t.Skipf("cannot create test eBPF program (kernel may lack support): %v", err)
+	}
+	t.Cleanup(func() { _ = prog.Close() })
+	return prog
+}
+
+func TestValidateDatapathBindings(t *testing.T) {
+	origLinkByName := linkByName
+	origFilterLister := filterLister
+	t.Cleanup(func() {
+		linkByName = origLinkByName
+		filterLister = origFilterLister
+	})
+
+	dae0 := mkLink("dae0")
+	eth0 := mkLink("eth0")
+	eth1 := mkLink("eth1")
+
+	// boundIfaces mimics what bindDaens/_bindLan/_bindWan record after a
+	// successful bind: the *resolved* interface name, the expected label, and
+	// the full TC filter handle(s). prog is nil here, so validation degrades to
+	// a handle-only check (the program-aware path is covered separately).
+	tests := []struct {
+		name         string
+		known        map[string]netlink.Link
+		filters      map[string][]netlink.Filter
+		bound        []boundIface
+		wantEmpty    bool
+		wantContains []string
+	}{
+		{
+			name:  "all bindings present",
+			known: map[string]netlink.Link{"dae0": dae0, "eth0": eth0},
+			filters: map[string][]netlink.Filter{
+				"dae0": mkFilters(handleDae0),
+				"eth0": mkFilters(handleLanIn, handleLanEg),
+			},
+			bound: []boundIface{
+				{name: "dae0", label: "dae0", filters: []boundFilter{{handle: handleDae0}}},
+				{name: "eth0", label: "LAN", filters: []boundFilter{{handle: handleLanIn}, {handle: handleLanEg}}},
+			},
+			wantEmpty: true,
+		},
+		{
+			name:   "dae0 filter missing",
+			known:  map[string]netlink.Link{"dae0": dae0, "eth0": eth0},
+			filters: map[string][]netlink.Filter{"eth0": mkFilters(handleLanIn, handleLanEg)},
+			bound: []boundIface{
+				{name: "dae0", label: "dae0", filters: []boundFilter{{handle: handleDae0}}},
+				{name: "eth0", label: "LAN", filters: []boundFilter{{handle: handleLanIn}, {handle: handleLanEg}}},
+			},
+			wantEmpty:    false,
+			wantContains: []string{fmt.Sprintf("dae0 (dae0, handle 0x%x missing or program mismatch)", handleDae0)},
+		},
+		{
+			name:   "lan filter missing",
+			known:  map[string]netlink.Link{"dae0": dae0, "eth0": eth0},
+			filters: map[string][]netlink.Filter{"dae0": mkFilters(handleDae0)},
+			bound: []boundIface{
+				{name: "dae0", label: "dae0", filters: []boundFilter{{handle: handleDae0}}},
+				{name: "eth0", label: "LAN", filters: []boundFilter{{handle: handleLanIn}, {handle: handleLanEg}}},
+			},
+			wantEmpty:    false,
+			wantContains: []string{fmt.Sprintf("eth0 (LAN, handle 0x%x missing or program mismatch)", handleLanIn)},
+		},
+		{
+			name:   "wan filter missing",
+			known:  map[string]netlink.Link{"dae0": dae0, "eth1": eth1},
+			filters: map[string][]netlink.Filter{"dae0": mkFilters(handleDae0)},
+			bound: []boundIface{
+				{name: "dae0", label: "dae0", filters: []boundFilter{{handle: handleDae0}}},
+				{name: "eth1", label: "WAN", filters: []boundFilter{{handle: handleWanIn}, {handle: handleWanEg}}},
+			},
+			wantEmpty:    false,
+			wantContains: []string{fmt.Sprintf("eth1 (WAN, handle 0x%x missing or program mismatch)", handleWanIn)},
+		},
+		{
+			name:   "interface not found",
+			known:  map[string]netlink.Link{"dae0": dae0},
+			filters: map[string][]netlink.Filter{"dae0": mkFilters(handleDae0)},
+			bound: []boundIface{
+				{name: "dae0", label: "dae0", filters: []boundFilter{{handle: handleDae0}}},
+				{name: "eth0", label: "LAN", filters: []boundFilter{{handle: handleLanIn}, {handle: handleLanEg}}},
+			},
+			wantEmpty:    false,
+			wantContains: []string{"eth0 (LAN, link not found)"},
+		},
+		{
+			name:      "no bindings recorded",
+			known:     map[string]netlink.Link{},
+			filters:   map[string][]netlink.Filter{},
+			bound:     nil,
+			wantEmpty: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			linkByName = func(name string) (netlink.Link, error) {
+				if l, ok := tt.known[name]; ok {
+					return l, nil
+				}
+				return nil, fmt.Errorf("link %s not found", name)
+			}
+			filterLister = func(link netlink.Link, parent uint32) ([]netlink.Filter, error) {
+				if fs, ok := tt.filters[link.Attrs().Name]; ok {
+					return fs, nil
+				}
+				return nil, nil
+			}
+
+			c := &controlPlaneCore{datapathIfaces: tt.bound}
+			missing, _ := c.validateDatapathBindings()
+
+			if tt.wantEmpty {
+				if len(missing) != 0 {
+					t.Fatalf("expected no missing bindings, got %v", missing)
+				}
+				return
+			}
+			if len(missing) == 0 {
+				t.Fatalf("expected missing bindings %v, got none", tt.wantContains)
+			}
+			for _, want := range tt.wantContains {
+				found := false
+				for _, m := range missing {
+					if m == want {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("missing binding %q not found in %v", want, missing)
+				}
+			}
+		})
+	}
+}
+
+func TestRepairDatapathBindings(t *testing.T) {
+	origLinkByName := linkByName
+	origFilterLister := filterLister
+	origRebindLan := rebindLanFn
+	origRebindWan := rebindWanFn
+	t.Cleanup(func() {
+		linkByName = origLinkByName
+		filterLister = origFilterLister
+		rebindLanFn = origRebindLan
+		rebindWanFn = origRebindWan
+	})
+
+	dae0 := mkLink("dae0")
+	eth0 := mkLink("eth0")
+	eth1 := mkLink("eth1")
+
+	tests := []struct {
+		name             string
+		known            map[string]netlink.Link
+		filters          map[string][]netlink.Filter
+		bound            []boundIface
+		lanRebindErr     error
+		wanRebindErr     error
+		lanRebindFixes   bool
+		wanRebindFixes   bool
+		wantStillMissing []string
+		wantFatal        bool
+	}{
+		{
+			name:  "LAN missing then self-healed",
+			known: map[string]netlink.Link{"dae0": dae0, "eth0": eth0},
+			filters: map[string][]netlink.Filter{"dae0": mkFilters(handleDae0)},
+			bound: []boundIface{
+				{name: "dae0", label: "dae0", filters: []boundFilter{{handle: handleDae0}}},
+				{name: "eth0", label: "LAN", filters: []boundFilter{{handle: handleLanIn}, {handle: handleLanEg}}},
+			},
+			lanRebindFixes: true,
+			wantFatal:      false,
+		},
+		{
+			name:  "WAN missing but rebind fails (warn only)",
+			known: map[string]netlink.Link{"dae0": dae0, "eth1": eth1},
+			filters: map[string][]netlink.Filter{"dae0": mkFilters(handleDae0)},
+			bound: []boundIface{
+				{name: "dae0", label: "dae0", filters: []boundFilter{{handle: handleDae0}}},
+				{name: "eth1", label: "WAN", filters: []boundFilter{{handle: handleWanIn}, {handle: handleWanEg}}},
+			},
+			wanRebindErr:     fmt.Errorf("simulated clsact unavailable"),
+			wantStillMissing: []string{fmt.Sprintf("eth1 (WAN, handle 0x%x missing or program mismatch)", handleWanIn)},
+			wantFatal:        false,
+		},
+		{
+			name:  "dae0 missing is fatal and not self-healed",
+			known: map[string]netlink.Link{"dae0": dae0, "eth0": eth0},
+			filters: map[string][]netlink.Filter{"eth0": mkFilters(handleLanIn, handleLanEg)},
+			bound: []boundIface{
+				{name: "dae0", label: "dae0", filters: []boundFilter{{handle: handleDae0}}},
+				{name: "eth0", label: "LAN", filters: []boundFilter{{handle: handleLanIn}, {handle: handleLanEg}}},
+			},
+			wantStillMissing: []string{fmt.Sprintf("dae0 (dae0, handle 0x%x missing or program mismatch)", handleDae0)},
+			wantFatal:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// filters is a mutable copy so a successful rebind can "add" the
+			// missing filter, mirroring a real re-attach.
+			filters := map[string][]netlink.Filter{}
+			for k, v := range tt.filters {
+				filters[k] = v
+			}
+			linkByName = func(name string) (netlink.Link, error) {
+				if l, ok := tt.known[name]; ok {
+					return l, nil
+				}
+				return nil, fmt.Errorf("link %s not found", name)
+			}
+			filterLister = func(link netlink.Link, parent uint32) ([]netlink.Filter, error) {
+				if fs, ok := filters[link.Attrs().Name]; ok {
+					return fs, nil
+				}
+				return nil, nil
+			}
+			rebindLanFn = func(c *controlPlaneCore, name string) error {
+				if tt.lanRebindErr != nil {
+					return tt.lanRebindErr
+				}
+				if tt.lanRebindFixes {
+					filters[name] = mkFilters(handleLanIn, handleLanEg)
+				}
+				return nil
+			}
+			rebindWanFn = func(c *controlPlaneCore, name string) error {
+				if tt.wanRebindErr != nil {
+					return tt.wanRebindErr
+				}
+				if tt.wanRebindFixes {
+					filters[name] = mkFilters(handleWanIn, handleWanEg)
+				}
+				return nil
+			}
+
+			c := &controlPlaneCore{datapathIfaces: tt.bound}
+			c.log = logrus.New()
+			c.log.SetOutput(io.Discard)
+
+			stillMissing, fatal := c.repairDatapathBindings()
+
+			if fatal != tt.wantFatal {
+				t.Errorf("fatal = %v, want %v", fatal, tt.wantFatal)
+			}
+			if len(tt.wantStillMissing) == 0 {
+				if len(stillMissing) != 0 {
+					t.Fatalf("expected no still-missing, got %v", stillMissing)
+				}
+				return
+			}
+			if len(stillMissing) == 0 {
+				t.Fatalf("expected still-missing %v, got none", tt.wantStillMissing)
+			}
+			for _, want := range tt.wantStillMissing {
+				found := false
+				for _, m := range stillMissing {
+					if m == want {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("still-missing %q not found in %v", want, stillMissing)
+				}
+			}
+		})
+	}
+}
+
+func TestHasDaeTcFilter(t *testing.T) {
+	origFilterLister := filterLister
+	t.Cleanup(func() { filterLister = origFilterLister })
+
+	link := mkLink("eth0")
+	parents := []uint32{netlink.HANDLE_MIN_INGRESS, netlink.HANDLE_MIN_EGRESS}
+
+	t.Run("handle present, prog nil degrades to match", func(t *testing.T) {
+		filterLister = func(link netlink.Link, parent uint32) ([]netlink.Filter, error) {
+			return mkBpfFilters([]uint32{handleLanIn}, []int{123}), nil
+		}
+		if !hasDaeTcFilter(link, handleLanIn, parents, nil) {
+			t.Errorf("expected match (handle present, prog nil -> degrade to handle)")
+		}
+	})
+
+	t.Run("handle mismatch", func(t *testing.T) {
+		filterLister = func(link netlink.Link, parent uint32) ([]netlink.Filter, error) {
+			return mkBpfFilters([]uint32{handleLanIn}, []int{123}), nil
+		}
+		if hasDaeTcFilter(link, handleLanEg, parents, nil) {
+			t.Errorf("expected no match for wrong handle")
+		}
+	})
+
+	t.Run("no filters", func(t *testing.T) {
+		filterLister = func(link netlink.Link, parent uint32) ([]netlink.Filter, error) {
+			return nil, nil
+		}
+		if hasDaeTcFilter(link, handleLanIn, parents, nil) {
+			t.Errorf("expected no match when no filters attached")
+		}
+	})
+
+	t.Run("program mismatch is a zombie", func(t *testing.T) {
+		prog := mkTestProg(t)
+		wantID, ok := expectedProgID(prog)
+		if !ok {
+			t.Skip("cannot resolve program id")
+		}
+		filterLister = func(link netlink.Link, parent uint32) ([]netlink.Filter, error) {
+			// attached id differs from the expected program id -> zombie.
+			return mkBpfFilters([]uint32{handleLanIn}, []int{int(wantID) + 1}), nil
+		}
+		if hasDaeTcFilter(link, handleLanIn, parents, prog) {
+			t.Errorf("expected zombie (program id mismatch) to be rejected")
+		}
+	})
+
+	t.Run("program match is healthy", func(t *testing.T) {
+		prog := mkTestProg(t)
+		wantID, ok := expectedProgID(prog)
+		if !ok {
+			t.Skip("cannot resolve program id")
+		}
+		filterLister = func(link netlink.Link, parent uint32) ([]netlink.Filter, error) {
+			return mkBpfFilters([]uint32{handleLanIn}, []int{int(wantID)}), nil
+		}
+		if !hasDaeTcFilter(link, handleLanIn, parents, prog) {
+			t.Errorf("expected healthy filter (program id matches) to pass")
+		}
+	})
+
+	t.Run("kernel reports no id degrades to handle match", func(t *testing.T) {
+		prog := mkTestProg(t)
+		filterLister = func(link netlink.Link, parent uint32) ([]netlink.Filter, error) {
+			return mkBpfFilters([]uint32{handleLanIn}, []int{0}), nil
+		}
+		if !hasDaeTcFilter(link, handleLanIn, parents, prog) {
+			t.Errorf("expected degrade to handle match when kernel id missing")
+		}
+	})
+
+	t.Run("non-bpf filter with matching handle degrades to match", func(t *testing.T) {
+		prog := mkTestProg(t)
+		filterLister = func(link netlink.Link, parent uint32) ([]netlink.Filter, error) {
+			return mkFilters(handleLanIn), nil
+		}
+		if !hasDaeTcFilter(link, handleLanIn, parents, prog) {
+			t.Errorf("expected non-bpf filter to degrade to handle match")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

This PR replaces the weak upstream #1039 with a stronger, self-contained datapath self-heal, and additionally layers in the **program-aware** check (the defense #1039 alone could not provide).

### What it does
- After `_bindLan` / `_bindWan` / `bindDaens` successfully attach a TC filter, the binding is recorded as `boundIface{ name, label, filters []boundFilter }`, where each `boundFilter` carries the **full** TC handle (`major<<16 | minor`) **and** the `*ebpf.Program` the filter is expected to point to. `dae0peer` (which lives inside the dae netns) is recorded too and validated there via `GetDaeNetns().WithRequired`.
- `commitInterfaceBindings()` resets the recorded set at the start of each run, then `NewControlPlane` / `CommitPreparedDatapath` call `repairDatapathBindings()` once after binding.
- `repairDatapathBindings()` auto re-attaches **missing LAN/WAN filters** (self-heal); a **missing `dae0` is fatal** and aborts startup/reload; `dae0peer` is surfaced as a non-fatal warning.

### Why stronger than #1039
- The weak #1039 only compared the **major** 16 bits of the handle. This matches the **full handle**, so it correctly distinguishes the two filters LAN/WAN carry under the same major (`0x2023…ingress` vs `0x2023…egress`).
- `hasDaeTcFilter` now also verifies the attached **BPF program id** (`netlink.BpfFilter.Id`, populated from `TCA_BPF_ID`) against the expected program. This catches **"zombie" filters** — a handle that is present but points to a stale / different / unloaded BPF program (e.g. after a BPF reload swapped the program under a persistently-attached handle) — which a handle-only check would silently pass. If the program id cannot be resolved (no `prog.Info()`) or the kernel does not report it, validation **degrades gracefully to a handle-only check**, so it never regresses into false negatives.

### Relationship to #1047
This PR and #1047 are complementary, not overlapping:
- This PR: mode ① (TC handle missing) + mode ③ (program-mismatch zombie).
- #1047: mode ② (stale flipped-handle zombie) via make-before-break deletion on reload.
Both can be merged independently.

### Tests
`control_plane_core_selfheal_test.go` adds table-driven coverage for `validateDatapathBindings`, `repairDatapathBindings`, and `hasDaeTcFilter` (handle-only, zombie rejection, healthy match, kernel-id-missing degradation, non-BPF-filter degradation). Program-aware cases use a real trivial eBPF program and skip gracefully where the kernel lacks support.

### Note
The self-heal path is wired into the live startup/reload flow (previously the helpers existed but were only exercised by unit tests). Please exercise on real hardware / in CI e2e before merge.

Supersedes #1039.
