### PR TITLE
fix(dialer): reuse DNS-UDP latency for data-UDP node selection

### DIFF
--- a/component/outbound/dialer/alive_dialer_set.go
+++ b/component/outbound/dialer/alive_dialer_set.go
@@ -252,10 +252,10 @@ func (a *AliveDialerSet) NotifyLatencyChange(dialer *Dialer, alive bool) {
 				}
 			}
 			a.dialerToIndex[dialer] = len(a.aliveEntries)
-			a.aliveEntries = append(a.aliveEntries, aliveEntry{
-				dialer:         dialer,
-				sortingLatency: 0, // Will be updated below if hasLatency
-			})
+		a.aliveEntries = append(a.aliveEntries, aliveEntry{
+			dialer:         dialer,
+			sortingLatency: rawLatency + a.dialerToLatencyOffset[dialer],
+		})
 		}
 	} else {
 		index := a.dialerToIndex[dialer]
@@ -376,14 +376,24 @@ func (a *AliveDialerSet) NotifyLatencyChange(dialer *Dialer, alive bool) {
 				}
 			}
 		}
-	} else if alive && minPolicy && a.minLatency.dialer == nil {
-		// Use first dialer if no dialer has alive state (usually happen at the very beginning).
-		a.minLatency.dialer = dialer
+	} else if alive && minPolicy {
+		// No active latency probe for this network type (e.g. data-UDP), so
+		// hasLatency is always false here. Honor add_latency as a manual
+		// weight by incorporating the offset and letting it override the
+		// optimistic first-dialer selection (see issue #1072).
+		sortingLatency = rawLatency + a.dialerToLatencyOffset[dialer]
+		if index := a.dialerToIndex[dialer]; index >= 0 {
+			a.aliveEntries[index].sortingLatency = sortingLatency
+		}
+		if a.minLatency.dialer == nil || sortingLatency < a.minLatency.sortingLatency {
+			a.minLatency.dialer = dialer
+			a.minLatency.sortingLatency = sortingLatency
+		}
 		if a.log.IsLevelEnabled(logrus.InfoLevel) {
 			a.log.WithFields(logrus.Fields{
 				"group":   a.dialerGroupName,
 				"network": a.CheckTyp.String(),
-				"dialer":  a.minLatency.dialer.property.Name,
+				"dialer":  dialer.property.Name,
 			}).Infof("Group selects dialer")
 		}
 	}
@@ -435,11 +445,11 @@ func (a *AliveDialerSet) recomputeSelectionStateLocked() {
 		rawLatency, hasLatency := entry.dialer.snapshotLatencyForPolicy(a.CheckTyp, a.selectionPolicy)
 		if hasLatency {
 			a.dialerToLatency[entry.dialer] = rawLatency
-			entry.sortingLatency = rawLatency + a.dialerToLatencyOffset[entry.dialer]
-			continue
 		}
-		// Keep optimistic startup semantics for alive dialers without latency data yet.
-		entry.sortingLatency = 0
+		// Always apply the manual latency offset. For network types without
+		// an active latency probe (e.g. data-UDP) the offset is the only
+		// ranking signal, so add_latency acts as a true manual weight.
+		entry.sortingLatency = rawLatency + a.dialerToLatencyOffset[entry.dialer]
 	}
 
 	a.calcMinLatency()

