### PR TITLE
fix(subscription): preserve valid persisted fallback

### DIFF
--- a/common/subscription/subscription.go
+++ b/common/subscription/subscription.go
@@ -141,14 +141,71 @@ func ResolveFile(u *url.URL, configDir string) (b []byte, err error) {
 	return bytes.TrimSpace(b), err
 }
 
+func resolveSubscriptionForPersist(log *logrus.Logger, b []byte) ([]string, error) {
+	nodes, err := ResolveSubscriptionAsSIP008(log, b)
+	if err == nil {
+		if len(nodes) == 0 {
+			return nil, fmt.Errorf("subscription contains no nodes")
+		}
+		return nodes, nil
+	}
+	log.Debugln(err)
+
+	nodes = ResolveSubscriptionAsBase64(log, b)
+	if len(nodes) == 0 {
+		return nil, fmt.Errorf("subscription contains no valid nodes")
+	}
+	return nodes, nil
+}
+
+func resolvePersistedSubscription(u *url.URL, configDir, tag string) ([]byte, error) {
+	persisted := *u
+	persisted.Host = "persist.d/" + tag + ".sub"
+	persisted.Path = ""
+	return ResolveFile(&persisted, configDir)
+}
+
+func writeSubscriptionAtomically(path string, b []byte) (err error) {
+	file, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := file.Name()
+	renamed := false
+	defer func() {
+		if !renamed {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if err = file.Chmod(0600); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if _, err = file.Write(b); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err = file.Sync(); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err = file.Close(); err != nil {
+		return err
+	}
+	if err = os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+	renamed = true
+	return nil
+}
+
 func ResolveSubscription(log *logrus.Logger, client *http.Client, configDir string, subscription string) (tag string, nodes []string, err error) {
-	/// Get tag.
 	tag, subscription = common.GetTagFromLinkLikePlaintext(subscription)
 
-	/// Parse url.
 	u, err := url.Parse(subscription)
 	if err != nil {
-		return tag, nil, fmt.Errorf("failed to parse subscription \"%v\": %w", subscription, err)
+		return tag, nil, fmt.Errorf("failed to parse subscription %q: %w", subscription, err)
 	}
 	log.Debugf("ResolveSubscription: %v", subscription)
 	var (
@@ -183,45 +240,61 @@ func ResolveSubscription(log *logrus.Logger, client *http.Client, configDir stri
 	if err != nil {
 		if persistToFile {
 			log.Warnln("failed to fetch subscription, try to read from file")
-			u.Host = "persist.d/" + tag + ".sub"
-			u.Path = ""
-			b, err = ResolveFile(u, configDir)
-
+			b, err = resolvePersistedSubscription(u, configDir, tag)
 			if err != nil {
 				return "", nil, err
 			}
 			goto resolve
 		}
-
 		return "", nil, err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	b, err = io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024)) // 10MB max subscription size
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		statusErr := fmt.Errorf("subscription request returned HTTP status %s", resp.Status)
+		if persistToFile {
+			log.Warnf("%v, try to read from file", statusErr)
+			b, err = resolvePersistedSubscription(u, configDir, tag)
+			if err != nil {
+				return "", nil, fmt.Errorf("%v; failed to read persisted subscription: %w", statusErr, err)
+			}
+			goto resolve
+		}
+		return "", nil, statusErr
+	}
+
+	b, err = io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
 	if err != nil {
 		return "", nil, err
 	}
 
 	if persistToFile {
-		path := filepath.Join(configDir, "persist.d")
-		if _, err := os.Stat(path); os.IsNotExist(err) {
-			err := os.MkdirAll(path, 0700)
+		resolvedNodes, resolveErr := resolveSubscriptionForPersist(log, b)
+		if resolveErr != nil {
+			log.Warnf("fetched subscription is invalid (%v), try to read from file", resolveErr)
+			b, err = resolvePersistedSubscription(u, configDir, tag)
 			if err != nil {
+				return "", nil, fmt.Errorf("fetched subscription is invalid: %v; failed to read persisted subscription: %w", resolveErr, err)
+			}
+			goto resolve
+		}
+
+		persistDir := filepath.Join(configDir, "persist.d")
+		if _, statErr := os.Stat(persistDir); os.IsNotExist(statErr) {
+			if err := os.MkdirAll(persistDir, 0700); err != nil {
 				return "", nil, err
 			}
+		} else if statErr != nil {
+			return "", nil, statErr
 		}
 
-		path = filepath.Join(path, tag+".sub")
-		file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
-		if err != nil {
+		persistPath := filepath.Join(persistDir, tag+".sub")
+		if err = writeSubscriptionAtomically(persistPath, b); err != nil {
 			return "", nil, err
 		}
-		defer func() { _ = file.Close() }()
-
-		_, err = file.Write(b)
-		if err != nil {
-			return "", nil, err
-		}
+		return tag, resolvedNodes, nil
 	}
+
 resolve:
 	if nodes, err = ResolveSubscriptionAsSIP008(log, b); err == nil {
 		return tag, nodes, nil

--- a/common/subscription/subscription_test.go
+++ b/common/subscription/subscription_test.go
@@ -1,8 +1,14 @@
 package subscription
 
 import (
+	"bytes"
 	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -50,5 +56,131 @@ func TestResolveSubscriptionAsSIP008_SS2022KeepsRawPSK(t *testing.T) {
 
 	if got, want := string(decoded), "2022-blake3-aes-256-gcm:"+password; got != want {
 		t.Fatalf("unexpected decoded userinfo: got %q want %q", got, want)
+	}
+}
+
+func encodeSubscription(nodes ...string) []byte {
+	return []byte(base64.StdEncoding.EncodeToString([]byte(strings.Join(nodes, "\n"))))
+}
+
+func TestResolveSubscriptionPersistFallsBackOnInvalidResponse(t *testing.T) {
+	configDir := t.TempDir()
+	persistDir := filepath.Join(configDir, "persist.d")
+	if err := os.MkdirAll(persistDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	oldPayload := encodeSubscription("ss://old.example:443#old")
+	persistPath := filepath.Join(persistDir, "locked.sub")
+	if err := os.WriteFile(persistPath, oldPayload, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("Subscribe refresh is locked. Unlock it in your dashboard before fetching the subscription"))
+	}))
+	defer server.Close()
+
+	subscriptionURL := "locked:" + strings.Replace(server.URL, "http://", "http-file://", 1)
+	tag, nodes, err := ResolveSubscription(logrus.New(), server.Client(), configDir, subscriptionURL)
+	if err != nil {
+		t.Fatalf("ResolveSubscription: %v", err)
+	}
+	if tag != "locked" {
+		t.Fatalf("tag = %q, want locked", tag)
+	}
+	if len(nodes) != 1 || nodes[0] != "ss://old.example:443#old" {
+		t.Fatalf("nodes = %#v, want persisted node", nodes)
+	}
+
+	got, err := os.ReadFile(persistPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, oldPayload) {
+		t.Fatalf("persisted subscription was overwritten by invalid response: %q", got)
+	}
+}
+
+func TestResolveSubscriptionPersistReplacesValidResponse(t *testing.T) {
+	configDir := t.TempDir()
+	persistDir := filepath.Join(configDir, "persist.d")
+	if err := os.MkdirAll(persistDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	persistPath := filepath.Join(persistDir, "valid.sub")
+	if err := os.WriteFile(persistPath, encodeSubscription("ss://old.example:443#old"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	newPayload := encodeSubscription("ss://new.example:443#new")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(newPayload)
+	}))
+	defer server.Close()
+
+	subscriptionURL := "valid:" + strings.Replace(server.URL, "http://", "http-file://", 1)
+	_, nodes, err := ResolveSubscription(logrus.New(), server.Client(), configDir, subscriptionURL)
+	if err != nil {
+		t.Fatalf("ResolveSubscription: %v", err)
+	}
+	if len(nodes) != 1 || nodes[0] != "ss://new.example:443#new" {
+		t.Fatalf("nodes = %#v, want new node", nodes)
+	}
+
+	got, err := os.ReadFile(persistPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, newPayload) {
+		t.Fatalf("persisted subscription = %q, want %q", got, newPayload)
+	}
+	info, err := os.Stat(persistPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Fatalf("persisted mode = %04o, want 0600", info.Mode().Perm())
+	}
+}
+
+func TestResolveSubscriptionPersistFallsBackOnHTTPError(t *testing.T) {
+	configDir := t.TempDir()
+	persistDir := filepath.Join(configDir, "persist.d")
+	if err := os.MkdirAll(persistDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	oldPayload := encodeSubscription("ss://old.example:443#old")
+	persistPath := filepath.Join(persistDir, "unavailable.sub")
+	if err := os.WriteFile(persistPath, oldPayload, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("temporarily unavailable"))
+	}))
+	defer server.Close()
+
+	subscriptionURL := "unavailable:" + strings.Replace(server.URL, "http://", "http-file://", 1)
+	tag, nodes, err := ResolveSubscription(logrus.New(), server.Client(), configDir, subscriptionURL)
+	if err != nil {
+		t.Fatalf("ResolveSubscription: %v", err)
+	}
+	if tag != "unavailable" {
+		t.Fatalf("tag = %q, want unavailable", tag)
+	}
+	if len(nodes) != 1 || nodes[0] != "ss://old.example:443#old" {
+		t.Fatalf("nodes = %#v, want persisted node", nodes)
+	}
+
+	got, err := os.ReadFile(persistPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, oldPayload) {
+		t.Fatalf("persisted subscription changed after HTTP error: %q", got)
 	}
 }


### PR DESCRIPTION
### Background

Persistent `http-file` / `https-file` subscriptions are intended to provide a last-known-good fallback when a remote subscription cannot be refreshed.

Previously, a successful HTTP request could overwrite the persisted file before the response was proven to contain usable subscription nodes. An empty, invalid, locked, or otherwise unusable response could therefore destroy the valid fallback.

This change validates fetched subscription content before persistence, falls back to the existing persisted subscription for invalid responses and non-2xx HTTP responses, and replaces valid persisted data atomically using a temporary file and rename.

The persisted file remains mode `0600`.

There is partial overlap with #1058, which also contains persistence handling as part of the much larger group-entry-chain feature. This PR intentionally keeps the subscription integrity fix independent and narrowly scoped, and additionally covers non-2xx HTTP fallback behavior.

### Checklist

- [x] The Pull Request has been fully tested
- [ ] There's an entry in the CHANGELOGS
- [ ] There is a user-facing docs PR against https://github.com/daeuniverse/dae

### Full Changelogs

- Preserve the last valid persisted subscription when refreshed content contains no usable nodes.
- Fall back to persisted content on non-2xx HTTP responses.
- Atomically replace persisted subscription files only after validation.
- Keep persisted subscription permissions at `0600`.
- Add regression coverage for invalid responses, valid replacement, and HTTP error fallback.

### Issue Reference

Closes #1076.

Also addresses #1007.

Related: #1058 contains partially overlapping persistence handling inside a larger feature PR.

### Test Result

- Focused subscription regression tests passed.
- `go test -tags dae_stub_ebpf ./...` passed on the fork runner.
- HTTP 503 → persisted fallback regression coverage was added during final review.
- `git diff --check` passed.