### PR TITLE
docs: clarify fixed policy fallback behavior

### DIFF
--- a/example.dae
+++ b/example.dae
@@ -312,7 +312,8 @@ group {
         # Randomly select a node from the group for every connection.
         #policy: random
 
-        # Select the first node from the group for every connection.
+        # Always select the first node from the group, regardless of alive state.
+        # No alive check or automatic fallback is performed if that node is unavailable.
         #policy: fixed(0)
 
         # Select the node with min last latency from the group for every connection.


### PR DESCRIPTION
### Background

The `fixed` group policy intentionally does not fall back to another node when the selected node becomes unavailable.

The existing documentation can be read as if normal fallback behavior still applies to `fixed`, which creates a mismatch between user expectations and the actual policy semantics.

This documentation change makes the no-fallback behavior explicit.

### Checklist

- [ ] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- Clarify that the `fixed` policy fails when its selected node is unavailable instead of selecting another node.

### Issue Reference

Closes #1005.

### Test Result

Documentation-only change. No runtime code is modified.