### PR TITLE
fix(control): use DNS handoff when choosing dial target

### DIFF
--- a/control/control_plane.go
+++ b/control/control_plane.go
@@ -1617,7 +1617,8 @@ func (c *ControlPlane) ChooseDialTarget(outbound consts.OutboundIndex, dst netip
 			if isIPLikeDomain(domain) {
 				break
 			}
-			if c.dnsController.HasDnsKnowledge(c.dnsController.cacheKey(domain, common.AddrToDnsType(dst.Addr()))) {
+			dnsController := c.ActiveDnsController()
+			if dnsController != nil && dnsController.HasDnsKnowledge(dnsController.cacheKey(domain, common.AddrToDnsType(dst.Addr()))) {
 				// Has A/AAAA records. It is a real domain.
 				dialMode = consts.DialMode_Domain
 				shouldReroute = true

--- a/control/control_plane_dns_handoff_test.go
+++ b/control/control_plane_dns_handoff_test.go
@@ -1,0 +1,54 @@
+package control
+
+import (
+	"io"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/daeuniverse/dae/common/consts"
+	dnsmessage "github.com/miekg/dns"
+	"github.com/sirupsen/logrus"
+)
+
+func TestChooseDialTargetUsesDNSHandoff(t *testing.T) {
+	log := logrus.New()
+	log.SetOutput(io.Discard)
+
+	controller, err := NewDnsController(nil, &DnsControllerOption{Log: log})
+	if err != nil {
+		t.Fatalf("create DNS controller: %v", err)
+	}
+	defer func() { _ = controller.Close() }()
+
+	const domain = "example.com"
+	dst := netip.MustParseAddrPort("203.0.113.1:443")
+	controller.rememberDnsKnowledge(
+		controller.cacheKey(domain, dnsmessage.TypeA),
+		time.Now().Add(time.Minute),
+	)
+
+	controlPlane := &ControlPlane{
+		log: log,
+		controlPlaneGenerationState: controlPlaneGenerationState{
+			dialMode: consts.DialMode_Domain,
+		},
+	}
+	controlPlane.dnsHandoffController.Store(controller)
+
+	dialTarget, shouldReroute, dialIP := controlPlane.ChooseDialTarget(
+		consts.OutboundIndex(100),
+		dst,
+		domain,
+	)
+
+	if dialTarget != "example.com:443" {
+		t.Fatalf("dial target = %q, want %q", dialTarget, "example.com:443")
+	}
+	if !shouldReroute {
+		t.Fatal("expected handoff DNS knowledge to enable rerouting")
+	}
+	if dialIP {
+		t.Fatal("expected domain dial target, got IP dial mode")
+	}
+}


### PR DESCRIPTION
### Background

During DNS controller handoff, `ChooseDialTarget()` could still consult the old `c.dnsController` directly instead of the controller currently active through the handoff mechanism.

If DNS knowledge exists only in the handoff controller, the old lookup misses it and the dial target can incorrectly remain an IP address instead of switching back to the original domain.

This change uses `ActiveDnsController()` and handles the nil case before consulting DNS knowledge.

A regression test reproduces the handoff state and verifies that the domain is selected and rerouting is requested.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- Use the active DNS handoff controller when deciding whether a dial target should use its original domain.
- Add a regression test covering DNS knowledge stored in the handoff controller.

### Issue Reference

Closes #1054.

### Test Result

- Added `TestChooseDialTargetUsesDNSHandoff`.
- Fork CI for the corrected regression fixture passed.
- Upstream CI is awaiting maintainer approval for fork-originated workflows.