### PR TITLE
feat(proxy): support group entry chains

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1134,6 +1134,35 @@ func configureTransparentHugePages(log *logrus.Logger, disable bool) {
 	}
 }
 
+func configuredPersistSubscriptionTags(subscriptions []config.KeyableString) map[string]struct{} {
+	tags := make(map[string]struct{})
+	for _, sub := range subscriptions {
+		tag, link := common.GetTagFromLinkLikePlaintext(string(sub))
+		link = strings.TrimSpace(link)
+		if tag != "" && (strings.HasPrefix(link, "http-file://") || strings.HasPrefix(link, "https-file://")) {
+			tags[tag] = struct{}{}
+		}
+	}
+	return tags
+}
+
+func removeStalePersistedSubscriptions(configDir string, configuredTags map[string]struct{}) error {
+	files, err := os.ReadDir(filepath.Join(configDir, "persist.d"))
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	for _, file := range files {
+		tag := strings.TrimSuffix(file.Name(), ".sub")
+		if _, ok := configuredTags[tag]; ok {
+			continue
+		}
+		if err := os.Remove(filepath.Join(configDir, "persist.d", file.Name())); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func newControlPlaneWithMode(ctx context.Context, log *logrus.Logger, bpf any, dnsCache map[string]*control.DnsCache, conf *config.Config, externGeoDataDirs []string, prepareOnly bool) (c *control.ControlPlane, err error) {
 	// Deep copy to prevent modification.
 	conf = deepcopy.Copy(conf).(*config.Config)
@@ -1229,13 +1258,13 @@ func newControlPlaneWithMode(ctx context.Context, log *logrus.Logger, bpf any, d
 	if len(conf.Subscription) > 0 {
 		log.Infoln("Fetching subscriptions...")
 	}
+	configuredPersistTags := configuredPersistSubscriptionTags(conf.Subscription)
 	// Parallelize subscription resolution to improve startup performance.
 	// Use a semaphore to limit concurrency and avoid overwhelming the network.
 	type subscriptionResult struct {
 		tag   string
 		nodes []string
 		err   error
-		sub   config.KeyableString
 	}
 	numSubscriptions := len(conf.Subscription)
 	if numSubscriptions > 0 {
@@ -1249,13 +1278,14 @@ func newControlPlaneWithMode(ctx context.Context, log *logrus.Logger, bpf any, d
 				sem <- struct{}{}        // Acquire semaphore
 				defer func() { <-sem }() // Release semaphore
 
+				configuredTag, _ := common.GetTagFromLinkLikePlaintext(string(s))
 				subDialer := direct.SymmetricDirect
 				if daeDNSRouter != nil {
 					wrappedDialer, wrapErr := daeDNSRouter.WrapSubscriptionDialer(subDialer, string(s))
 					if wrapErr != nil {
 						results <- subscriptionResult{
+							tag: configuredTag,
 							err: wrapErr,
-							sub: s,
 						}
 						return
 					}
@@ -1267,7 +1297,6 @@ func newControlPlaneWithMode(ctx context.Context, log *logrus.Logger, bpf any, d
 					tag:   tag,
 					nodes: nodes,
 					err:   err,
-					sub:   s,
 				}
 			}(sub)
 		}
@@ -1276,7 +1305,11 @@ func newControlPlaneWithMode(ctx context.Context, log *logrus.Logger, bpf any, d
 		for range numSubscriptions {
 			result := <-results
 			if result.err != nil {
-				log.Warnf(`failed to resolve subscription "%v": %v`, result.sub, result.err)
+				tag := result.tag
+				if tag == "" {
+					tag = "<untagged>"
+				}
+				log.WithError(result.err).WithField("subscription", tag).Error("failed to resolve subscription")
 				resolvingfailed = true
 			}
 			if len(result.nodes) > 0 {
@@ -1287,19 +1320,9 @@ func newControlPlaneWithMode(ctx context.Context, log *logrus.Logger, bpf any, d
 		log.Infof("Subscriptions fetched in %v", time.Since(stageStart))
 	}
 
-	// Delete all files in persist.d that are not in tagToNodeList
-	files, err := os.ReadDir(filepath.Join(filepath.Dir(cfgFile), "persist.d"))
-	if err != nil && !os.IsNotExist(err) {
+	// Delete caches only when their persistent subscription was removed from config.
+	if err := removeStalePersistedSubscriptions(filepath.Dir(cfgFile), configuredPersistTags); err != nil {
 		return nil, err
-	}
-	for _, file := range files {
-		tag := strings.TrimSuffix(file.Name(), ".sub")
-		if _, ok := tagToNodeList[tag]; !ok {
-			err := os.Remove(filepath.Join(filepath.Dir(cfgFile), "persist.d", file.Name()))
-			if err != nil {
-				return nil, err
-			}
-		}
 	}
 
 	if len(tagToNodeList) == 0 {

--- a/cmd/subscription_persist_test.go
+++ b/cmd/subscription_persist_test.go
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2026, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/daeuniverse/dae/config"
+)
+
+func TestRemoveStalePersistedSubscriptionsKeepsConfiguredFailedSubscription(t *testing.T) {
+	dir := t.TempDir()
+	persistDir := filepath.Join(dir, "persist.d")
+	if err := os.MkdirAll(persistDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"current.sub", "stale.sub"} {
+		if err := os.WriteFile(filepath.Join(persistDir, name), []byte("node"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	tags := configuredPersistSubscriptionTags([]config.KeyableString{
+		"current:https-file://example.com/sub",
+	})
+	if err := removeStalePersistedSubscriptions(dir, tags); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(persistDir, "current.sub")); err != nil {
+		t.Fatalf("configured cache was removed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(persistDir, "stale.sub")); !os.IsNotExist(err) {
+		t.Fatalf("stale cache still exists: %v", err)
+	}
+}

--- a/common/group_chain.go
+++ b/common/group_chain.go
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2026, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package common
+
+import (
+	"fmt"
+	"strings"
+)
+
+// GroupChain describes the supported group-based chain form. Proxy chains
+// retain dae's endpoint -> relay order, so the entry group is on the right.
+type GroupChain struct {
+	Name         string
+	EntryGroup   string
+	EndpointLink string
+	Link         string
+}
+
+// ParseGroupChain recognizes group-based node chains without changing the
+// parsing behavior of ordinary nodes and node-to-node chains.
+func ParseGroupChain(link string) (*GroupChain, bool, error) {
+	name, linklike := GetTagFromLinkLikePlaintext(link)
+	parts := strings.Split(linklike, "->")
+	groupAt := -1
+	groupName := ""
+	for i, part := range parts {
+		part = strings.TrimSpace(part)
+		if !strings.HasPrefix(part, "group(") {
+			continue
+		}
+		if !strings.HasSuffix(part, ")") {
+			return nil, true, fmt.Errorf("invalid group chain entry syntax")
+		}
+		groupAt = i
+		groupName = strings.TrimSpace(part[len("group(") : len(part)-1])
+		break
+	}
+	if groupAt < 0 {
+		return nil, false, nil
+	}
+	if len(parts) != 2 || groupAt != 1 {
+		return nil, true, fmt.Errorf("group chain must have the form endpoint -> group(NAME)")
+	}
+	if groupName == "" {
+		return nil, true, fmt.Errorf("group chain entry name is empty")
+	}
+	endpointLink := strings.TrimSpace(parts[0])
+	if endpointLink == "" {
+		return nil, true, fmt.Errorf("group chain endpoint is empty")
+	}
+	return &GroupChain{
+		Name:         strings.TrimSpace(name),
+		EntryGroup:   groupName,
+		EndpointLink: endpointLink,
+		Link:         strings.TrimSpace(linklike),
+	}, true, nil
+}

--- a/common/group_chain_test.go
+++ b/common/group_chain_test.go
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2026, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package common
+
+import "testing"
+
+func TestParseGroupChain(t *testing.T) {
+	tests := []struct {
+		name      string
+		link      string
+		wantMatch bool
+		wantErr   bool
+	}{
+		{name: "valid", link: "hk_to_us: vmess://endpoint -> group(HK)", wantMatch: true},
+		{name: "ordinary node", link: "hk: vmess://node"},
+		{name: "ordinary chain", link: "chain: vmess://endpoint -> tuic://relay"},
+		{name: "ordinary long chain", link: "chain: vmess://endpoint -> tuic://relay-1 -> vless://relay-2"},
+		{name: "group on endpoint side", link: "bad: group(US) -> vmess://relay", wantMatch: true, wantErr: true},
+		{name: "group to group", link: "bad: group(HK) -> group(US)", wantMatch: true, wantErr: true},
+		{name: "nested", link: "bad: vmess://endpoint -> vmess://relay -> group(HK)", wantMatch: true, wantErr: true},
+		{name: "empty group", link: "bad: vmess://endpoint -> group()", wantMatch: true, wantErr: true},
+		{name: "malformed group", link: "bad: vmess://endpoint -> group(HK", wantMatch: true, wantErr: true},
+		{name: "empty endpoint", link: "bad: -> group(HK)", wantMatch: true, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, matched, err := ParseGroupChain(tt.link)
+			if matched != tt.wantMatch {
+				t.Fatalf("matched = %v, want %v", matched, tt.wantMatch)
+			}
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.name == "valid" {
+				if got.Name != "hk_to_us" || got.EntryGroup != "HK" || got.EndpointLink != "vmess://endpoint" {
+					t.Fatalf("unexpected parse result: %#v", got)
+				}
+			}
+		})
+	}
+}

--- a/common/subscription/subscription.go
+++ b/common/subscription/subscription.go
@@ -141,6 +141,72 @@ func ResolveFile(u *url.URL, configDir string) (b []byte, err error) {
 	return bytes.TrimSpace(b), err
 }
 
+func validateSubscriptionNodes(log *logrus.Logger, tag string, nodes []string) []string {
+	valid := make([]string, 0, len(nodes))
+	for i, node := range nodes {
+		_, groupChain, err := common.ParseGroupChain(node)
+		if err == nil && groupChain {
+			err = fmt.Errorf("group entry chains are not allowed in subscriptions")
+		}
+		if err != nil {
+			log.WithFields(logrus.Fields{
+				"subscription": tag,
+				"node_index":   i,
+				"reason":       err.Error(),
+			}).Error("skip invalid subscription node")
+			continue
+		}
+		valid = append(valid, node)
+	}
+	return valid
+}
+
+func resolveSubscriptionContent(log *logrus.Logger, tag string, b []byte) []string {
+	nodes, err := ResolveSubscriptionAsSIP008(log, b)
+	if err != nil {
+		log.Debugln(err)
+		nodes = ResolveSubscriptionAsBase64(log, b)
+	}
+	return validateSubscriptionNodes(log, tag, nodes)
+}
+
+func readPersistedSubscription(configDir, tag string) ([]byte, error) {
+	return ResolveFile(&url.URL{Host: "persist.d/" + tag + ".sub"}, configDir)
+}
+
+func writePersistedSubscription(configDir, tag string, b []byte) (err error) {
+	dir := filepath.Join(configDir, "persist.d")
+	path := filepath.Join(dir, tag+".sub")
+	if err := common.EnsureFileInSubDir(path, dir); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".dae-sub-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+	}()
+	if err = tmp.Chmod(0600); err != nil {
+		return err
+	}
+	if _, err = tmp.Write(b); err != nil {
+		return err
+	}
+	if err = tmp.Sync(); err != nil {
+		return err
+	}
+	if err = tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
 func ResolveSubscription(log *logrus.Logger, client *http.Client, configDir string, subscription string) (tag string, nodes []string, err error) {
 	/// Get tag.
 	tag, subscription = common.GetTagFromLinkLikePlaintext(subscription)
@@ -150,7 +216,7 @@ func ResolveSubscription(log *logrus.Logger, client *http.Client, configDir stri
 	if err != nil {
 		return tag, nil, fmt.Errorf("failed to parse subscription \"%v\": %w", subscription, err)
 	}
-	log.Debugf("ResolveSubscription: %v", subscription)
+	log.WithField("subscription", tag).Debug("ResolveSubscription")
 	var (
 		b    []byte
 		req  *http.Request
@@ -158,14 +224,15 @@ func ResolveSubscription(log *logrus.Logger, client *http.Client, configDir stri
 	)
 
 	persistToFile := false
+	fetchedRemote := false
 
 	switch u.Scheme {
 	case "file":
 		b, err = ResolveFile(u, configDir)
 		if err != nil {
-			return "", nil, err
+			return tag, nil, err
 		}
-		goto resolve
+		goto validate
 	case "http-file", "https-file":
 		if len(tag) == 0 {
 			return "", nil, fmt.Errorf("tag is required for http-file/https-file subscription")
@@ -176,57 +243,48 @@ func ResolveSubscription(log *logrus.Logger, client *http.Client, configDir stri
 	}
 	req, err = http.NewRequest("GET", subscription, nil)
 	if err != nil {
-		return "", nil, err
+		return tag, nil, err
 	}
 	req.Header.Set("User-Agent", fmt.Sprintf("dae/%v (like v2rayA/1.0 WebRequestHelper) (like v2rayN/1.0 WebRequestHelper)", config.Version))
 	resp, err = client.Do(req)
 	if err != nil {
 		if persistToFile {
 			log.Warnln("failed to fetch subscription, try to read from file")
-			u.Host = "persist.d/" + tag + ".sub"
-			u.Path = ""
-			b, err = ResolveFile(u, configDir)
+			b, err = readPersistedSubscription(configDir, tag)
 
 			if err != nil {
-				return "", nil, err
+				return tag, nil, err
 			}
-			goto resolve
+			goto validate
 		}
 
-		return "", nil, err
+		return tag, nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
 	b, err = io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024)) // 10MB max subscription size
 	if err != nil {
-		return "", nil, err
+		return tag, nil, err
 	}
+	fetchedRemote = true
 
-	if persistToFile {
-		path := filepath.Join(configDir, "persist.d")
-		if _, err := os.Stat(path); os.IsNotExist(err) {
-			err := os.MkdirAll(path, 0700)
-			if err != nil {
-				return "", nil, err
+validate:
+	nodes = resolveSubscriptionContent(log, tag, b)
+	if len(nodes) == 0 {
+		if persistToFile && fetchedRemote {
+			log.WithField("subscription", tag).Error("subscription contains no valid nodes; use last valid cache")
+			cached, cacheErr := readPersistedSubscription(configDir, tag)
+			if cacheErr == nil {
+				if cachedNodes := resolveSubscriptionContent(log, tag, cached); len(cachedNodes) > 0 {
+					return tag, cachedNodes, nil
+				}
 			}
 		}
-
-		path = filepath.Join(path, tag+".sub")
-		file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
-		if err != nil {
-			return "", nil, err
-		}
-		defer func() { _ = file.Close() }()
-
-		_, err = file.Write(b)
-		if err != nil {
-			return "", nil, err
+		return tag, nil, fmt.Errorf("subscription %q contains no valid nodes", tag)
+	}
+	if persistToFile && fetchedRemote {
+		if err := writePersistedSubscription(configDir, tag, b); err != nil {
+			return tag, nil, err
 		}
 	}
-resolve:
-	if nodes, err = ResolveSubscriptionAsSIP008(log, b); err == nil {
-		return tag, nodes, nil
-	} else {
-		log.Debugln(err)
-	}
-	return tag, ResolveSubscriptionAsBase64(log, b), nil
+	return tag, nodes, nil
 }

--- a/common/subscription/subscription_test.go
+++ b/common/subscription/subscription_test.go
@@ -1,8 +1,14 @@
 package subscription
 
 import (
+	"bytes"
 	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -50,5 +56,72 @@ func TestResolveSubscriptionAsSIP008_SS2022KeepsRawPSK(t *testing.T) {
 
 	if got, want := string(decoded), "2022-blake3-aes-256-gcm:"+password; got != want {
 		t.Fatalf("unexpected decoded userinfo: got %q want %q", got, want)
+	}
+}
+
+func encodeSubscription(nodes ...string) []byte {
+	return []byte(base64.StdEncoding.EncodeToString([]byte(strings.Join(nodes, "\n"))))
+}
+
+func TestValidateSubscriptionNodesSkipsGroupChainWithoutLoggingLink(t *testing.T) {
+	const secret = "uuid-password-token"
+	var logs bytes.Buffer
+	log := logrus.New()
+	log.SetOutput(&logs)
+	nodes := []string{
+		"vmess://" + secret + "@endpoint -> group(HK)",
+		"vmess://valid",
+	}
+
+	valid := validateSubscriptionNodes(log, "remote", nodes)
+	if len(valid) != 1 || valid[0] != nodes[1] {
+		t.Fatalf("valid nodes = %#v", valid)
+	}
+	if strings.Contains(logs.String(), secret) || strings.Contains(logs.String(), nodes[0]) {
+		t.Fatalf("log leaked node credentials: %s", logs.String())
+	}
+	if !strings.Contains(logs.String(), "skip invalid subscription node") {
+		t.Fatalf("missing invalid-node log: %s", logs.String())
+	}
+}
+
+func TestValidateSubscriptionNodesKeepsOrdinaryLongChain(t *testing.T) {
+	node := "vmess://endpoint -> tuic://relay-1 -> vless://relay-2"
+	valid := validateSubscriptionNodes(logrus.New(), "remote", []string{node})
+	if len(valid) != 1 || valid[0] != node {
+		t.Fatalf("valid nodes = %#v", valid)
+	}
+}
+
+func TestResolveSubscriptionKeepsPersistedNodesWhenRemoteHasNoValidNodes(t *testing.T) {
+	dir := t.TempDir()
+	persistDir := filepath.Join(dir, "persist.d")
+	if err := os.MkdirAll(persistDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	oldContent := encodeSubscription("vmess://old-valid")
+	persistPath := filepath.Join(persistDir, "remote.sub")
+	if err := os.WriteFile(persistPath, oldContent, 0600); err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(encodeSubscription("vmess://endpoint -> group(HK)"))
+	}))
+	defer server.Close()
+
+	link := "remote:" + strings.Replace(server.URL, "http://", "http-file://", 1)
+	tag, nodes, err := ResolveSubscription(logrus.New(), server.Client(), dir, link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tag != "remote" || len(nodes) != 1 || nodes[0] != "vmess://old-valid" {
+		t.Fatalf("tag = %q, nodes = %#v", tag, nodes)
+	}
+	got, err := os.ReadFile(persistPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, oldContent) {
+		t.Fatal("invalid remote subscription overwrote the last valid cache")
 	}
 }

--- a/component/outbound/dialer/dialer.go
+++ b/component/outbound/dialer/dialer.go
@@ -289,6 +289,18 @@ func (d *Dialer) CloneWithGlobalOption(option *GlobalOption) *Dialer {
 
 // CloneWithGlobalOptionContext returns a new dialer instance initialized with option.
 func (d *Dialer) CloneWithGlobalOptionContext(ctx context.Context, option *GlobalOption) *Dialer {
+	if cloner, ok := d.Dialer.(interface {
+		CloneWithGlobalOption(context.Context, *GlobalOption) (netproxy.Dialer, error)
+	}); ok {
+		cloneDialer, err := cloner.CloneWithGlobalOption(ctx, option)
+		if err == nil {
+			return NewDialerContext(ctx, cloneDialer, option, d.InstanceOption, cloneProperty(d.property))
+		}
+		if option != nil && option.Log != nil {
+			option.Log.WithError(err).WithField("dialer", d.Property().Name).
+				Warnln("Failed to clone custom dialer; falling back to shared dialer instance")
+		}
+	}
 	if d.property != nil && d.property.Link != "" {
 		clone, err := NewFromLinkWithProxyCacheContext(ctx, option, d.InstanceOption, d.property.Link, d.property.SubscriptionTag, NewProxyIpCache())
 		if err == nil {

--- a/component/outbound/dialer/netconn.go
+++ b/component/outbound/dialer/netconn.go
@@ -1,0 +1,56 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2026, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package dialer
+
+import (
+	"context"
+	"net"
+
+	"github.com/daeuniverse/outbound/netproxy"
+)
+
+type netConnDialer struct {
+	netproxy.Dialer
+}
+
+func (d *netConnDialer) DialContext(ctx context.Context, network, addr string) (netproxy.Conn, error) {
+	conn, err := d.Dialer.DialContext(ctx, network, addr)
+	if err != nil {
+		return nil, err
+	}
+	if _, ok := conn.(net.Conn); ok {
+		return conn, nil
+	}
+	localAddr := netConnAddr{network: network}
+	remoteAddr := netConnAddr{network: network, address: addr}
+	if packetConn, ok := conn.(netproxy.PacketConn); ok {
+		return &netPacketConn{PacketConn: packetConn, localAddr: localAddr, remoteAddr: remoteAddr}, nil
+	}
+	return &netproxy.FakeNetConn{Conn: conn, LAddr: localAddr, RAddr: remoteAddr}, nil
+}
+
+type netConnAddr struct {
+	network string
+	address string
+}
+
+func (a netConnAddr) Network() string { return a.network }
+func (a netConnAddr) String() string  { return a.address }
+
+type netPacketConn struct {
+	netproxy.PacketConn
+	localAddr  net.Addr
+	remoteAddr net.Addr
+}
+
+func (c *netPacketConn) LocalAddr() net.Addr  { return c.localAddr }
+func (c *netPacketConn) RemoteAddr() net.Addr { return c.remoteAddr }
+
+// EnsureNetConn adapts connections returned by a chain entry for exit
+// protocols that require the standard library's net.Conn interface.
+func EnsureNetConn(d netproxy.Dialer) netproxy.Dialer {
+	return &netConnDialer{Dialer: d}
+}

--- a/component/outbound/dialer/netconn_test.go
+++ b/component/outbound/dialer/netconn_test.go
@@ -1,0 +1,90 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2026, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package dialer
+
+import (
+	"context"
+	"net"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/daeuniverse/outbound/netproxy"
+)
+
+type netConnTestDialer struct {
+	conn netproxy.Conn
+}
+
+func (d netConnTestDialer) DialContext(context.Context, string, string) (netproxy.Conn, error) {
+	return d.conn, nil
+}
+
+type netConnTestConn struct{}
+
+func (*netConnTestConn) Read([]byte) (int, error)         { return 0, nil }
+func (*netConnTestConn) Write(p []byte) (int, error)      { return len(p), nil }
+func (*netConnTestConn) Close() error                     { return nil }
+func (*netConnTestConn) SetDeadline(time.Time) error      { return nil }
+func (*netConnTestConn) SetReadDeadline(time.Time) error  { return nil }
+func (*netConnTestConn) SetWriteDeadline(time.Time) error { return nil }
+
+type netConnTestPacketConn struct {
+	netConnTestConn
+}
+
+func (*netConnTestPacketConn) ReadFrom([]byte) (int, netip.AddrPort, error) {
+	return 0, netip.AddrPort{}, nil
+}
+func (*netConnTestPacketConn) WriteTo(p []byte, _ string) (int, error) { return len(p), nil }
+
+func TestEnsureNetConn(t *testing.T) {
+	raw := &netConnTestConn{}
+	conn, err := EnsureNetConn(netConnTestDialer{conn: raw}).DialContext(context.Background(), "tcp", "example.com:443")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := conn.(net.Conn); !ok {
+		t.Fatalf("adapted connection = %T, want net.Conn", conn)
+	}
+	if got := conn.(*netproxy.FakeNetConn).Conn; got != raw {
+		t.Fatalf("wrapped connection = %T, want original %T", got, raw)
+	}
+	if conn.(net.Conn).LocalAddr() == nil || conn.(net.Conn).RemoteAddr().String() != "example.com:443" {
+		t.Fatalf("adapted addresses = %v -> %v", conn.(net.Conn).LocalAddr(), conn.(net.Conn).RemoteAddr())
+	}
+}
+
+func TestEnsureNetConnKeepsStandardConn(t *testing.T) {
+	raw, peer := net.Pipe()
+	defer func() { _ = raw.Close() }()
+	defer func() { _ = peer.Close() }()
+	conn, err := EnsureNetConn(netConnTestDialer{conn: raw}).DialContext(context.Background(), "tcp", "example.com:443")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conn != raw {
+		t.Fatalf("adapted connection = %T, want original %T", conn, raw)
+	}
+}
+
+func TestEnsureNetConnPreservesPacketConn(t *testing.T) {
+	raw := &netConnTestPacketConn{}
+	conn, err := EnsureNetConn(netConnTestDialer{conn: raw}).DialContext(context.Background(), "udp", "1.1.1.1:53")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := conn.(net.Conn); !ok {
+		t.Fatalf("adapted packet connection = %T, want net.Conn", conn)
+	}
+	if _, ok := conn.(netproxy.PacketConn); !ok {
+		t.Fatalf("adapted packet connection = %T, want netproxy.PacketConn", conn)
+	}
+	netConn := conn.(net.Conn)
+	if netConn.LocalAddr() == nil || netConn.RemoteAddr() == nil || netConn.RemoteAddr().String() != "1.1.1.1:53" {
+		t.Fatalf("adapted packet addresses = %v -> %v", netConn.LocalAddr(), netConn.RemoteAddr())
+	}
+}

--- a/component/outbound/filter.go
+++ b/component/outbound/filter.go
@@ -38,6 +38,14 @@ type DialerSet struct {
 	nodeToTagMap map[*dialer.Dialer]string
 }
 
+func (s *DialerSet) Add(d *dialer.Dialer, subscriptionTag string) {
+	if d == nil {
+		return
+	}
+	s.dialers = append(s.dialers, d)
+	s.nodeToTagMap[d] = subscriptionTag
+}
+
 func NewDialerSetFromLinks(option *dialer.GlobalOption, tagToNodeList map[string][]string) *DialerSet {
 	return NewDialerSetFromLinksContext(context.Background(), option, tagToNodeList)
 }
@@ -49,10 +57,13 @@ func NewDialerSetFromLinksContext(ctx context.Context, option *dialer.GlobalOpti
 		nodeToTagMap: make(map[*dialer.Dialer]string),
 	}
 	for subscriptionTag, nodes := range tagToNodeList {
-		for _, node := range nodes {
+		for nodeIndex, node := range nodes {
 			d, err := dialer.NewFromLinkContext(ctx, option, dialer.InstanceOption{DisableCheck: false}, node, subscriptionTag)
 			if err != nil {
-				s.log.Infof("failed to parse node: %v", err)
+				s.log.WithFields(logrus.Fields{
+					"subscription": subscriptionTag,
+					"node_index":   nodeIndex,
+				}).WithError(err).Error("failed to parse node")
 				continue
 			}
 			s.dialers = append(s.dialers, d)

--- a/component/outbound/filter_test.go
+++ b/component/outbound/filter_test.go
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2026, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package outbound
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/daeuniverse/dae/component/outbound/dialer"
+	"github.com/sirupsen/logrus"
+)
+
+func TestDialerSetParseErrorDoesNotLogNodeLink(t *testing.T) {
+	const secret = "uuid-password-token"
+	var logs bytes.Buffer
+	log := logrus.New()
+	log.SetOutput(&logs)
+	set := NewDialerSetFromLinks(&dialer.GlobalOption{Log: log}, map[string][]string{
+		"remote": {"unknown://" + secret},
+	})
+	defer func() { _ = set.Close() }()
+	if strings.Contains(logs.String(), secret) {
+		t.Fatalf("log leaked node credentials: %s", logs.String())
+	}
+}

--- a/component/outbound/group_chain.go
+++ b/component/outbound/group_chain.go
@@ -1,0 +1,314 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2026, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package outbound
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/daeuniverse/dae/common"
+	"github.com/daeuniverse/dae/common/consts"
+	"github.com/daeuniverse/dae/component/outbound/dialer"
+	D "github.com/daeuniverse/outbound/dialer"
+	"github.com/daeuniverse/outbound/netproxy"
+	"github.com/daeuniverse/outbound/protocol/direct"
+)
+
+type groupChainDialer struct {
+	entry              *DialerGroup
+	spec               common.GroupChain
+	option             *dialer.GlobalOption
+	endpoints          map[*dialer.Dialer]netproxy.Dialer
+	validationEndpoint netproxy.Dialer
+	mu                 sync.Mutex
+	current            [8]*dialer.Dialer
+	preferCurrent      [8]bool
+	retryAt            [8]map[*dialer.Dialer]time.Time
+	closeOne           sync.Once
+}
+
+func NewGroupChainDialer(ctx context.Context, option *dialer.GlobalOption, entry *DialerGroup, spec common.GroupChain) (*dialer.Dialer, error) {
+	chain, property, err := newGroupChainNetproxyDialer(option, entry, spec)
+	if err != nil {
+		return nil, err
+	}
+	return dialer.NewDialerContext(ctx, chain, option, dialer.InstanceOption{}, property), nil
+}
+
+func newGroupChainNetproxyDialer(option *dialer.GlobalOption, entry *DialerGroup, spec common.GroupChain) (*groupChainDialer, *dialer.Property, error) {
+	if entry == nil {
+		return nil, nil, fmt.Errorf("group chain %q references a nil entry group", spec.Name)
+	}
+	c := &groupChainDialer{
+		entry:     entry,
+		spec:      spec,
+		option:    option,
+		endpoints: make(map[*dialer.Dialer]netproxy.Dialer, len(entry.Dialers)),
+	}
+	var endpointProperty *D.Property
+	for _, entryDialer := range entry.Dialers {
+		endpoint, property, err := D.NewNetproxyDialerFromLink(dialer.EnsureNetConn(entryDialer), &option.ExtraOption, spec.EndpointLink)
+		if err != nil {
+			_ = c.Close()
+			return nil, nil, fmt.Errorf("create group chain %q endpoint: %w", spec.Name, err)
+		}
+		c.endpoints[entryDialer] = endpoint
+		if endpointProperty == nil {
+			endpointProperty = property
+		}
+	}
+	if endpointProperty == nil {
+		validationEndpoint, property, err := D.NewNetproxyDialerFromLink(direct.SymmetricDirect, &option.ExtraOption, spec.EndpointLink)
+		if err != nil {
+			return nil, nil, fmt.Errorf("create group chain %q endpoint: %w", spec.Name, err)
+		}
+		c.validationEndpoint = validationEndpoint
+		endpointProperty = property
+	}
+	name := spec.Name
+	if name == "" {
+		name = endpointProperty.Name + "->group(" + spec.EntryGroup + ")"
+	}
+	property := &dialer.Property{
+		Property: D.Property{
+			Name:     name,
+			Address:  endpointProperty.Address,
+			Protocol: endpointProperty.Protocol + "->group(" + spec.EntryGroup + ")",
+			Link:     spec.Link,
+		},
+	}
+	return c, property, nil
+}
+
+func (c *groupChainDialer) ReferencedGroupName() string { return c.spec.EntryGroup }
+
+func (c *groupChainDialer) CloneWithGlobalOption(_ context.Context, option *dialer.GlobalOption) (netproxy.Dialer, error) {
+	clone, _, err := newGroupChainNetproxyDialer(option, c.entry, c.spec)
+	return clone, err
+}
+
+func (c *groupChainDialer) DialContext(ctx context.Context, network, addr string) (netproxy.Conn, error) {
+	nt := groupChainNetworkType(network, addr)
+	candidates, err := c.candidates(nt)
+	if err != nil {
+		return nil, fmt.Errorf("entry node unavailable for group %q: %w", c.spec.EntryGroup, err)
+	}
+	if len(candidates) == 0 {
+		return nil, fmt.Errorf("chain unavailable for new connections: all healthy entry nodes are awaiting retry")
+	}
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, netproxy.DialTimeout)
+		defer cancel()
+	}
+	var errs []error
+	for i, candidate := range candidates {
+		endpoint := c.endpoints[candidate]
+		if endpoint == nil {
+			continue
+		}
+		attemptCtx := ctx
+		cancelAttempt := func() {}
+		if deadline, ok := ctx.Deadline(); ok && len(candidates)-i > 1 {
+			remaining := time.Until(deadline)
+			if remaining > 0 {
+				attemptCtx, cancelAttempt = context.WithTimeout(ctx, remaining/time.Duration(len(candidates)-i))
+			}
+		}
+		conn, err := endpoint.DialContext(attemptCtx, network, addr)
+		cancelAttempt()
+		if err == nil {
+			c.setCurrent(nt, candidate)
+			return conn, nil
+		}
+		errs = append(errs, fmt.Errorf("%s: %w", candidate.Property().Name, err))
+		c.deferCandidate(nt, candidate)
+		if c.entry.GetSelectionPolicy() == consts.DialerSelectionPolicy_Fixed {
+			break
+		}
+		if ctx.Err() != nil {
+			break
+		}
+	}
+	return nil, fmt.Errorf("chain unavailable for new connections: %w", errors.Join(errs...))
+}
+
+func (c *groupChainDialer) candidates(nt *dialer.NetworkType) ([]*dialer.Dialer, error) {
+	selected, _, selectedType, err := c.entry.SelectWithExclusionResult(nt, true, nil)
+	if err != nil {
+		return nil, err
+	}
+	if selectedType == nil {
+		selectedType = nt
+	}
+	if c.entry.GetSelectionPolicy() == consts.DialerSelectionPolicy_Fixed {
+		if !selected.MustGetAlive(selectedType) {
+			return nil, ErrNoAliveDialer
+		}
+		return []*dialer.Dialer{selected}, nil
+	}
+	idx := nt.Index()
+	now := time.Now()
+	c.mu.Lock()
+	current := c.current[idx]
+	preferCurrent := c.preferCurrent[idx]
+	c.preferCurrent[idx] = false
+	retryAt := make(map[*dialer.Dialer]time.Time, len(c.retryAt[idx]))
+	for candidate, until := range c.retryAt[idx] {
+		retryAt[candidate] = until
+	}
+	c.mu.Unlock()
+	result := make([]*dialer.Dialer, 0, len(c.entry.Dialers))
+	appendCandidate := func(candidate *dialer.Dialer) {
+		if candidate == nil {
+			return
+		}
+		if !candidate.MustGetAlive(selectedType) {
+			return
+		}
+		for _, existing := range result {
+			if existing == candidate {
+				return
+			}
+		}
+		if until := retryAt[candidate]; until.After(now) {
+			return
+		}
+		result = append(result, candidate)
+	}
+	if preferCurrent {
+		appendCandidate(current)
+	}
+	appendCandidate(selected)
+	appendCandidate(current)
+	healthyCount := 0
+	for _, candidate := range c.entry.Dialers {
+		if candidate.MustGetAlive(selectedType) {
+			healthyCount++
+			appendCandidate(candidate)
+		}
+	}
+	if healthyCount == 0 {
+		return nil, ErrNoAliveDialer
+	}
+	return result, nil
+}
+
+func (c *groupChainDialer) setCurrent(nt *dialer.NetworkType, candidate *dialer.Dialer) {
+	c.mu.Lock()
+	c.current[nt.Index()] = candidate
+	if c.retryAt[nt.Index()] != nil {
+		delete(c.retryAt[nt.Index()], candidate)
+	}
+	c.mu.Unlock()
+}
+
+func (c *groupChainDialer) deferCandidate(nt *dialer.NetworkType, candidate *dialer.Dialer) {
+	idx := nt.Index()
+	interval := time.Duration(0)
+	if c.option != nil {
+		interval = c.option.CheckInterval
+	}
+	if interval <= 0 {
+		interval = c.entry.MinCheckInterval()
+	}
+	c.mu.Lock()
+	if c.retryAt[idx] == nil {
+		c.retryAt[idx] = make(map[*dialer.Dialer]time.Time)
+	}
+	c.retryAt[idx][candidate] = time.Now().Add(interval)
+	c.mu.Unlock()
+}
+
+func groupChainNetworkType(network, addr string) *dialer.NetworkType {
+	magic, err := netproxy.ParseMagicNetwork(network)
+	if err == nil {
+		network = magic.Network
+	}
+	l4 := consts.L4ProtoStr_TCP
+	if strings.HasPrefix(network, "udp") {
+		l4 = consts.L4ProtoStr_UDP
+	}
+	ipVersion := consts.IpVersionStr("")
+	if magic != nil && magic.IPVersion != "" {
+		ipVersion = consts.IpVersionStr(magic.IPVersion)
+	}
+	if ipVersion == "" {
+		if host, _, err := net.SplitHostPort(addr); err == nil {
+			if ip, err := netip.ParseAddr(strings.Trim(host, "[]")); err == nil {
+				ipVersion = consts.IpVersionFromAddr(ip)
+			}
+		}
+	}
+	if ipVersion == "" {
+		if strings.HasSuffix(network, "6") {
+			ipVersion = consts.IpVersionStr_6
+		} else {
+			ipVersion = consts.IpVersionStr_4
+		}
+	}
+	nt := &dialer.NetworkType{L4Proto: l4, IpVersion: ipVersion}
+	if l4 == consts.L4ProtoStr_UDP {
+		nt.UdpHealthDomain = dialer.UdpHealthDomainData
+	}
+	return nt
+}
+
+func (c *groupChainDialer) Close() error {
+	var closeErr error
+	c.closeOne.Do(func() {
+		for _, endpoint := range c.endpoints {
+			if closer, ok := endpoint.(interface{ Close() error }); ok {
+				closeErr = errors.Join(closeErr, closer.Close())
+			}
+		}
+		if closer, ok := c.validationEndpoint.(interface{ Close() error }); ok {
+			closeErr = errors.Join(closeErr, closer.Close())
+		}
+	})
+	return closeErr
+}
+
+func RestoreGroupChainSelection(current, previous netproxy.Dialer) {
+	to, ok := current.(*groupChainDialer)
+	if !ok {
+		return
+	}
+	from, ok := previous.(*groupChainDialer)
+	if !ok || to.spec.EntryGroup != from.spec.EntryGroup || to.spec.EndpointLink != from.spec.EndpointLink ||
+		to.entry == nil || from.entry == nil ||
+		to.entry.currentSelectionState().policy != from.entry.currentSelectionState().policy {
+		return
+	}
+	from.mu.Lock()
+	var names [8]string
+	for idx, old := range from.current {
+		if old != nil && old.Property() != nil {
+			names[idx] = old.Property().Name
+		}
+	}
+	from.mu.Unlock()
+	to.mu.Lock()
+	defer to.mu.Unlock()
+	for idx, name := range names {
+		if name == "" {
+			continue
+		}
+		for candidate := range to.endpoints {
+			if candidate.Property() != nil && candidate.Property().Name == name {
+				to.current[idx] = candidate
+				to.preferCurrent[idx] = true
+				break
+			}
+		}
+	}
+}

--- a/component/outbound/group_chain_test.go
+++ b/component/outbound/group_chain_test.go
@@ -1,0 +1,196 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2026, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package outbound
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/daeuniverse/dae/common"
+	"github.com/daeuniverse/dae/common/consts"
+	"github.com/daeuniverse/dae/component/outbound/dialer"
+	D "github.com/daeuniverse/outbound/dialer"
+	"github.com/daeuniverse/outbound/netproxy"
+)
+
+type groupChainTestEndpoint struct {
+	mu    sync.Mutex
+	fail  bool
+	calls int
+}
+
+func (d *groupChainTestEndpoint) DialContext(context.Context, string, string) (netproxy.Conn, error) {
+	d.mu.Lock()
+	d.calls++
+	fail := d.fail
+	d.mu.Unlock()
+	if fail {
+		return nil, errors.New("unreachable")
+	}
+	left, right := net.Pipe()
+	_ = right.Close()
+	return left, nil
+}
+
+func (d *groupChainTestEndpoint) setFail(fail bool) {
+	d.mu.Lock()
+	d.fail = fail
+	d.mu.Unlock()
+}
+
+func (d *groupChainTestEndpoint) callCount() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.calls
+}
+
+func newGroupChainTestEntry(option *dialer.GlobalOption, name string) *dialer.Dialer {
+	return dialer.NewDialer(noopTestDialer{}, option, dialer.InstanceOption{DisableCheck: true}, &dialer.Property{
+		Property: D.Property{Name: name, Link: name + ": direct://"},
+	})
+}
+
+func setGroupChainTestHealth(d *dialer.Dialer, latency time.Duration) {
+	snapshot := d.HealthSnapshot()
+	for _, idx := range []int{dialer.IdxTcp4, dialer.IdxDnsTcp4} {
+		snapshot.Collections[idx].Alive = true
+		snapshot.Collections[idx].Latencies = dialer.LatenciesNSnapshot{
+			Latencies:     []time.Duration{latency},
+			SumNLatencies: latency,
+		}
+	}
+	d.RestoreHealthSnapshot(snapshot)
+}
+
+func newGroupChainTestGroup(policy DialerSelectionPolicy) (*DialerGroup, []*dialer.Dialer) {
+	option := &dialer.GlobalOption{Log: log, CheckInterval: 10 * time.Second}
+	entries := []*dialer.Dialer{
+		newGroupChainTestEntry(option, "HK1"),
+		newGroupChainTestEntry(option, "HK2"),
+	}
+	group := NewDialerGroup(option, "HK", entries, newEmptyAnnotations(len(entries)), policy, func(bool, *dialer.NetworkType, bool) {})
+	setGroupChainTestHealth(entries[0], time.Millisecond)
+	setGroupChainTestHealth(entries[1], 2*time.Millisecond)
+	return group, entries
+}
+
+func TestGroupChainFailoverAndRecovery(t *testing.T) {
+	group, entries := newGroupChainTestGroup(DialerSelectionPolicy{Policy: consts.DialerSelectionPolicy_MinLastLatency})
+	hk1 := &groupChainTestEndpoint{fail: true}
+	hk2 := &groupChainTestEndpoint{}
+	chain := &groupChainDialer{
+		entry:     group,
+		spec:      common.GroupChain{EntryGroup: "HK", EndpointLink: "vmess://endpoint"},
+		endpoints: map[*dialer.Dialer]netproxy.Dialer{entries[0]: hk1, entries[1]: hk2},
+		option:    &dialer.GlobalOption{Log: log},
+	}
+
+	conn, err := chain.DialContext(context.Background(), "tcp4", "1.1.1.1:443")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = conn.Close()
+	if hk1.callCount() != 1 || hk2.callCount() != 1 {
+		t.Fatalf("calls after failover = HK1:%d HK2:%d, want 1/1", hk1.callCount(), hk2.callCount())
+	}
+
+	hk1.setFail(false)
+	chain.mu.Lock()
+	chain.retryAt[dialer.IdxTcp4] = map[*dialer.Dialer]time.Time{entries[0]: time.Now().Add(-time.Second)}
+	chain.mu.Unlock()
+	conn, err = chain.DialContext(context.Background(), "tcp4", "1.1.1.1:443")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = conn.Close()
+	if hk1.callCount() != 2 {
+		t.Fatalf("HK1 calls after recovery = %d, want 2", hk1.callCount())
+	}
+}
+
+func TestGroupChainFixedDoesNotFailOver(t *testing.T) {
+	group, entries := newGroupChainTestGroup(DialerSelectionPolicy{Policy: consts.DialerSelectionPolicy_Fixed, FixedIndex: 0})
+	hk1 := &groupChainTestEndpoint{fail: true}
+	hk2 := &groupChainTestEndpoint{}
+	chain := &groupChainDialer{
+		entry:     group,
+		spec:      common.GroupChain{EntryGroup: "HK"},
+		endpoints: map[*dialer.Dialer]netproxy.Dialer{entries[0]: hk1, entries[1]: hk2},
+	}
+
+	_, err := chain.DialContext(context.Background(), "tcp4", "1.1.1.1:443")
+	if err == nil {
+		t.Fatal("expected fixed chain failure")
+	}
+	if hk1.callCount() != 1 || hk2.callCount() != 0 {
+		t.Fatalf("calls = HK1:%d HK2:%d, want 1/0", hk1.callCount(), hk2.callCount())
+	}
+}
+
+func TestGroupChainReportsUnavailableEntry(t *testing.T) {
+	option := &dialer.GlobalOption{Log: log, CheckInterval: 10 * time.Second}
+	group := NewDialerGroup(option, "HK", nil, nil,
+		DialerSelectionPolicy{Policy: consts.DialerSelectionPolicy_MinLastLatency},
+		func(bool, *dialer.NetworkType, bool) {},
+	)
+	chain := &groupChainDialer{
+		entry:     group,
+		spec:      common.GroupChain{EntryGroup: "HK"},
+		endpoints: map[*dialer.Dialer]netproxy.Dialer{},
+	}
+
+	_, err := chain.DialContext(context.Background(), "tcp4", "1.1.1.1:443")
+	if err == nil || !strings.Contains(err.Error(), "entry node unavailable") {
+		t.Fatalf("err = %v, want entry node unavailable", err)
+	}
+}
+
+func TestRestoreGroupChainSelectionByEntryName(t *testing.T) {
+	option := &dialer.GlobalOption{Log: log, CheckInterval: 10 * time.Second}
+	oldEntry := newGroupChainTestEntry(option, "HK2")
+	newEntry := newGroupChainTestEntry(option, "HK2")
+	policy := DialerSelectionPolicy{Policy: consts.DialerSelectionPolicy_MinLastLatency}
+	oldGroup := NewDialerGroup(option, "HK", []*dialer.Dialer{oldEntry}, newEmptyAnnotations(1), policy, func(bool, *dialer.NetworkType, bool) {})
+	newGroup := NewDialerGroup(option, "HK", []*dialer.Dialer{newEntry}, newEmptyAnnotations(1), policy, func(bool, *dialer.NetworkType, bool) {})
+	oldChain := &groupChainDialer{
+		entry:     oldGroup,
+		spec:      common.GroupChain{EntryGroup: "HK", EndpointLink: "vmess://endpoint"},
+		endpoints: map[*dialer.Dialer]netproxy.Dialer{oldEntry: &groupChainTestEndpoint{}},
+		current:   [8]*dialer.Dialer{dialer.IdxTcp4: oldEntry},
+		retryAt:   [8]map[*dialer.Dialer]time.Time{dialer.IdxTcp4: {oldEntry: time.Now().Add(time.Hour)}},
+	}
+	newChain := &groupChainDialer{
+		entry:     newGroup,
+		spec:      common.GroupChain{EntryGroup: "HK", EndpointLink: "vmess://endpoint"},
+		endpoints: map[*dialer.Dialer]netproxy.Dialer{newEntry: &groupChainTestEndpoint{}},
+	}
+
+	RestoreGroupChainSelection(newChain, oldChain)
+	if newChain.current[dialer.IdxTcp4] != newEntry || !newChain.preferCurrent[dialer.IdxTcp4] {
+		t.Fatal("stable entry selection was not restored")
+	}
+	if newChain.retryAt[dialer.IdxTcp4] != nil {
+		t.Fatal("transient retry state must not be restored")
+	}
+}
+
+func TestGroupChainNetworkTypeClassifiesRoutedUdpAsData(t *testing.T) {
+	udp6 := netproxy.MagicNetwork{Network: "udp", IPVersion: "6"}.Encode()
+	got := groupChainNetworkType(udp6, "1.1.1.1:53")
+	if got.L4Proto != consts.L4ProtoStr_UDP || got.IpVersion != consts.IpVersionStr_6 ||
+		got.EffectiveUdpHealthDomain() != dialer.UdpHealthDomainData || got.IsDnsSemantic() {
+		t.Fatalf("UDP type = %#v", got)
+	}
+	tcp4 := groupChainNetworkType("tcp4", "1.1.1.1:443")
+	if tcp4.L4Proto != consts.L4ProtoStr_TCP || tcp4.IpVersion != consts.IpVersionStr_4 {
+		t.Fatalf("TCP type = %#v", tcp4)
+	}
+}

--- a/config/group_chain_test.go
+++ b/config/group_chain_test.go
@@ -1,0 +1,69 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2026, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/daeuniverse/dae/pkg/config_parser"
+)
+
+func parseGroupChainConfig(t *testing.T, node, groups string) error {
+	t.Helper()
+	sections, err := config_parser.Parse(`
+global {}
+node {
+  ` + node + `
+}
+group {
+  ` + groups + `
+}
+routing { fallback: direct }
+`)
+	if err != nil {
+		return err
+	}
+	_, err = New(sections)
+	return err
+}
+
+func TestConfigAcceptsGroupChain(t *testing.T) {
+	err := parseGroupChainConfig(t,
+		`hk_to_us: 'vmess://endpoint -> group(HK)'`,
+		`HK { policy: min filter: name(HK1) }`,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestConfigRejectsUnknownGroupChainEntry(t *testing.T) {
+	err := parseGroupChainConfig(t, `hk_to_us: 'vmess://endpoint -> group(HK)'`, "")
+	if err == nil || !strings.Contains(err.Error(), `unknown group "HK"`) {
+		t.Fatalf("err = %v, want unknown group", err)
+	}
+}
+
+func TestConfigRejectsNestedGroupChain(t *testing.T) {
+	err := parseGroupChainConfig(t,
+		`bad: 'vmess://endpoint -> vmess://relay -> group(HK)'`,
+		`HK { policy: min }`,
+	)
+	if err == nil || !strings.Contains(err.Error(), "endpoint -> group(NAME)") {
+		t.Fatalf("err = %v, want group chain shape error", err)
+	}
+}
+
+func TestConfigAcceptsOrdinaryThreeNodeChain(t *testing.T) {
+	err := parseGroupChainConfig(t,
+		`chain: 'vmess://endpoint -> tuic://relay-1 -> vless://relay-2'`,
+		`HK { policy: min }`,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/config/patch.go
+++ b/config/patch.go
@@ -6,12 +6,13 @@
 package config
 
 import (
-	"github.com/daeuniverse/dae/common"
-	"github.com/sirupsen/logrus"
+	"fmt"
 	"strings"
 
+	"github.com/daeuniverse/dae/common"
 	"github.com/daeuniverse/dae/common/consts"
 	"github.com/daeuniverse/dae/pkg/config_parser"
+	"github.com/sirupsen/logrus"
 )
 
 type patch func(params *Config) error
@@ -19,6 +20,7 @@ type patch func(params *Config) error
 var patches = []patch{
 	patchBootstrapResolver,
 	patchTcpCheckHttpMethod,
+	patchProxyChains,
 	patchEmptyDns,
 	patchMustOutbound,
 }
@@ -32,6 +34,27 @@ func patchTcpCheckHttpMethod(params *Config) error {
 	if !common.IsValidHttpMethod(params.Global.TcpCheckHttpMethod) {
 		logrus.Warnf("Unknown HTTP Method '%v'. Fallback to 'CONNECT'.", params.Global.TcpCheckHttpMethod)
 		params.Global.TcpCheckHttpMethod = "CONNECT"
+	}
+	return nil
+}
+
+func patchProxyChains(params *Config) error {
+	groups := make(map[string]struct{}, len(params.Group))
+	for _, group := range params.Group {
+		groups[group.Name] = struct{}{}
+	}
+	for _, node := range params.Node {
+		name, _ := common.GetTagFromLinkLikePlaintext(string(node))
+		chain, matched, err := common.ParseGroupChain(string(node))
+		if err != nil {
+			return fmt.Errorf("proxy chain %q: %w", name, err)
+		}
+		if !matched {
+			continue
+		}
+		if _, ok := groups[chain.EntryGroup]; !ok {
+			return fmt.Errorf("group chain %q references unknown group %q", chain.Name, chain.EntryGroup)
+		}
 	}
 	return nil
 }

--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -559,14 +559,43 @@ func newControlPlaneWithContextOptions(
 			}, core.outboundAliveChangeCallback(1, disableKernelAliveCallback)),
 	}
 
-	// Filter out groups.
-	dialerSet := outbound.NewDialerSetFromLinksContext(context.Background(), option, tagToNodeList)
+	// Group-entry chains depend on a group selector, so defer only those nodes
+	// until their entry groups have been built. Ordinary nodes and node chains
+	// keep the existing construction path.
+	baseNodes := make(map[string][]string, len(tagToNodeList))
+	var groupChains []common.GroupChain
+	for subscriptionTag, nodes := range tagToNodeList {
+		for _, node := range nodes {
+			chain, matched, parseErr := common.ParseGroupChain(node)
+			if parseErr != nil {
+				return nil, parseErr
+			}
+			if matched {
+				groupChains = append(groupChains, *chain)
+				continue
+			}
+			baseNodes[subscriptionTag] = append(baseNodes[subscriptionTag], node)
+		}
+	}
+	dialerSet := outbound.NewDialerSetFromLinksContext(context.Background(), option, baseNodes)
 	deferFuncs = append(deferFuncs, dialerSet.Close)
 	deferFuncs = append(deferFuncs, func() error {
 		dialer.CleanupTransportCacheNamespace(option.TransportCacheNamespace)
 		return nil
 	})
-	for _, group := range groups {
+	groupIndex := make(map[string]int, len(groups))
+	for i := range groups {
+		if _, exists := groupIndex[groups[i].Name]; exists {
+			return nil, fmt.Errorf("duplicated outbound name: %v", groups[i].Name)
+		}
+		groupIndex[groups[i].Name] = i
+	}
+	builtGroups := make([]*outbound.DialerGroup, len(groups))
+	buildGroup := func(i int) (*outbound.DialerGroup, error) {
+		if builtGroups[i] != nil {
+			return builtGroups[i], nil
+		}
+		group := groups[i]
 		// Parse policy.
 		policy, err := outbound.NewDialerSelectionPolicyFromGroupParam(&group)
 		if err != nil {
@@ -603,8 +632,57 @@ func newControlPlaneWithContextOptions(
 		}
 		// Create dialer group and append it to outbounds.
 		dialerGroup := outbound.NewDialerGroup(finalOption, group.Name, dialers, annos, *policy,
-			core.outboundAliveChangeCallback(uint8(len(outbounds)), disableKernelAliveCallback))
-		outbounds = append(outbounds, dialerGroup)
+			core.outboundAliveChangeCallback(uint8(i+int(consts.OutboundUserDefinedMin)), disableKernelAliveCallback))
+		builtGroups[i] = dialerGroup
+		return dialerGroup, nil
+	}
+
+	entryGroups := make(map[string]*outbound.DialerGroup, len(groupChains))
+	for _, chain := range groupChains {
+		i, ok := groupIndex[chain.EntryGroup]
+		if !ok {
+			return nil, fmt.Errorf("group chain %q references unknown group %q", chain.Name, chain.EntryGroup)
+		}
+		entryGroup, err := buildGroup(i)
+		if err != nil {
+			return nil, err
+		}
+		for _, entryDialer := range entryGroup.Dialers {
+			_, linklike := common.GetTagFromLinkLikePlaintext(entryDialer.Property().Link)
+			if strings.Contains(linklike, "->") {
+				return nil, fmt.Errorf("group chain %q entry group %q contains chained node %q", chain.Name, chain.EntryGroup, entryDialer.Property().Name)
+			}
+		}
+		entryGroups[chain.EntryGroup] = entryGroup
+	}
+	for _, chain := range groupChains {
+		chainDialer, err := outbound.NewGroupChainDialer(context.Background(), option, entryGroups[chain.EntryGroup], chain)
+		if err != nil {
+			return nil, err
+		}
+		dialerSet.Add(chainDialer, "")
+	}
+	// Re-evaluate referenced entry filters after chain nodes exist. If an entry
+	// group would select any chain (including itself), reject the generation.
+	for name := range entryGroups {
+		i := groupIndex[name]
+		dialers, _, err := dialerSet.FilterAndAnnotate(groups[i].Filter, groups[i].FilterAnnotation)
+		if err != nil {
+			return nil, fmt.Errorf(`failed to validate group "%v": %w`, name, err)
+		}
+		for _, entryDialer := range dialers {
+			_, linklike := common.GetTagFromLinkLikePlaintext(entryDialer.Property().Link)
+			if strings.Contains(linklike, "->") {
+				return nil, fmt.Errorf("group chain entry group %q contains chained node %q", name, entryDialer.Property().Name)
+			}
+		}
+	}
+	for i := range groups {
+		group, err := buildGroup(i)
+		if err != nil {
+			return nil, err
+		}
+		outbounds = append(outbounds, group)
 	}
 
 	registeredDialerCallbacks := make(map[*dialer.Dialer]struct{})
@@ -675,6 +753,18 @@ func newControlPlaneWithContextOptions(
 
 	// Get referenced outbounds to limit health checks.
 	referencedOutbounds := builder.GetReferencedOutbounds()
+	// A group used as a chain entry is a health dependency of the routed outer
+	// group even though routing rules do not name it directly.
+	for _, group := range outbounds {
+		if _, referenced := referencedOutbounds[group.Name]; !referenced {
+			continue
+		}
+		for _, d := range group.Dialers {
+			if dependency, ok := d.Dialer.(interface{ ReferencedGroupName() string }); ok {
+				referencedOutbounds[dependency.ReferencedGroupName()] = struct{}{}
+			}
+		}
+	}
 	if len(referencedOutbounds) > 0 {
 		var names []string
 		for name := range referencedOutbounds {
@@ -1141,7 +1231,12 @@ func (c *ControlPlane) InheritDialerHealthFrom(previous *ControlPlane) bool {
 				continue
 			}
 			if oldDialer := oldDialers[d.Property().Name]; oldDialer != nil {
+				_, linklike := common.GetTagFromLinkLikePlaintext(d.Property().Link)
+				if strings.Contains(linklike, "->") && d.Property().Link != oldDialer.Property().Link {
+					continue
+				}
 				d.RestoreHealthSnapshot(oldDialer.ReloadHealthSnapshot())
+				outbound.RestoreGroupChainSelection(d.Dialer, oldDialer.Dialer)
 				hasOverlap = true
 			}
 		}

--- a/control/control_plane_drain_test.go
+++ b/control/control_plane_drain_test.go
@@ -729,6 +729,42 @@ func TestInheritDialerHealthFromReturnsFalseWhenNoOverlap(t *testing.T) {
 	}
 }
 
+func TestInheritDialerHealthFromSkipsChangedChainLink(t *testing.T) {
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+	option := &dialer.GlobalOption{Log: logger, CheckInterval: 30 * time.Second}
+	newTestDialer := func(link string) *dialer.Dialer {
+		return dialer.NewDialer(direct.SymmetricDirect, option, dialer.InstanceOption{}, &dialer.Property{
+			Property: D.Property{Name: "chain", Link: link},
+		})
+	}
+	oldDialer := newTestDialer("vmess://hk -> vmess://us")
+	defer func() { _ = oldDialer.Close() }()
+	newDialer := newTestDialer("vmess://sg -> vmess://jp")
+	defer func() { _ = newDialer.Close() }()
+	newGroup := func(d *dialer.Dialer) *outbound.DialerGroup {
+		return outbound.NewDialerGroup(option, "proxy", []*dialer.Dialer{d}, []*dialer.Annotation{{}},
+			outbound.DialerSelectionPolicy{Policy: consts.DialerSelectionPolicy_MinLastLatency},
+			func(bool, *dialer.NetworkType, bool) {})
+	}
+	oldGroup := newGroup(oldDialer)
+	defer func() { _ = oldGroup.Close() }()
+	newGroupValue := newGroup(newDialer)
+	defer func() { _ = newGroupValue.Close() }()
+	tcp4 := &dialer.NetworkType{L4Proto: consts.L4ProtoStr_TCP, IpVersion: consts.IpVersionStr_4}
+	oldDialer.ReportUnavailableForced(tcp4, nil)
+	oldDialer.NotifyHealthCheckResult(tcp4, false, false)
+
+	oldCP := &ControlPlane{controlPlaneGenerationState: controlPlaneGenerationState{outbounds: []*outbound.DialerGroup{oldGroup}}}
+	newCP := &ControlPlane{controlPlaneGenerationState: controlPlaneGenerationState{outbounds: []*outbound.DialerGroup{newGroupValue}}}
+	if newCP.InheritDialerHealthFrom(oldCP) {
+		t.Fatal("changed chain link must not inherit old health")
+	}
+	if !newDialer.MustGetAlive(tcp4) {
+		t.Fatal("changed chain unexpectedly inherited unavailable health")
+	}
+}
+
 func TestWaitDNSUpstreamsReadyReturnsWhenChannelCloses(t *testing.T) {
 	cp := &ControlPlane{
 		ctx:   context.Background(),

--- a/example.dae
+++ b/example.dae
@@ -181,7 +181,12 @@ node {
     mylink: 'ss://LINK'
     node1: 'vmess://LINK'
     node2: 'vless://LINK'
-    chains: 'tuic://LINK -> vmess://LINK'
+    # Proxy chains keep endpoint -> relay order. The destination sees the endpoint's IP.
+    chains: 'vmess://ENDPOINT_LINK -> tuic://RELAY_LINK'
+    # A group entry chain uses one concrete endpoint followed by one entry group.
+    # The entry group cannot contain chain nodes.
+    # Chain nodes are selected by name(), not subtag().
+    group_entry_chain: 'vmess://US_ENDPOINT_LINK -> group(group2)'
     hysteria2: 'hysteria2://password@server-ip:port/?sni=domain'
 }
 


### PR DESCRIPTION
## Summary

- support proxy chains whose client-facing entry is selected from an existing group
- preserve dae's existing `endpoint -> relay` chain order and ordinary N-node chain behavior
- add the group-entry form `endpoint -> group(entry)` without changing ordinary chain parsing
- preserve UDP packet capability and classify routed UDP with the data-UDP health domain
- retain useful subscription errors without logging credential-bearing node URLs

## Motivation

Ordinary proxy chains require every hop to be a concrete node. This prevents a chain from reusing an existing group's health checks and selection policy for its client-facing entry hop.

This change adds a group-entry form while retaining dae's established chain notation:

```dae
group_entry_chain: 'vmess://US_ENDPOINT_LINK -> group(group2)'
```

The configuration remains in endpoint-to-relay order. The physical traffic path is:

```text
client -> selected group entry -> concrete endpoint -> target
```

The destination therefore observes the concrete endpoint's address.

## Behavior and compatibility

- Ordinary chains continue to use the existing outbound implementation, including chains with more than two concrete nodes.
- Only chains containing `group(...)` use the new group-chain handling.
- A group-entry chain contains one concrete endpoint followed by one existing group: `endpoint -> group(entry)`.
- The referenced entry group cannot select chain nodes, preventing nested and self-referential group chains.
- The entry group's selection policy and health state are reused. Non-fixed policies can try another healthy entry candidate when one complete entry-to-endpoint path fails.
- The selected entry is restored when possible during a control-plane reload to avoid unnecessary path changes.

## Connection compatibility

Some entry protocols return `netproxy.Conn`, while endpoint protocols such as Shadowsocks 2022 and AnyTLS require the standard `net.Conn` interface.

The group-chain boundary adapts entry connections without replacing existing `net.Conn` implementations. The adapter supplies non-nil local and remote addresses and preserves `netproxy.PacketConn`, so UDP packet paths remain available.

Routed UDP is classified with `UdpHealthDomainData`, keeping data-path UDP health separate from DNS UDP health.

## Subscription handling

Group-entry chains are local configuration constructs because they reference a local group, so subscription-provided group chains are skipped. Ordinary multi-node subscription chains remain accepted.

Skipped nodes are reported by subscription tag and index without logging the full node URL. Resolution and parse failures retain the underlying error for diagnostics. Persisted subscription content is replaced only after an update contains at least one usable node, preserving the last valid content when an update contains no usable entries.

## Testing

Tested on an ARM64 RK3568 board running Linux 6.18.41 with the amended binary. TCP used an external HTTP target; data-path UDP used a STUN binding request on UDP/3478 with transaction-ID validation.

| Client-facing entry | Concrete endpoint | TCP | Data UDP |
| --- | --- | --- | --- |
| Hysteria2/UDP | Hysteria2/UDP | Passed | Passed |
| VMess/TCP | Hysteria2/UDP | Passed | Passed |
| Hysteria2/UDP | VMess/TCP | Passed | Passed |
| VMess/TCP | VMess/TCP | Passed | Passed |

For every combination, server logs showed the RK3568 connecting to the public entry and the endpoint receiving its connection from the local entry service, confirming the physical order `client -> entry -> endpoint -> target`.

Additional validation:

- `go test -count=1 -tags dae_stub_ebpf ./common/... ./config/...`
- `GOOS=linux GOARCH=arm64 go test -count=1 -exec=true -tags dae_stub_ebpf ./component/outbound/... ./control/...`
- Linux x86_64 tests for `./common/...`, `./config/...`, and `./component/outbound/...`
- Linux x86_64 targeted control-plane reload and drain tests
- `git diff --check`

The full Linux CI remains the authoritative coverage for lint, eBPF audit, kernel tests, and all architecture builds.