--- a/component/outbound/dialer/connectivity_check.go
+++ b/component/outbound/dialer/connectivity_check.go
@@ -174,7 +174,31 @@ func (d *Dialer) snapshotLatencyForPolicy(
 	policy consts.DialerSelectionPolicy,
 ) (rawLatency time.Duration, hasLatency bool) {
 	d.collectionFineMu.RLock()
-	collection := d.mustGetCollection(typ)
+	// Data-UDP has no latency probe of its own: real proxied UDP traffic only
+	// flips the alive flag and never records a delay. As a result, data-UDP
+	// always reported hasLatency=false and relied solely on configuration order
+	// / add_latency for node selection, which (a) made add_latency a no-op (see
+	// issue #1072) and (b) let TCP and data-UDP pick divergent nodes.
+	//
+	// We reuse the measured latency of the DNS-UDP health domain of the same
+	// dialer as a proxy signal. In typical deployments the DNS-UDP probe and
+	// data-UDP traffic traverse the very same upstream proxy channel (only the
+	// final destination differs by a few milliseconds), so the DNS-UDP delay is
+	// a faithful representation of the channel quality seen by data-UDP.
+	//
+	// Only the latency value is borrowed. The data-UDP alive state remains
+	// driven exclusively by real UDP traffic, preserving the deliberate
+	// isolation between the DNS and data UDP health domains.
+	latencyType := typ
+	if typ.L4Proto == consts.L4ProtoStr_UDP && typ.EffectiveUdpHealthDomain() == UdpHealthDomainData {
+		latencyType = &NetworkType{
+			L4Proto:         consts.L4ProtoStr_UDP,
+			IpVersion:       typ.IpVersion,
+			IsDns:           true,
+			UdpHealthDomain: UdpHealthDomainDns,
+		}
+	}
+	collection := d.mustGetCollection(latencyType)
 	switch policy {
 	case consts.DialerSelectionPolicy_MinLastLatency:
 		rawLatency, hasLatency = collection.Latencies10.LastLatency()


### PR DESCRIPTION
## Summary

Data-UDP has no latency probe of its own: real proxied UDP traffic only
flips the alive flag and never records a delay. As a result,
`Dialer.snapshotLatencyForPolicy` always reported `hasLatency=false` for
the data-UDP health domain, and node selection fell back to configuration
order / `add_latency` only. Two consequences:

1. `add_latency` was a **no-op for data-UDP** (issue #1072) — the manual
   weight was dropped because it was gated behind `hasLatency`.
2. **TCP and data-UDP could pick divergent nodes**, because TCP sorts by a
   real measured channel latency while data-UDP sorted by config order.

This PR makes data-UDP borrow the **measured latency of the DNS-UDP health
domain of the same dialer** as a proxy signal, and additionally applies
`add_latency` unconditionally so the manual weight works even before any
latency is available.

## Why this is valid

In typical deployments the DNS-UDP probe and real data-UDP traffic
traverse the **very same upstream proxy channel** — only the final
destination differs (DNS server vs. target site), and that tail segment is
just a few milliseconds. So the DNS-UDP delay is a faithful representation
of the channel quality that data-UDP would see.

## What changes

**1. Borrow DNS-UDP latency (`snapshotLatencyForPolicy`)**

For a data-UDP `NetworkType`, redirect the latency read to the
corresponding DNS-UDP collection (same IP version):

```go
latencyType := typ
if typ.L4Proto == consts.L4ProtoStr_UDP && typ.EffectiveUdpHealthDomain() == UdpHealthDomainData {
    latencyType = &NetworkType{
        L4Proto:         consts.L4ProtoStr_UDP,
        IpVersion:       typ.IpVersion,
        IsDns:           true,
        UdpHealthDomain: UdpHealthDomainDns,
    }
}
collection := d.mustGetCollection(latencyType)
```

**2. Apply `add_latency` unconditionally (`AliveDialerSet`)**

For network types without an active probe, `hasLatency` is always false,
so the offset was never folded into `sortingLatency`. Now the offset is
always added (in `NotifyLatencyChange` entry creation and
`recomputeSelectionStateLocked`), using strict `<` when overriding
`minLatency` so ties keep the earlier-registered dialer — consistent with
`calcMinLatency`.

## Combined effect

- `add_latency` works for data-UDP **from the very first selection**
  (offset-only during the startup window before the DNS-UDP probe
  returns), and keeps working once the borrowed proxy latency arrives
  (`proxy latency + offset`).
- data-UDP sorts by **real channel latency + offset**, the same signal TCP
  uses, so TCP and data-UDP tend to converge on the same node.
- Fixes #1072.

## Isolation is preserved

**Only the latency value is borrowed.** The data-UDP alive state is still
driven exclusively by real proxied UDP traffic
(`ReportAvailableTraffic` / `markUnavailableTraffic`). DNS probe failures
do **not** poison the data-UDP health domain, keeping the deliberate
separation between DNS-UDP and data-UDP that protects long-lived QUIC /
game sessions.

## Notes / scope

- The borrowed latency is refreshed whenever the data-UDP domain transitions
  alive (startup seeding and revivals driven by real UDP traffic). In steady
  state with active UDP this captures channel quality at each evaluation.
- **Supersedes PR #1073.** That PR only unblocked `add_latency` for
  data-UDP (its entire scope); this PR folds that in (mechanism 2 above)
  and additionally gives data-UDP a real measured signal and aligns it with
  TCP.

## Test plan

- [ ] `go test ./component/outbound/...`
- [ ] Configure a group with `add_latency` on a data-UDP-capable node and
      confirm it is honored from the first selection and after probe return.
- [ ] Confirm TCP and data-UDP select the same lowest-latency node.

Fixes: #1072
Supersedes: #1073
