### PR TITLE
fix(control): disable rp_filter in dae netns

### DIFF
--- a/control/netns_utils.go
+++ b/control/netns_utils.go
@@ -468,6 +468,16 @@ func (ns *DaeNetns) setupSysctl() (err error) {
 	_ = sysctl.Keyf("net.ipv4.tcp_early_demux").Set("1", false)
 	_ = sysctl.Keyf("net.ipv4.ip_early_demux").Set("1", false)
 
+	// Reverse-path filtering in daens can reject locally generated proxied IPv4
+	// traffic before the TProxy socket receives it. Linux uses the stricter of
+	// conf/all and conf/<interface>, so both values must be disabled here.
+	if err = sysctl.Keyf("net.ipv4.conf.all.rp_filter").Set("0", false); err != nil {
+		return fmt.Errorf("failed to set rp_filter for all in daens: %v", err)
+	}
+	if err = sysctl.Keyf("net.ipv4.conf.%s.rp_filter", NsVethName).Set("0", false); err != nil {
+		return fmt.Errorf("failed to set rp_filter for dae0peer: %v", err)
+	}
+
 	// (ip net e daens) sysctl net.ipv4.conf.dae0peer.accept_local=1
 	// This is to prevent kernel from dropping skb due to "martian source" check: https://elixir.bootlin.com/linux/v6.6/source/net/ipv4/fib_frontend.c#L381
 	if err = sysctl.Keyf("net.ipv4.conf.%s.accept_local", NsVethName).Set("1", false); err != nil {


### PR DESCRIPTION
### Background

Local IPv4 traffic proxied through dae can be dropped inside `daens` by Linux reverse-path filtering.

The host-side namespace already disables `rp_filter`, but `daens` has its own sysctl state. Linux reverse-path validation uses the stricter effective setting, so `net.ipv4.conf.all.rp_filter` and the `dae0peer` interface setting also need to be disabled inside the dae namespace.

This change applies both settings while `DaeNetns` is configuring the namespace, before the IPv4 datapath is used.

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- Disable IPv4 reverse-path filtering for `all` and `dae0peer` inside `daens`.

### Issue Reference

Closes #1078.

### Test Result

- `git diff --check`
- Change is scoped to namespace sysctl initialization.
- Upstream GitHub Actions are currently awaiting maintainer approval for fork-originated workflows.