### PR TITLE
fix(control): return TC_ACT_PIPE on wan_egress pass-through paths

### DIFF
--- a/control/kern/tests/bpf_test.c
+++ b/control/kern/tests/bpf_test.c
@@ -144,7 +144,7 @@ SEC("tc/check/dport_mismatch")
 int testcheck_dport_mismatch(struct __sk_buff *skb)
 {
 	return check_routing_ipv4_tcp(skb,
-				      TC_ACT_OK,
+				      TC_ACT_PIPE,
 				      IPV4(192,168,0,1), IPV4(1,1,1,1),
 				      19233, 79);
 }
@@ -188,7 +188,7 @@ SEC("tc/check/ipset_match")
 int testcheck_ipset_match(struct __sk_buff *skb)
 {
 	return check_routing_ipv4_tcp(skb,
-				      TC_ACT_OK,
+				      TC_ACT_PIPE,
 				      IPV4(192,168,0,1), IPV4(100,64,0,2),
 				      19233, 80);
 }
@@ -276,7 +276,7 @@ SEC("tc/check/source_ipset_match")
 int testcheck_source_ipset_match(struct __sk_buff *skb)
 {
 	return check_routing_ipv4_tcp(skb,
-				      TC_ACT_OK,
+				      TC_ACT_PIPE,
 				      IPV4(192,168,50,1), IPV4(1,1,1,1),
 				      19233, 80);
 }
@@ -394,7 +394,7 @@ SEC("tc/check/sport_mismatch")
 int testcheck_sport_mismatch(struct __sk_buff *skb)
 {
 	return check_routing_ipv4_tcp(skb,
-				      TC_ACT_OK,
+				      TC_ACT_PIPE,
 				      IPV4(192,168,0,1), IPV4(1,1,1,1),
 				      19233, 79);
 }
