### PR TITLE
fix(cmd): keep current generation on reload when subscriptions fail to 0 nodes

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1310,6 +1310,18 @@ func newControlPlaneWithMode(ctx context.Context, log *logrus.Logger, bpf any, d
 		}
 	}
 
+	if bpf != nil && resolvingfailed && len(tagToNodeList) == 0 {
+		// On reload, if every subscription failed to resolve and we ended up
+		// with no nodes, refuse to switch to a dead generation. The caller's
+		// rollback path then keeps the currently working generation (which
+		// still has its nodes) active instead of silently cutting all proxied
+		// traffic. A transient upstream/network failure should never take down
+		// an otherwise-healthy running config; the persisted cache in persist.d
+		// normally shields us, but when it is missing/empty this guard is the
+		// last line of defense.
+		return nil, fmt.Errorf("refusing reload with 0 nodes: all subscription resolving failed; keeping the current generation")
+	}
+
 	if len(conf.Global.LanInterface) == 0 && len(conf.Global.WanInterface) == 0 {
 		log.Warnln("No interface to bind.")
 	}


### PR DESCRIPTION
## Problem

On reload, dae re-resolves subscriptions. If **every** subscription fails to fetch (e.g. the upstream is temporarily unreachable) **and** the persisted cache in `persist.d` is missing or empty, the new generation ends up with **zero nodes**.

The reload orchestration only rolls back when the control plane build returns an error (`cmd/run.go`: `if err != nil`). A zero-node generation is not treated as an error, so dae silently switched to a dead generation and cut all proxied traffic until the next full restart.

## Root cause

`newControlPlaneWithMode` resolves subscriptions and, when the result is empty, only logs a warning (`"No node found because all subscription resolving failed."`) — it never returns an error. So the caller's rollback branch is never taken on a 0-node reload.

## Fix

When reloading (`bpf != nil`) and every subscription failed to resolve while the new generation would have zero nodes, return an error. The existing rollback path then keeps the currently working generation (which still has its nodes) active.

Notes:
- A **successful-but-empty** fetch (subscription legitimately returned 0 nodes) is left alone — `resolvingfailed` is only set on a hard fetch error, so an intentional zero-node config is unaffected.
- The `persist.d` cache normally shields us by serving the last good nodes on a transient failure; this guard is the last line of defense for when that cache is also missing/empty.
- Initial startup (`bpf == nil`) is intentionally not guarded — there is no "previous generation" to preserve.

## Scope

Based directly on fee4c866 (v2.0.0). No unrelated changes.
