### PR TITLE
docs(config): document TCP check HTTP methods

### DIFF
--- a/example.dae
+++ b/example.dae
@@ -75,6 +75,8 @@ global {
 
     # The HTTP request method to `tcp_check_url`. Use 'HEAD' by default because some server implementations bypass
     # accounting for this kind of traffic.
+    # Available methods (choose one only): HEAD, GET, POST, PUT, PATCH, DELETE, COPY, OPTIONS, LINK, UNLINK, PURGE,
+    # LOCK, UNLOCK, PROPFIND, CONNECT, TRACE.
     tcp_check_http_method: HEAD
 
     # This DNS will be used to check UDP connectivity of nodes. And if dns_upstream below contains tcp, it also be used to check


### PR DESCRIPTION
### Background

`example.dae` previously showed only the default `HEAD` value for `tcp_check_http_method`, leaving the other accepted methods undiscoverable. Document every method accepted by the configuration and clarify that users must select only one.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS (not applicable: comment-only configuration documentation)
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae (not applicable: this change documents `example.dae` directly)

### Full Changelogs

- Document all accepted `tcp_check_http_method` values and clarify that only one may be selected.

### Issue Reference

N/A

### Test Result

- `git diff --check upstream/main...HEAD`
- Verified the documented list against `common.IsValidHttpMethod`.
- Go tests were not run because this change only adds comments to `example.dae`.
