### PR TITLE
fix(dialer): apply add_latency offset for network types without a latency probe

### DIFF
--- a/component/outbound/dialer/alive_dialer_set.go
+++ b/component/outbound/dialer/alive_dialer_set.go
@@ -254,7 +254,7 @@ func (a *AliveDialerSet) NotifyLatencyChange(dialer *Dialer, alive bool) {
 			a.dialerToIndex[dialer] = len(a.aliveEntries)
 			a.aliveEntries = append(a.aliveEntries, aliveEntry{
 				dialer:         dialer,
-				sortingLatency: 0, // Will be updated below if hasLatency
+				sortingLatency: rawLatency + a.dialerToLatencyOffset[dialer],
 			})
 		}
 	} else {
@@ -376,14 +376,24 @@ func (a *AliveDialerSet) NotifyLatencyChange(dialer *Dialer, alive bool) {
 				}
 			}
 		}
-	} else if alive && minPolicy && a.minLatency.dialer == nil {
-		// Use first dialer if no dialer has alive state (usually happen at the very beginning).
-		a.minLatency.dialer = dialer
+	} else if alive && minPolicy {
+		// No active latency probe for this network type (e.g. data-UDP), so
+		// hasLatency is always false here. Honor add_latency as a manual
+		// weight by incorporating the offset and letting it override the
+		// optimistic first-dialer selection (see issue #1072).
+		sortingLatency = rawLatency + a.dialerToLatencyOffset[dialer]
+		if index := a.dialerToIndex[dialer]; index >= 0 {
+			a.aliveEntries[index].sortingLatency = sortingLatency
+		}
+		if a.minLatency.dialer == nil || sortingLatency < a.minLatency.sortingLatency {
+			a.minLatency.dialer = dialer
+			a.minLatency.sortingLatency = sortingLatency
+		}
 		if a.log.IsLevelEnabled(logrus.InfoLevel) {
 			a.log.WithFields(logrus.Fields{
 				"group":   a.dialerGroupName,
 				"network": a.CheckTyp.String(),
-				"dialer":  a.minLatency.dialer.property.Name,
+				"dialer":  dialer.property.Name,
 			}).Infof("Group selects dialer")
 		}
 	}
@@ -435,11 +445,11 @@ func (a *AliveDialerSet) recomputeSelectionStateLocked() {
 		rawLatency, hasLatency := entry.dialer.snapshotLatencyForPolicy(a.CheckTyp, a.selectionPolicy)
 		if hasLatency {
 			a.dialerToLatency[entry.dialer] = rawLatency
-			entry.sortingLatency = rawLatency + a.dialerToLatencyOffset[entry.dialer]
-			continue
 		}
-		// Keep optimistic startup semantics for alive dialers without latency data yet.
-		entry.sortingLatency = 0
+		// Always apply the manual latency offset. For network types without
+		// an active latency probe (e.g. data-UDP) the offset is the only
+		// ranking signal, so add_latency acts as a true manual weight.
+		entry.sortingLatency = rawLatency + a.dialerToLatencyOffset[entry.dialer]
 	}
 
 	a.calcMinLatency()


### PR DESCRIPTION
## Summary

`add_latency` (the manual latency offset / weight) is currently a **structural no-op for data-UDP** (UDP/QUIC data traffic), and in fact for any network type that has no active latency probe.

### Root cause

In `component/outbound/dialer/alive_dialer_set.go` the offset is only folded into `sortingLatency` inside the `if hasLatency` branch:

- `NotifyLatencyChange`: `sortingLatency = rawLatency + a.dialerToLatencyOffset[dialer]` and the `aliveEntries[index].sortingLatency` write both live inside `if hasLatency`.
- `recomputeSelectionStateLocked`: entries without a measured latency are forced to `entry.sortingLatency = 0` instead of `0 + offset`.

For **data-UDP** there is no active latency probe (`hasLatency` is always `false`), so the offset never reaches `sortingLatency` and the dialer keeps `sortingLatency = 0`. Selection therefore ignores `add_latency` entirely for that traffic class — only TCP and DNS-UDP (which do have probes) honor it. The previous "optimistic first-dialer" branch also meant even a lower-offset data-UDP dialer could not displace the first one that came up.

### Fix

Always incorporate the offset into `sortingLatency`, regardless of whether a measured latency exists:

1. `recomputeSelectionStateLocked` now applies the offset for every entry (the `0` fallback is removed).
2. New entries are seeded with `rawLatency + offset` on add.
3. The `!hasLatency` branch in `NotifyLatencyChange` now folds in the offset and keeps `minLatency` consistent, so a lower-offset dialer wins even at startup and **re-wins after it recovers** from a failure (the recovery path calls `NotifyLatencyChange` via `ReportAvailableTraffic` -> `markAvailableTraffic`).

### Behavior / failover

- A dialer configured with `add_latency: -2000ms` (e.g. to pin a preferred node) now correctly wins data-UDP selection.
- Failover is preserved: when a dialer dies its entry is removed and `calcMinLatency` selects the next best (by offset); when it revives it is re-evaluated and re-wins if its offset is the lowest.
- TCP / DNS-UDP behavior is unchanged — the offset was already applied there, and the new code paths only affect the previously-unhandled `!hasLatency` case.

### Notes

- Reviewed against the selection hot path (`GetMinLatency` / `calcMinLatency`, which both read `aliveEntries[i].sortingLatency`).
- I could not run `go build`/`go test` in my environment, so CI build + the existing dialer tests are the source of truth here. Happy to add a focused unit test for data-UDP `add_latency` selection if maintainers want one before merge.

Fixes #1072