@@ -549,7 +549,7 @@ int testsetup_wan_egress_tcp_non_syn_stateless_passthrough(struct __sk_buff *skb
 SEC("tc/check/wan_egress_tcp_non_syn_stateless_passthrough")
 int testcheck_wan_egress_tcp_non_syn_stateless_passthrough(struct __sk_buff *skb)
 {
-	return check_status_and_mark(skb, TC_ACT_OK, 0);
+	return check_status_and_mark(skb, TC_ACT_PIPE, 0);
 }
 
 SEC("tc/pktgen/wan_egress_tcp_syn_redirect_track")
@@ -857,7 +857,7 @@ int testsetup_wan_egress_udp_non_initial_fragment_passthrough(struct __sk_buff *
 SEC("tc/check/wan_egress_udp_non_initial_fragment_passthrough")
 int testcheck_wan_egress_udp_non_initial_fragment_passthrough(struct __sk_buff *skb)
 {
-	return check_status_and_mark(skb, TC_ACT_OK, 0);
+	return check_status_and_mark(skb, TC_ACT_PIPE, 0);
 }
 
 SEC("tc/pktgen/wan_egress_direct_mark_reroute")
@@ -1030,7 +1030,7 @@ SEC("tc/check/l4proto_mismatch")
 int testcheck_l4proto_mismatch(struct __sk_buff *skb)
 {
 	return check_routing_ipv4_tcp(skb,
-				      TC_ACT_OK,
+				      TC_ACT_PIPE,
 				      IPV4(192,168,0,1), IPV4(1,1,1,1),
 				      19233, 79);
 }
@@ -1102,7 +1102,7 @@ SEC("tc/check/ipversion_mismatch")
 int testcheck_ipversion_mismatch(struct __sk_buff *skb)
 {
 	return check_routing_ipv4_tcp(skb,
-				      TC_ACT_OK,
+				      TC_ACT_PIPE,
 				      IPV4(192,168,0,1), IPV4(1,1,1,1),
 				      19233, 79);
 }
@@ -1215,7 +1215,7 @@ SEC("tc/check/mac_mismatch")
 int testcheck_mac_mismatch(struct __sk_buff *skb)
 {
 	return check_routing_ipv4_tcp(skb,
-				      TC_ACT_OK,
+				      TC_ACT_PIPE,
 				      IPV4(192,168,0,1), IPV4(1,1,1,1),
 				      19233, 79);
 }
@@ -1329,7 +1329,7 @@ SEC("tc/check/dscp_mismatch")
 int testcheck_dscp_mismatch(struct __sk_buff *skb)
 {
 	return check_routing_ipv4_tcp(skb,
-				      TC_ACT_OK,
+				      TC_ACT_PIPE,
 				      IPV4(192,168,0,1), IPV4(1,1,1,1),
 				      19233, 79);
 }
@@ -1366,7 +1366,7 @@ SEC("tc/check/dscp_ipv6_mismatch")
 int testcheck_dscp_ipv6_mismatch(struct __sk_buff *skb)
 {
 	return check_routing_ipv6_tcp(skb,
-				      TC_ACT_OK,
+				      TC_ACT_PIPE,
 				      0x20010db8, 0, 0, 0x10,
 				      0x26064700, 0, 0, 0x1111,
 				      19233, 79);
@@ -1607,7 +1607,7 @@ SEC("tc/check/and_mismatch")
 int testcheck_and_mismatch(struct __sk_buff *skb)
 {
 	return check_routing_ipv4_tcp(skb,
-				      TC_ACT_OK,
+				      TC_ACT_PIPE,
 				      IPV4(192,168,0,1), IPV4(1,1,1,1),
 				      19233, 2333);
 }
@@ -1644,7 +1644,7 @@ SEC("tc/check/not_match")
 int testcheck_not_match(struct __sk_buff *skb)
 {
 	return check_routing_ipv4_tcp(skb,
-				      TC_ACT_OK,
+				      TC_ACT_PIPE,
 				      IPV4(192,168,0,1), IPV4(1,1,1,1),
 				      19233, 80);
 }

--- a/control/kern/tproxy.c
+++ b/control/kern/tproxy.c
@@ -2511,7 +2511,7 @@ do_tproxy_wan_egress_tcp(struct __sk_buff *skb, __u32 link_h_len,
 			scratch->flag[1] = IpVersionType_6;
 		scratch->flag[6] = tuples->dscp;
 		if (pid_is_control_plane(skb, &pid_pname))
-			return TC_ACT_OK;
+			return TC_ACT_PIPE;
 		if (pid_pname)
 			__builtin_memcpy(&scratch->flag[2], pid_pname->pname,
 					 TASK_COMM_LEN);
@@ -2569,7 +2569,7 @@ do_tproxy_wan_egress_tcp(struct __sk_buff *skb, __u32 link_h_len,
 
 		if (!tcp_conn) {
 			if (outbound == OUTBOUND_DIRECT && mark == 0)
-				return TC_ACT_OK;
+				return TC_ACT_PIPE;
 			return TC_ACT_SHOT;
 		}
 
@@ -2591,7 +2591,7 @@ do_tproxy_wan_egress_tcp(struct __sk_buff *skb, __u32 link_h_len,
 			0, NULL, 0);
 
 		if (!tcp_conn || !tcp_conn->meta.data.has_routing)
-			return TC_ACT_OK;
+			return TC_ACT_PIPE;
 
 		outbound = tcp_conn->meta.data.outbound;
 		mark = tcp_conn->meta.data.mark;
@@ -2607,7 +2607,7 @@ do_tproxy_wan_egress_tcp(struct __sk_buff *skb, __u32 link_h_len,
 		bpf_printk("GO OUTBOUND_DIRECT");
 #endif
 		skb->mark = mark;
-		return TC_ACT_OK;
+		return TC_ACT_PIPE;
 	} else if (unlikely(outbound == OUTBOUND_BLOCK)) {
 #if defined(__DEBUG_ROUTING) || defined(__PRINT_ROUTING_RESULT)
 		bpf_printk("SHOT OUTBOUND_BLOCK");
@@ -2666,14 +2666,14 @@ do_tproxy_wan_egress_udp(struct __sk_buff *skb, __u32 link_h_len,
 	scratch->flag[6] = tuples->dscp;
 
 	if (pid_is_control_plane(skb, &pid_pname))
-		return TC_ACT_OK;
+		return TC_ACT_PIPE;
 
 	if (!is_short_lived_udp_traffic(&tuples->five)) {
 		udp_conn_state = mark_udp_seen(&tuples->five, false,
 					       NULL, NULL, NULL, NULL,
 					       0, NULL, 0);
 		if (udp_conn_state && udp_conn_state->is_wan_ingress_direction)
-			return TC_ACT_OK;
+			return TC_ACT_PIPE;
 
 		if (udp_conn_state && udp_conn_state->meta.data.has_routing) {
 			outbound = udp_conn_state->meta.data.outbound;
@@ -2747,7 +2747,7 @@ fast_path_skip_routing:
 #endif
 
 	if (!wan_egress_needs_control_plane(outbound, mark))
-		return TC_ACT_OK;
+		return TC_ACT_PIPE;
 	else if (unlikely(outbound == OUTBOUND_BLOCK))
 		return TC_ACT_SHOT;
 
@@ -2774,10 +2774,16 @@ fast_path_skip_routing:
 }
 
 // Per-CPU scratch to stay under 512-byte stack limit across the call chain.
+//
+// Pass-through paths return TC_ACT_PIPE, not TC_ACT_OK, so that other filters
+// attached to the same clsact qdisc still get to see the packet: cls_bpf maps
+// TC_ACT_PIPE to TC_ACT_UNSPEC, which is the only return value that lets
+// __tcf_classify() continue down the filter chain. This matches what
+// wan_ingress and lan_egress already do.
 static __noinline int do_tproxy_wan_egress(struct __sk_buff *skb, __u32 link_h_len)
 {
 	if (skb->ingress_ifindex != NOWHERE_IFINDEX)
-		return TC_ACT_OK;
+		return TC_ACT_PIPE;
 
 	__u32 scratch_key = 0;
 	struct parsed_packet *pkt =
@@ -2795,7 +2801,7 @@ static __noinline int do_tproxy_wan_egress(struct __sk_buff *skb, __u32 link_h_l
 			bpf_printk("wan_egress parse error: %d, dropping", ret);
 			return TC_ACT_SHOT;
 		}
-		return TC_ACT_OK;
+		return TC_ACT_PIPE;
 	}
 
 	if (pkt->l4proto == IPPROTO_TCP)
@@ -2804,7 +2810,7 @@ static __noinline int do_tproxy_wan_egress(struct __sk_buff *skb, __u32 link_h_l
 	if (pkt->l4proto == IPPROTO_UDP)
 		return do_tproxy_wan_egress_udp(skb, link_h_len, &pkt->tuples,
 						&pkt->ethh, &pkt->udph);
-	return TC_ACT_OK;
+	return TC_ACT_PIPE;
 }
 
 SEC("tc/wan_egress_l2")


### PR DESCRIPTION
### Background

`do_tproxy_wan_egress()` and its TCP/UDP helpers return `TC_ACT_OK` on every path
where the packet is *not* redirected to the control plane. On a `clsact` qdisc that
ends the filter chain: `cls_bpf_exec_opcode()` translates only `TC_ACT_PIPE` into
`TC_ACT_UNSPEC`, and `TC_ACT_UNSPEC` is the sole return value that makes
`__tcf_classify()` continue on to the next filter. Any other value — `TC_ACT_OK`
included — returns immediately, so **nothing attached after dae on the WAN egress
hook ever runs**.

dae's own `wan_ingress` and `lan_egress` already return `TC_ACT_PIPE` for exactly
this reason; `wan_egress` is the odd one out.

The worst case is the very first check in the function:

```c
if (skb->ingress_ifindex != NOWHERE_IFINDEX)
    return TC_ACT_OK;
```

Every *forwarded* packet — i.e. all router traffic — takes this branch before
anything is even parsed, so on a router dae unconditionally truncates the egress
filter chain on its WAN device.

**How this was found.** On an OpenWrt router running dae alongside
[qosify](https://git.openwrt.org/?p=project/qosify.git), qosify's egress DSCP
classifier attaches to the same `clsact` at priority `0x110` (after dae's 1/2) and
simply never executed. `cake` kept shaping at the root qdisc, so there was no error
anywhere — but its `diffserv` tins were being picked from whatever DSCP the LAN
client had set rather than from qosify's classification. A silent, hard-to-attribute
downgrade. Ingress was unaffected, precisely because `wan_ingress` returns
`TC_ACT_PIPE`.

qosify is not a special case; this applies to any tc filter a user adds on the WAN
device.

### Full Changelogs

- [control/kern] Return `TC_ACT_PIPE` instead of `TC_ACT_OK` from all pass-through
  paths of `do_tproxy_wan_egress()`, `do_tproxy_wan_egress_tcp()` and
  `do_tproxy_wan_egress_udp()` (10 sites): the forwarded-packet early return, the
  unsupported-protocol and non-TCP/UDP returns, the `pid_is_control_plane()`
  returns, the direct-outbound returns (including the one that sets `skb->mark`),
  the stateless established-TCP return, and the `is_wan_ingress_direction` return.
  `TC_ACT_SHOT` and `redirect_to_control_plane_egress()` paths are unchanged.
- [control/kern] Comment above `do_tproxy_wan_egress()` recording why the
  pass-through value must be `TC_ACT_PIPE`.
- [control/kern/tests] Update the 13 BPF unit-test expectations whose setup runs
  `wan_egress` and asserts a pass-through status. The `lan_ingress` test
  expectations keep `TC_ACT_OK` since that program is untouched.

### Not in scope

`do_tproxy_lan_ingress()` has the same `TC_ACT_OK` pass-through pattern and
arguably deserves the same treatment (it would affect tc filters on LAN
interfaces). I kept this PR to `wan_egress` because that is the path with a
demonstrated real-world failure and the smallest review surface — happy to extend
it if maintainers prefer a single sweep.

Also note the two `parse_transport()` "positive: unsupported protocol — pass
through" returns in `wan_ingress`/`lan_egress` still return `TC_ACT_OK` despite the
comment saying pass-through. Left alone here for the same reason.

### Issue Reference

None — reported here for the first time.

### Test Result

- `control/kern/tproxy.c` and `control/kern/tests/bpf_test.c` both compile clean
  with `clang -O2 -g -Wall -target bpf -D__TARGET_ARCH_x86`.
- I could **not** run the `dae_bpf_tests` suite: my environment is an unprivileged
  LXC container with `kernel.unprivileged_bpf_disabled=2`, so the programs cannot be
  loaded. The test expectations were updated by tracing which `tc/setup/*` program
  reaches `wan_egress` (via `entry_call_map` tail call or a direct
  `do_tproxy_wan_egress()` call) and which reaches `lan_ingress`. **CI or a
  maintainer needs to confirm the suite passes.**
- Behaviour verified on the original router: with dae's WAN egress program left at
  `TC_ACT_OK`, a qosify egress filter at a lower priority never fires; ordering
  qosify ahead of dae restores DSCP marking, which is the same result this change
  achieves without requiring users to reorder filters.
