### PR TITLE
fix(cmd): re-queue reload request dropped during an in-flight reload

### DIFF
--- a/cmd/reload_manager.go
+++ b/cmd/reload_manager.go
@@ -29,6 +29,8 @@ type reloadManager struct {
 	reloading                    atomic.Bool
 	reloadActive                 atomic.Bool
 	reloadPending                atomic.Bool
+	reloadMissed                 atomic.Bool
+	log                          *logrus.Logger
 	mu                           sync.Mutex
 	reloadingErr                 error
 	lastRetirementMu             sync.Mutex
@@ -39,16 +41,17 @@ type reloadManager struct {
 	pendingReloadRequestedAtMono uint64
 }
 
-func newReloadManager(reloadReqs chan reloadRequest, runStateChanges chan struct{}, sigs <-chan os.Signal) *reloadManager {
+func newReloadManager(log *logrus.Logger, reloadReqs chan reloadRequest, runStateChanges chan struct{}, sigs <-chan os.Signal) *reloadManager {
 	return &reloadManager{
 		reloadReqs:      reloadReqs,
 		runStateChanges: runStateChanges,
 		sigs:            sigs,
+		log:             log,
 	}
 }
 
 func (m *reloadManager) queueReloadRequest(log *logrus.Logger, req reloadRequest) bool {
-	return tryQueueReloadRequest(log, m.reloadReqs, &m.reloadActive, &m.reloadPending, req)
+	return tryQueueReloadRequest(log, m.reloadReqs, &m.reloadActive, &m.reloadPending, &m.reloadMissed, req)
 }
 
 func (m *reloadManager) beginHandoff() {
@@ -250,12 +253,49 @@ func (m *reloadManager) finishReloadFailure() {
 	m.reloading.Store(false)
 	m.reloadActive.Store(false)
 	clearReloadPending(&m.reloadPending)
+	m.maybeRequeueMissedReload()
 }
 
 func (m *reloadManager) finishReloadSuccess() {
 	m.reloading.Store(false)
 	m.reloadActive.Store(false)
-	releaseReloadPendingAfterRetirement(&m.reloadPending, m.takePendingRetirementDone())
+	done := m.takePendingRetirementDone()
+	if done == nil {
+		clearReloadPending(&m.reloadPending)
+		m.maybeRequeueMissedReload()
+		return
+	}
+	go func() {
+		<-done
+		clearReloadPending(&m.reloadPending)
+		m.maybeRequeueMissedReload()
+	}()
+}
+
+// maybeRequeueMissedReload re-queues a single reload if a request was dropped
+// while another reload was already in progress. tryQueueReloadRequest silently
+// ignores (drops) a reload signal whose CAS on reloadPending loses because a
+// reload is already queued or running; without this compensation the latest
+// configuration change would be lost until the next manual reload. The
+// re-queued request reads the current configuration, so a burst of dropped
+// requests collapses into exactly one follow-up reload (further signals
+// arriving during that follow-up are themselves coalesced by the worker's
+// coalesceReloadRequest), keeping the system eventually consistent without an
+// unbounded reload storm.
+func (m *reloadManager) maybeRequeueMissedReload() {
+	if m == nil || m.reloadMissed.Swap(false) == false {
+		return
+	}
+	req := reloadRequest{
+		isSuspend:       false,
+		requestedAt:     time.Now(),
+		requestedAtMono: monotonicNowNano(),
+	}
+	if m.queueReloadRequest(m.log, req) {
+		if m.log != nil {
+			m.log.Warnln("[Reload] A reload request was dropped while another reload was in progress; re-queuing one reload to apply the latest configuration")
+		}
+	}
 }
 
 func (m *reloadManager) startControlPlaneRetirement(

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -143,9 +143,13 @@ func tryQueueReloadRequest(
 	reloadReqs chan<- reloadRequest,
 	reloadActive *atomic.Bool,
 	reloadPending *atomic.Bool,
+	reloadMissed *atomic.Bool,
 	req reloadRequest,
 ) bool {
 	if reloadPending != nil && !reloadPending.CompareAndSwap(false, true) {
+		if reloadMissed != nil {
+			reloadMissed.Store(true)
+		}
 		if log != nil {
 			log.Warnln("[Reload] Reload already in progress or handoff pending; ignoring this signal")
 		}
@@ -381,7 +385,7 @@ func (r *Runner) Run() (err error) {
 	}()
 
 	reloadReqs := make(chan reloadRequest, 1)
-	reloadManager := newReloadManager(reloadReqs, runStateChanges, sigs)
+	reloadManager := newReloadManager(log, reloadReqs, runStateChanges, sigs)
 	fastExit := false
 
 	go func() {

--- a/cmd/run_shutdown_test.go
+++ b/cmd/run_shutdown_test.go
@@ -364,15 +364,19 @@ func TestTryQueueReloadRequestRejectsConcurrentReload(t *testing.T) {
 	reqs := make(chan reloadRequest, 1)
 	var reloadActive atomic.Bool
 	var reloadPending atomic.Bool
+	var reloadMissed atomic.Bool
 
-	if !tryQueueReloadRequest(newDiscardLogger(), reqs, &reloadActive, &reloadPending, reloadRequest{isSuspend: false}) {
+	if !tryQueueReloadRequest(newDiscardLogger(), reqs, &reloadActive, &reloadPending, &reloadMissed, reloadRequest{isSuspend: false}) {
 		t.Fatal("expected first reload request to be queued")
 	}
 	if !reloadPending.Load() {
 		t.Fatal("expected reloadPending to remain set after queuing reload")
 	}
-	if tryQueueReloadRequest(newDiscardLogger(), reqs, &reloadActive, &reloadPending, reloadRequest{isSuspend: true}) {
+	if tryQueueReloadRequest(newDiscardLogger(), reqs, &reloadActive, &reloadPending, &reloadMissed, reloadRequest{isSuspend: true}) {
 		t.Fatal("expected concurrent reload request to be rejected")
+	}
+	if !reloadMissed.Load() {
+		t.Fatal("expected reloadMissed to be set after a concurrent request is dropped")
 	}
 
 	select {
@@ -382,6 +386,37 @@ func TestTryQueueReloadRequestRejectsConcurrentReload(t *testing.T) {
 		}
 	default:
 		t.Fatal("expected queued reload request")
+	}
+}
+
+func TestReloadManagerRequeuesMissedRequest(t *testing.T) {
+	reqs := make(chan reloadRequest, 1)
+	m := &reloadManager{
+		reloadReqs: reqs,
+		log:        newDiscardLogger(),
+	}
+	// Simulate an in-flight reload that drops an incoming request.
+	m.reloadPending.Store(true)
+	if tryQueueReloadRequest(m.log, reqs, &m.reloadActive, &m.reloadPending, &m.reloadMissed, reloadRequest{isSuspend: false}) {
+		t.Fatal("expected concurrent request to be rejected while reload in progress")
+	}
+	if !m.reloadMissed.Load() {
+		t.Fatal("expected reloadMissed to be set after a dropped request")
+	}
+	// The in-flight reload finishes: pending is cleared, then the missed
+	// request is re-queued so the latest configuration is not lost.
+	m.reloadPending.Store(false)
+	m.maybeRequeueMissedReload()
+	if m.reloadMissed.Load() {
+		t.Fatal("expected reloadMissed to be cleared after re-queue")
+	}
+	select {
+	case req := <-reqs:
+		if req.isSuspend {
+			t.Fatal("expected re-queued request to be a normal reload")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected a reload request to be re-queued after a missed drop")
 	}
 }
 
@@ -535,7 +570,7 @@ func TestReloadManagerBuildShutdownHandoffUsesPendingStagedHandoff(t *testing.T)
 	oldPlane := &control.ControlPlane{}
 	newPlane := &control.ControlPlane{}
 
-	manager := newReloadManager(make(chan reloadRequest, 1), make(chan struct{}, 1), make(chan os.Signal, 1))
+	manager := newReloadManager(newDiscardLogger(), make(chan reloadRequest, 1), make(chan struct{}, 1), make(chan os.Signal, 1))
 	manager.setPendingStagedHandoff(&stagedReloadHandoff{
 		oldControlPlane: oldPlane,
 		oldListener:     oldListener,
@@ -557,7 +592,7 @@ func TestReloadManagerBuildShutdownHandoffUsesPendingStagedHandoff(t *testing.T)
 
 func TestReloadManagerCoalesceReloadRequestKeepsLatestQueuedRequest(t *testing.T) {
 	reloadReqs := make(chan reloadRequest, 2)
-	manager := newReloadManager(reloadReqs, make(chan struct{}, 1), make(chan os.Signal, 1))
+	manager := newReloadManager(newDiscardLogger(), reloadReqs, make(chan struct{}, 1), make(chan os.Signal, 1))
 
 	now := time.Now()
 	latest := reloadRequest{
@@ -683,7 +718,7 @@ func TestBuildPreparedDNSHandoffHooksStartHookPropagatesStopError(t *testing.T) 
 }
 
 func TestReloadManagerStartControlPlaneRetirementCompletesAndCancelsOldContext(t *testing.T) {
-	manager := newReloadManager(make(chan reloadRequest, 1), make(chan struct{}, 1), make(chan os.Signal, 1))
+	manager := newReloadManager(newDiscardLogger(), make(chan reloadRequest, 1), make(chan struct{}, 1), make(chan os.Signal, 1))
 	manager.setPendingReloadMetadata(time.Now(), 0)
 
 	oldCtx, oldCancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## Summary

`tryQueueReloadRequest` silently drops a reload signal whose `CompareAndSwap` on `reloadPending` loses because a reload is already queued or running. The dropped request is never retried, so the latest configuration change is lost until the next manual reload.

## Root cause

During a reload (staged handoff + retirement), `reloadPending` stays `true` until the old generation is fully retired. Any `dae reload` (SIGUSR1/SIGUSR2) arriving in that window hits the `CompareAndSwap(false, true)` failure branch and returns `false` with only a log warning — no compensation. After the in-flight reload finishes, the dropped request's intent (apply the newest config) is gone.

This is most visible when an automation/script issues `dae reload` faster than a reload completes, or when two quick manual reloads race.

## Fix

- Add a `reloadMissed` flag to `reloadManager`. The CAS-failure drop path now sets it.
- `finishReloadSuccess` / `finishReloadFailure` re-queue **exactly one** follow-up reload once `reloadPending` clears (post-retirement for the success path, synchronously for the failure path).

The re-queued request reads the current configuration, so a burst of dropped requests collapses into a single follow-up reload (further signals arriving during that follow-up are coalesced by the worker's `coalesceReloadRequest`). This keeps the system eventually consistent without an unbounded reload storm: once no more signals arrive, the last dropped request is honored and the chain stops.

## Testing

- `TestTryQueueReloadRequestRejectsConcurrentReload`: now asserts `reloadMissed` is set after a concurrent request is dropped.
- `TestReloadManagerRequeuesMissedRequest` (new): simulates an in-flight reload that drops a request, then verifies the `finishReload`-style `maybeRequeueMissedReload` re-queues exactly one normal reload and clears the flag.

Verified `gofmt` clean and `GOOS=linux go build -tags dae_stub_ebpf ./cmd/...` plus `go test -c` compile.

## Notes

This is independent of the datapath/self-heal reload work (#1047/#1048) and the zero-node rollback guard (#1050); it addresses a different hole (concurrent request loss at the signal layer).