### PR TITLE
fix(cmd): tear down dae netns on fast exit to avoid leftover dae0/netns

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1069,15 +1069,19 @@ func shutdownAfterSignalWithHandoff(
 		}
 	}
 
-	if fastExit {
-		log.Infoln("[Shutdown] Fast exit enabled; skipping in-process netns and control-plane teardown. Residual kernel state will be purged on next startup.")
-		return nil
-	}
-
+	// Always tear down the dae netns first, even on fast exit. Closing the
+	// netns removes the dae0/dae0peer netkit (or veth) pair and the named
+	// netns /run/netns/daens, and is cheap. Leaving it behind leaks kernel
+	// state after every stop and can break a subsequent restart.
 	if netns != nil {
 		if e := netns.Close(); e != nil {
 			log.Warnf("close dae netns: %v", e)
 		}
+	}
+
+	if fastExit {
+		log.Infoln("[Shutdown] Fast exit enabled; skipping in-process control-plane teardown. Residual connection state will be purged on next startup.")
+		return nil
 	}
 
 	var closeErrs []error


### PR DESCRIPTION
## Problem

On `systemctl stop dae` (clean SIGTERM), the `dae0`/`dae0peer` netkit (or veth) pair and the named netns `/run/netns/daens` are left behind. `shutdownAfterSignalWithHandoff` returns early on `fastExit` before calling `netns.Close()`, so the kernel state it owns is never torn down.

Fixes #1084.

## Change

Tear down the netns unconditionally, before the fast-exit early return. netns teardown is cheap (delete the link, delete the named netns, close two fds); only the expensive control-plane teardown (aborting connections, closing dialers) is skipped on fast exit.

## Verification

Reproduced and verified on a Debian LXC (kernel 7.0.14-12-pve) in netkit mode:

- Before: `ip link show dae0` (state UP) and `ls /run/netns/daens` both remain after a clean stop.
- After: both are gone after `systemctl stop dae`.
