### PR TITLE
fix(component): re-bind interface when its operational state returns to Up

### DIFF
--- a/component/interface_manager.go
+++ b/component/interface_manager.go
@@ -29,16 +29,23 @@ type InterfaceManager struct {
 	mu        sync.Mutex
 	callbacks []callbackSet
 	upLinks   map[string]bool
+	// operStates records the last observed operational state per interface so
+	// that we can detect a link coming back up after an admin/carrier flap and
+	// re-trigger the binding. The kernel removes the ingress qdisc and the
+	// attached TC filters when a link goes down, and they are not re-added
+	// automatically on re-up, which would silently break traffic steering.
+	operStates map[string]netlink.LinkOperState
 }
 
 func NewInterfaceManager(log *logrus.Logger) *InterfaceManager {
 	closed, toClose := context.WithCancel(context.Background())
 	mgr := &InterfaceManager{
-		log:       log,
-		callbacks: make([]callbackSet, 0),
-		closed:    closed,
-		close:     toClose,
-		upLinks:   make(map[string]bool),
+		log:        log,
+		callbacks:  make([]callbackSet, 0),
+		closed:     closed,
+		close:      toClose,
+		upLinks:    make(map[string]bool),
+		operStates: make(map[string]netlink.LinkOperState),
 	}
 
 	ch := make(chan netlink.LinkUpdate)
@@ -167,12 +174,32 @@ func (m *InterfaceManager) monitor(ch <-chan netlink.LinkUpdate, done chan struc
 			case unix.RTM_NEWLINK:
 				var jobs []job
 				m.mu.Lock()
+				newOperState := update.Link.Attrs().OperState
+				prevOperState, known := m.operStates[ifName]
 				_, exists := m.upLinks[ifName]
-				if exists {
+
+				// Re-bind in two situations:
+				//   1. The interface is newly seen (first appearance) — the
+				//      existing behaviour.
+				//   2. The interface was already known but its operational state
+				//      transitioned back to Up. The kernel removes the ingress
+				//      qdisc and the attached TC filters when a link goes down
+				//      (admin down or carrier loss); on re-up they are not
+				//      re-added automatically, so without re-binding here the
+				//      dataplane silently loses all traffic steering on that
+				//      interface until the next full restart.
+				rebind := false
+				if !exists {
+					rebind = true
+					m.upLinks[ifName] = true
+				} else if known && prevOperState != newOperState && newOperState == netlink.OperUp {
+					rebind = true
+				}
+				m.operStates[ifName] = newOperState
+				if !rebind {
 					m.mu.Unlock()
 					continue
 				}
-				m.upLinks[ifName] = true
 				for _, callback := range m.callbacks {
 					matched, err := path.Match(callback.pattern, ifName)
 					if err != nil || !matched {

--- a/component/interface_manager_test.go
+++ b/component/interface_manager_test.go
@@ -7,11 +7,13 @@ package component
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
 func newTestInterfaceManager() *InterfaceManager {
@@ -19,11 +21,12 @@ func newTestInterfaceManager() *InterfaceManager {
 	log := logrus.New()
 	log.SetOutput(testingWriter{})
 	return &InterfaceManager{
-		log:       log,
-		callbacks: make([]callbackSet, 0),
-		closed:    closed,
-		close:     closeFunc,
-		upLinks:   make(map[string]bool),
+		log:        log,
+		callbacks:  make([]callbackSet, 0),
+		closed:     closed,
+		close:      closeFunc,
+		upLinks:    make(map[string]bool),
+		operStates: make(map[string]netlink.LinkOperState),
 	}
 }
 
@@ -120,5 +123,72 @@ func TestTryEnqueueInterfaceCallbackDropsWhenQueueFull(t *testing.T) {
 	case <-returned:
 	case <-time.After(time.Second):
 		t.Fatal("tryEnqueueInterfaceCallback blocked on a full queue")
+	}
+}
+
+// TestInterfaceManagerRebindsOnOperStateUpTransition verifies that the binding
+// callback is retriggered when a known link flaps down and comes back up. The
+// kernel removes the ingress qdisc and TC filters on link down, so without
+// this re-bind the dataplane would silently lose traffic steering after a flap.
+func TestInterfaceManagerRebindsOnOperStateUpTransition(t *testing.T) {
+	mgr := newTestInterfaceManager()
+
+	var total atomic.Int32
+	calls := make(chan string, 8)
+	go func() {
+		for range calls {
+			total.Add(1)
+		}
+	}()
+
+	mgr.callbacks = append(mgr.callbacks, callbackSet{
+		pattern: "*",
+		newCallback: func(link netlink.Link) {
+			calls <- link.Attrs().Name
+		},
+	})
+
+	ch := make(chan netlink.LinkUpdate)
+	done := make(chan struct{})
+	go mgr.monitor(ch, done)
+	defer func() { _ = mgr.Close() }()
+
+	const ifName = "eth0"
+	// The monitor debounces callbacks by 200ms; wait for the margin to elapse
+	// so any pending callback has been dispatched before we assert.
+	settle := func() { time.Sleep(300 * time.Millisecond) }
+	send := func(state netlink.LinkOperState) {
+		ch <- netlink.LinkUpdate{
+			Header: unix.NlMsghdr{Type: unix.RTM_NEWLINK},
+			Link:   &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: ifName, OperState: state}},
+		}
+	}
+
+	// 1. First appearance (OperUp) must bind.
+	send(netlink.OperUp)
+	settle()
+	if v := total.Load(); v != 1 {
+		t.Fatalf("after first appearance: got %d bind callback(s), want 1", v)
+	}
+
+	// 2. A repeated OperUp (no state change) must NOT re-bind.
+	send(netlink.OperUp)
+	settle()
+	if v := total.Load(); v != 1 {
+		t.Fatalf("after repeated OperUp: got %d bind callback(s), want 1 (no extra rebind)", v)
+	}
+
+	// 3. Going down (OperDown) must NOT re-bind.
+	send(netlink.OperDown)
+	settle()
+	if v := total.Load(); v != 1 {
+		t.Fatalf("after OperDown: got %d bind callback(s), want 1 (no rebind on down)", v)
+	}
+
+	// 4. Coming back up (OperDown -> OperUp) MUST re-bind.
+	send(netlink.OperUp)
+	settle()
+	if v := total.Load(); v != 2 {
+		t.Fatalf("after flap back to OperUp: got %d bind callback(s), want 2 (rebind on up transition)", v)
 	}
 }


### PR DESCRIPTION
## Problem

The kernel removes the ingress qdisc and attached TC filters when a link goes down (admin down or carrier loss). On re-up they are not re-added automatically.

dae only (re)binds an interface's TC filters when the interface first appears (the `upLinks` gate in `InterfaceManager.monitor`). An admin-down -> up cycle does **not** emit a `RTM_DELLINK` — it only sends `RTM_NEWLINK` — so the binding callback was never re-fired. Result: after a flap, that interface silently loses all traffic steering until the next full daemon restart.

## Root cause

`component/interface_manager.go` `monitor()` skipped `RTM_NEWLINK` for any interface already recorded in `upLinks`, without considering the link's operational state. The bind callbacks (`_bindLan`/`_bindWan`, registered in `control_plane_core.go`) already know how to re-attach the filters; the gap was purely the event gate.

## Fix

Track each interface's last observed `OperState`. Re-fire `newCallback` when a known link transitions back to `OperUp` (in addition to the existing first-appearance path). The bind path is idempotent (`FilterDel` best-effort + `FilterAdd` tolerating `EEXIST`), so re-binding on a flap is safe and harmless.

## Test

`TestInterfaceManagerRebindsOnOperStateUpTransition` covers: first appearance binds, a repeated `OperUp` does not re-bind, `OperDown` does not bind, and the `OperDown -> OperUp` transition re-binds.

## Scope

Based directly on fee4c866 (v2.0.0). No unrelated changes.
