### PR TITLE
fix(control): unmount named netns synchronously before removing it

### DIFF
--- a/control/netns_utils.go
+++ b/control/netns_utils.go
@@ -561,7 +561,13 @@ func (ns *DaeNetns) setupIPv6Datapath() (err error) {
 
 func DeleteNamedNetns(name string) error {
 	namedPath := path.Join("/run/netns", name)
-	_ = unix.Unmount(namedPath, unix.MNT_DETACH|unix.MNT_FORCE)
+	// Try a synchronous unmount first; MNT_DETACH alone is lazy and may leave
+	// the mount point behind (os.Remove then fails with EBUSY), which leaks
+	// /run/netns/<name> and breaks a subsequent restart. Fall back to lazy
+	// unmount only if the synchronous one fails (e.g. device busy).
+	if err := unix.Unmount(namedPath, 0); err != nil {
+		_ = unix.Unmount(namedPath, unix.MNT_DETACH)
+	}
 	return os.Remove(namedPath)
 }
 


### PR DESCRIPTION
## Problem

`DeleteNamedNetns` uses `unix.Unmount(namedPath, unix.MNT_DETACH|unix.MNT_FORCE)` (lazy unmount). `MNT_DETACH` is asynchronous: it can return before the mount point is actually torn down, so the following `os.Remove(namedPath)` fails with EBUSY and `/run/netns/<name>` is left behind. On the next start, `netns.NewNamed` fails with `open /run/netns/daens: file exists`, breaking restart.

Reproduced on Debian LXC (PVE shared kernel 7.0.14-12-pve), netkit mode. Manual `umount /run/netns/daens; rm -f /run/netns/daens` works, confirming a plain synchronous unmount is sufficient.

Note that this is a race, not an LXC-only quirk. On bare metal the window is usually small enough that `os.Remove` wins, so the bug has not surfaced, but it can still happen whenever the netns mount point is still referenced at teardown time (e.g. lingering UDP sessions or a busy connection holding the namespace). In that case a bare-metal restart hits the same `open /run/netns/daens: file exists` failure. LXC merely makes the race reliably reproducible.

## Fix

Try a synchronous unmount (`flags=0`) first, and fall back to lazy unmount only if it fails (e.g. device busy). Also drop `MNT_FORCE`, which is only meaningful for NFS-style filesystems.

```go
if err := unix.Unmount(namedPath, 0); err != nil {
    _ = unix.Unmount(namedPath, unix.MNT_DETACH)
}
return os.Remove(namedPath)
```