### PR TITLE
fix(control): preserve dae DNS in group overrides

### DIFF
--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -587,10 +587,9 @@ func newControlPlaneWithContextOptions(
 				log.Debugln("\t<Empty>")
 			}
 		}
-		groupOption, err := ParseGroupOverrideOption(group, *global, log)
+		groupOption, err := parseGroupOverrideOptionWithRuntime(group, *global, log, option)
 		finalOption := option
 		if err == nil && groupOption != nil {
-			groupOption.TransportCacheNamespace = option.TransportCacheNamespace
 			newDialers := make([]*dialer.Dialer, 0)
 			for _, d := range dialers {
 				newDialer := d.CloneWithGlobalOptionContext(context.Background(), groupOption)
@@ -867,6 +866,32 @@ func ParseGroupOverrideOption(group config.Group, global config.Global, log *log
 		return option, nil
 	}
 	return nil, nil
+}
+
+func parseGroupOverrideOptionWithRuntime(
+	group config.Group,
+	global config.Global,
+	log *logrus.Logger,
+	runtimeSource *dialer.GlobalOption,
+) (*dialer.GlobalOption, error) {
+	option, err := ParseGroupOverrideOption(group, global, log)
+	if err != nil || option == nil {
+		return option, err
+	}
+	inheritGroupOptionRuntime(option, runtimeSource)
+	return option, nil
+}
+
+// inheritGroupOptionRuntime preserves dependencies that are assembled while
+// building the control plane rather than derived from config.Global. Group
+// health-check overrides rebuild GlobalOption from config, so dropping these
+// fields would make the cloned node dialers bypass dae's internal DNS router.
+func inheritGroupOptionRuntime(dst, src *dialer.GlobalOption) {
+	if dst == nil || src == nil {
+		return
+	}
+	dst.DaeDNS = src.DaeDNS
+	dst.TransportCacheNamespace = src.TransportCacheNamespace
 }
 
 // clearReloadDomainRoutingMap keeps reload behavior aligned with main:

--- a/control/group_override_option_test.go
+++ b/control/group_override_option_test.go
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright (c) 2022-2026, daeuniverse Organization <dae@v2raya.org>
+ */
+
+package control
+
+import (
+	"testing"
+	"time"
+
+	"github.com/daeuniverse/dae/component/daedns"
+	componentdialer "github.com/daeuniverse/dae/component/outbound/dialer"
+	"github.com/daeuniverse/dae/config"
+	"github.com/sirupsen/logrus"
+)
+
+func TestParseGroupOverrideOptionWithRuntimePreservesDaeDNS(t *testing.T) {
+	router := &daedns.Router{}
+	src := &componentdialer.GlobalOption{
+		DaeDNS:                  router,
+		TransportCacheNamespace: "reload-generation-1",
+	}
+
+	dst, err := parseGroupOverrideOptionWithRuntime(config.Group{
+		CheckInterval: time.Minute,
+	}, config.Global{}, logrus.New(), src)
+	if err != nil {
+		t.Fatalf("parseGroupOverrideOptionWithRuntime() error = %v", err)
+	}
+	if dst == nil {
+		t.Fatal("expected group override option")
+	}
+
+	if dst.DaeDNS != router {
+		t.Fatal("group override dropped dae DNS router")
+	}
+	if dst.TransportCacheNamespace != src.TransportCacheNamespace {
+		t.Fatalf("TransportCacheNamespace = %q, want %q", dst.TransportCacheNamespace, src.TransportCacheNamespace)
+	}
+}


### PR DESCRIPTION
## Summary

- preserve runtime-injected `DaeDNS` when group health-check overrides rebuild `GlobalOption`
- continue preserving `TransportCacheNamespace` through the same runtime inheritance path
- add a regression test covering both runtime fields

## Root cause

Group health-check overrides rebuild `GlobalOption` from `config.Global`. Runtime dependencies are attached later while constructing the control plane, so the rebuilt option dropped the internal dae DNS router. Dialers cloned for an overridden group could therefore bypass dae's internal DNS routing when resolving node hostnames.

## Impact

Groups that override connectivity-check settings keep using the configured internal DNS routing for node resolution.