### PR TITLE
chore(ebpf): correct misleading comment regarding CO-RE relocation failure

### DIFF
--- a/control/kern/tproxy.c
+++ b/control/kern/tproxy.c
@@ -3,7 +3,13 @@
 
 // +build ignore
 
-// Disable implicit CO-RE from vmlinux.h to bypass bad relocation caused by GCC 15 DTE stripping UAPI structs.
+// Disable implicit CO-RE from vmlinux.h to bypass bad relocation.
+// Note: Previously misattributed to GCC 15 DTE. The actual root cause is that
+// pahole fails to parse DWARF5 debug info correctly, which strips UAPI structs
+// from the generated BTF.
+// Workaround for implicit CO-RE: compile kernel with CONFIG_DEBUG_INFO_DWARF4=y.
+// However, it is highly recommended to keep this macro defined, as it still
+// significantly improves overall compatibility across different environments.
 #define BPF_NO_PRESERVE_ACCESS_INDEX 1
 
 #include "headers/errno-base.h"


### PR DESCRIPTION
<!-- NOTE: Please read the contribution guidelines before submitting your patch, and ensure you followed them all: https://github.com/daeuniverse/dae/blob/main/docs/en/development/contribute.md -->

### Background

I am correcting a misjudgment I made in a previous commit. 
The previous comment incorrectly attributed the CO-RE bad relocation (stripping UAPI structs) to GCC 15 Dead Type Elimination (DTE). 
Recently, while debugging a separate LSM loading issue, I discovered that the root cause was actually related to the DWARF debug information level. 
This prompted me to go back and verify the original dae code, and it turned out to be the exact same issue. 
When the kernel is compiled with DWARF5, pahole(v1.31) may fail to parse it correctly, silently dropping UAPI structures during BTF generation. 
I am updating this comment to correct my previous assumption and to ensure future developers are not misled into investigating GCC compiler bugs. 
The actual workaround for the kernel is to compile with CONFIG_DEBUG_INFO_DWARF4=y.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- Fix: Correct misleading code comment regarding CO-RE relocation failure and GCC 15 DTE.

### Issue Reference

<!--- If it fixes an open issue, please link to the issue here. -->
N/A

### Test Result

Code compiles successfully. eBPF programs load without errors in the current environment.